### PR TITLE
feat: implement compositor transform & matrix engine

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -10,6 +10,15 @@ pub enum Value {
     /// Represents `fit-content(N px)` — uses available space up to N px,
     /// but no more than max-content and no less than min-content.
     FitContent(f32),
+    Transform(Vec<TransformOp>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransformOp {
+    Translate(f32, f32), // px
+    Scale(f32, f32),     // factor
+    Rotate(f32),         // radians
+    Matrix(f32, f32, f32, f32, f32, f32), // matrix(a, b, c, d, e, f)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -438,6 +447,14 @@ pub fn parse_value(val: &str) -> Value {
     if val == "min-content" || val == "max-content" || val == "fit-content" {
         return Value::Keyword(val.to_string());
     }
+
+    // transform: translate(...) rotate(...)
+    if val.contains('(') && (val.starts_with("translate") || val.starts_with("scale") || val.starts_with("rotate") || val.starts_with("matrix")) {
+        let ops = parse_transform_list(val);
+        if !ops.is_empty() {
+            return Value::Transform(ops);
+        }
+    }
     // fit-content(<length>) — e.g. fit-content(300px)
     if val.starts_with("fit-content(") && val.ends_with(')') {
         let inner = &val["fit-content(".len()..val.len() - 1];
@@ -625,4 +642,62 @@ mod tests {
         assert!(parse_color("navy").is_some());
         assert!(parse_color("transparent").is_some());
     }
+}
+
+fn parse_transform_list(val: &str) -> Vec<TransformOp> {
+    let mut ops = Vec::new();
+    let parts = split_respecting_parens(val);
+    for part in parts {
+        let part = part.trim();
+        if part.is_empty() { continue; }
+        
+        if let Some(open) = part.find('(') {
+            let name = &part[..open].to_lowercase();
+            let args_str = &part[open + 1..part.len() - 1];
+            let args: Vec<&str> = args_str.split(',').map(|s| s.trim()).collect();
+            
+            match name.as_str() {
+                "translate" => {
+                    let x = parse_px_or_zero(args.get(0).copied().unwrap_or("0"));
+                    let y = parse_px_or_zero(args.get(1).copied().unwrap_or("0"));
+                    ops.push(TransformOp::Translate(x, y));
+                }
+                "scale" => {
+                    let x = args.get(0).and_then(|s| s.parse::<f32>().ok()).unwrap_or(1.0);
+                    let y = args.get(1).and_then(|s| s.parse::<f32>().ok()).unwrap_or(x);
+                    ops.push(TransformOp::Scale(x, y));
+                }
+                "rotate" => {
+                    let mut rad = 0.0;
+                    if let Some(arg) = args.get(0) {
+                        let arg = arg.trim();
+                        if arg.ends_with("deg") {
+                            let deg = arg.trim_end_matches("deg").parse::<f32>().unwrap_or(0.0);
+                            rad = deg.to_radians();
+                        } else {
+                            rad = arg.parse::<f32>().unwrap_or(0.0);
+                        }
+                    }
+                    ops.push(TransformOp::Rotate(rad));
+                }
+                "matrix" => {
+                    if args.len() == 6 {
+                        let a = args[0].parse().unwrap_or(1.0);
+                        let b = args[1].parse().unwrap_or(0.0);
+                        let c = args[2].parse().unwrap_or(0.0);
+                        let d = args[3].parse().unwrap_or(1.0);
+                        let e = args[4].parse().unwrap_or(0.0);
+                        let f = args[5].parse().unwrap_or(0.0);
+                        ops.push(TransformOp::Matrix(a, b, c, d, e, f));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    ops
+}
+
+fn parse_px_or_zero(s: &str) -> f32 {
+    s.trim_end_matches("px").parse::<f32>().unwrap_or(0.0)
 }

--- a/src/layer_tree.rs
+++ b/src/layer_tree.rs
@@ -1,5 +1,6 @@
 use crate::layout::{LayoutBox, DisplayType, Rect as LayoutRect};
-use crate::css::{Value, Color, BoxShadow};
+use crate::css::{Value, Color, BoxShadow, TransformOp};
+use crate::matrix::{Matrix3x3, Matrix4x4};
 use markup5ever_rcdom::NodeData;
 
 // ── Paint Commands ────────────────────────────────────────────────────────────
@@ -38,8 +39,8 @@ pub enum CompositingTrigger {
     ZIndex(i32),
     /// `opacity` < 1.0
     Opacity(f32),
-    /// `transform` property with a value other than `none`
-    Transform(String),
+    /// `transform` property with a resolved matrix
+    Transform(Matrix4x4),
     /// `position: fixed`
     ///
     /// NOTE: The layout engine does not produce viewport-relative positions for
@@ -71,6 +72,8 @@ pub struct Layer {
     pub bounds: LayoutRect,
     /// CSS properties that caused this layer to be created.
     pub triggers: Vec<CompositingTrigger>,
+    /// Transformation matrix for this layer.
+    pub transform: Matrix4x4,
     /// Ordered list of drawing operations for this layer.
     pub paint_commands: Vec<PaintCommand>,
     /// IDs of layers created as direct children of this layer during tree build.
@@ -80,13 +83,14 @@ pub struct Layer {
 }
 
 impl Layer {
-    fn new(id: usize, z_index: i32, opacity: f32, bounds: LayoutRect, triggers: Vec<CompositingTrigger>) -> Self {
+    fn new(id: usize, z_index: i32, opacity: f32, bounds: LayoutRect, triggers: Vec<CompositingTrigger>, transform: Matrix4x4) -> Self {
         Self {
             id,
             z_index,
             opacity,
             bounds,
             triggers,
+            transform,
             paint_commands: Vec::new(),
             child_layer_ids: Vec::new(),
         }
@@ -139,7 +143,7 @@ impl LayerTreeBuilder {
     /// `viewport` is the full drawable area and becomes the bounds of the root layer.
     pub fn build(layout: &LayoutBox, viewport: LayoutRect) -> LayerTree {
         let mut tree = LayerTree::new();
-        let root = Layer::new(0, 0, 1.0, viewport, vec![]);
+        let root = Layer::new(0, 0, 1.0, viewport, vec![], Matrix4x4::identity());
         tree.add_layer(root);
         Self::traverse(layout, &mut tree, 0, viewport);
         tree
@@ -159,13 +163,13 @@ impl LayerTreeBuilder {
             return;
         }
 
-        let triggers = Self::detect_triggers(layout);
+        let (triggers, matrix) = Self::detect_triggers(layout);
 
         if !triggers.is_empty() {
             // This box establishes a new compositing layer.
             let new_id = tree.layers.len();
             let opacity = layout.get_opacity();
-            let new_layer = Layer::new(new_id, layout.z_index, opacity, d, triggers);
+            let new_layer = Layer::new(new_id, layout.z_index, opacity, d, triggers, matrix);
             tree.add_layer(new_layer);
 
             // Record parent → child relationship for future compositor use.
@@ -195,9 +199,10 @@ impl LayerTreeBuilder {
     ///
     /// BFC-establishing properties (InlineBlock, Flex, TableCell, overflow:hidden)
     /// are intentionally excluded — BFC != compositing layer per the CSS spec.
-    fn detect_triggers(layout: &LayoutBox) -> Vec<CompositingTrigger> {
+    fn detect_triggers(layout: &LayoutBox) -> (Vec<CompositingTrigger>, Matrix4x4) {
         let mut triggers = Vec::new();
         let sv = &layout.style_node.specified_values;
+        let mut matrix = Matrix4x4::identity();
 
         if layout.z_index != 0 {
             triggers.push(CompositingTrigger::ZIndex(layout.z_index));
@@ -208,10 +213,9 @@ impl LayerTreeBuilder {
             triggers.push(CompositingTrigger::Opacity(opacity));
         }
 
-        if let Some(Value::Keyword(k)) = sv.get("transform") {
-            if k != "none" {
-                triggers.push(CompositingTrigger::Transform(k.clone()));
-            }
+        if let Some(Value::Transform(ops)) = sv.get("transform") {
+            matrix = Self::compute_transform_matrix(ops);
+            triggers.push(CompositingTrigger::Transform(matrix));
         }
 
         match sv.get("position") {
@@ -226,7 +230,21 @@ impl LayerTreeBuilder {
             }
         }
 
-        triggers
+        (triggers, matrix)
+    }
+
+    fn compute_transform_matrix(ops: &[TransformOp]) -> Matrix4x4 {
+        let mut result = Matrix4x4::identity();
+        for op in ops {
+            let m = match op {
+                TransformOp::Translate(x, y) => Matrix4x4::translate(*x, *y, 0.0),
+                TransformOp::Scale(x, y) => Matrix4x4::from_2d(Matrix3x3::scale(*x, *y)),
+                TransformOp::Rotate(rad) => Matrix4x4::from_2d(Matrix3x3::rotate(*rad)),
+                TransformOp::Matrix(a, b, c, d, e, f) => Matrix4x4::from_2d(Matrix3x3([*a, *c, *e, *b, *d, *f, 0.0, 0.0, 1.0])),
+            };
+            result = result.multiply(&m);
+        }
+        result
     }
 
     /// Emit paint commands for a single `LayoutBox` (not its children) into `layer`.
@@ -394,5 +412,28 @@ mod tests {
             wc_layer.triggers.iter().any(|t| matches!(t, CompositingTrigger::WillChange(_))),
             "layer should have WillChange trigger"
         );
+    }
+
+    #[test]
+    fn test_transform_trigger_creates_layer_with_matrix() {
+        let tree = build_tree_from_html(
+            r#"<div style="width:100px; height:50px; transform:translate(50px, 100px);">Content</div>"#,
+            "",
+        );
+        assert!(tree.layers.len() >= 2);
+        let t_layer = tree.layers.iter().find(|l| l.id != 0).expect("child layer");
+        
+        let mut found_transform = false;
+        for trigger in &t_layer.triggers {
+            if let CompositingTrigger::Transform(m) = trigger {
+                found_transform = true;
+                // Matrix translation part should match 50, 100
+                assert_eq!(m.0[3], 50.0);
+                assert_eq!(m.0[7], 100.0);
+            }
+        }
+        assert!(found_transform, "layer must have Transform trigger with matrix");
+        assert_eq!(t_layer.transform.0[3], 50.0);
+        assert_eq!(t_layer.transform.0[7], 100.0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ pub mod layout;
 pub mod render;
 pub mod layer_tree;
 pub mod js;
+pub mod matrix;
 
 struct BrowserApp {
     url: String,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,0 +1,144 @@
+/// 2D Transformation Matrix (3x3).
+/// Represented as a flat array of 9 elements in row-major order:
+/// [ a, c, e ]
+/// [ b, d, f ]
+/// [ 0, 0, 1 ]
+///
+/// In CSS context: `matrix(a, b, c, d, e, f)`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Matrix3x3(pub [f32; 9]);
+
+impl Matrix3x3 {
+    pub fn identity() -> Self {
+        Self([
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+        ])
+    }
+
+    pub fn translate(tx: f32, ty: f32) -> Self {
+        Self([
+            1.0, 0.0, tx,
+            0.0, 1.0, ty,
+            0.0, 0.0, 1.0,
+        ])
+    }
+
+    pub fn scale(sx: f32, sy: f32) -> Self {
+        Self([
+            sx,  0.0, 0.0,
+            0.0, sy,  0.0,
+            0.0, 0.0, 1.0,
+        ])
+    }
+
+    pub fn rotate(radians: f32) -> Self {
+        let (sin, cos) = radians.sin_cos();
+        Self([
+            cos, -sin, 0.0,
+            sin,  cos, 0.0,
+            0.0,  0.0, 1.0,
+        ])
+    }
+
+    pub fn multiply(&self, other: &Self) -> Self {
+        let mut result = [0.0; 9];
+        for i in 0..3 {
+            for j in 0..3 {
+                for k in 0..3 {
+                    result[i * 3 + j] += self.0[i * 3 + k] * other.0[k * 3 + j];
+                }
+            }
+        }
+        Self(result)
+    }
+}
+
+/// 3D Transformation Matrix (4x4).
+/// Row-major order (standard for modern graphics APIs and CSS).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Matrix4x4(pub [f32; 16]);
+
+impl Matrix4x4 {
+    pub fn identity() -> Self {
+        Self([
+            1.0, 0.0, 0.0, 0.0,
+            0.0, 1.0, 0.0, 0.0,
+            0.0, 0.0, 1.0, 0.0,
+            0.0, 0.0, 0.0, 1.0,
+        ])
+    }
+
+    pub fn from_2d(m: Matrix3x3) -> Self {
+        Self([
+            m.0[0], m.0[1], 0.0, m.0[2],
+            m.0[3], m.0[4], 0.0, m.0[5],
+            0.0,    0.0,    1.0, 0.0,
+            m.0[6], m.0[7], 0.0, m.0[8],
+        ])
+    }
+
+    pub fn multiply(&self, other: &Self) -> Self {
+        let mut result = [0.0; 16];
+        for i in 0..4 {
+            for j in 0..4 {
+                for k in 0..4 {
+                    result[i * 4 + j] += self.0[i * 4 + k] * other.0[k * 4 + j];
+                }
+            }
+        }
+        Self(result)
+    }
+
+    pub fn translate(tx: f32, ty: f32, tz: f32) -> Self {
+        Self([
+            1.0, 0.0, 0.0, tx,
+            0.0, 1.0, 0.0, ty,
+            0.0, 0.0, 1.0, tz,
+            0.0, 0.0, 0.0, 1.0,
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matrix_identity() {
+        let m = Matrix3x3::identity();
+        assert_eq!(m.0[0], 1.0);
+        assert_eq!(m.0[4], 1.0);
+        assert_eq!(m.0[8], 1.0);
+    }
+
+    #[test]
+    fn test_matrix_translate() {
+        let m = Matrix3x3::translate(10.0, 20.0);
+        assert_eq!(m.0[2], 10.0);
+        assert_eq!(m.0[5], 20.0);
+    }
+
+    #[test]
+    fn test_matrix_multiply() {
+        let m1 = Matrix3x3::translate(10.0, 0.0);
+        let m2 = Matrix3x3::translate(0.0, 20.0);
+        let result = m1.multiply(&m2);
+        // [1 0 10] * [1 0 0 ] = [1 0 10]
+        // [0 1 0 ]   [0 1 20]   [0 1 20]
+        // [0 0 1 ]   [0 0 1 ]   [0 0 1 ]
+        assert_eq!(result.0[2], 10.0);
+        assert_eq!(result.0[5], 20.0);
+    }
+
+    #[test]
+    fn test_matrix_4x4_from_2d() {
+        let m2d = Matrix3x3::translate(10.0, 20.0);
+        let m4d = Matrix4x4::from_2d(m2d);
+        assert_eq!(m4d.0[3], 10.0);
+        assert_eq!(m4d.0[7], 20.0);
+        assert_eq!(m4d.0[10], 1.0); // Z-axis scale
+        assert_eq!(m4d.0[15], 1.0); // W-axis
+    }
+}


### PR DESCRIPTION
## Summary
- Implement 3x3 and 4x4 matrix math in `src/matrix.rs`
- Parse CSS `transform` property in `src/css.rs`
- Store resolved matrices in `Layer` tree

Closes #32