### PR TITLE
feat: implement requestAnimationFrame and render-step orchestration

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -8,6 +8,7 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 thread_local! {
     static MACRO_TASKS: RefCell<VecDeque<Box<dyn FnOnce(&mut Context)>>> = RefCell::new(VecDeque::new());
     static MICRO_TASKS: RefCell<VecDeque<Box<dyn FnOnce(&mut Context)>>> = RefCell::new(VecDeque::new());
+    static RAF_TASKS: RefCell<VecDeque<Box<dyn FnOnce(&mut Context, f64)>>> = RefCell::new(VecDeque::new());
     static DOM_ROOT: RefCell<Option<Handle>> = RefCell::new(None);
     static NODE_REGISTRY: RefCell<HashMap<u32, Handle>> = RefCell::new(HashMap::new());
     static NEXT_NODE_ID: RefCell<u32> = RefCell::new(1);
@@ -62,6 +63,23 @@ impl JsRuntime {
             Ok(JsValue::undefined())
         });
         context.register_global_callable(js_string!("setTimeout"), 2, set_timeout).unwrap();
+
+        // Register native requestAnimationFrame
+        let raf = NativeFunction::from_copy_closure(|_this, args, _context| {
+            if let Some(callback) = args.get(0).cloned() {
+                if let Some(obj) = callback.as_object() {
+                    if obj.is_callable() {
+                        RAF_TASKS.with(|tasks| {
+                            tasks.borrow_mut().push_back(Box::new(move |ctx, timestamp| {
+                                let _ = callback.as_object().unwrap().call(&JsValue::undefined(), &[JsValue::from(timestamp)], ctx);
+                            }));
+                        });
+                    }
+                }
+            }
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("requestAnimationFrame"), 1, raf).unwrap();
 
         // Register native __aura_queue_task
         let queue_task = NativeFunction::from_copy_closure(|_this, args, _context| {
@@ -276,6 +294,25 @@ impl JsRuntime {
             // Microtask checkpoint after event execution
             self.run_microtasks();
         }
+    }
+
+    pub fn poll_raf_tasks(&mut self, timestamp: f64) -> bool {
+        let mut did_work = false;
+
+        // Take a snapshot of current tasks to avoid infinite recursion in same frame
+        let mut tasks = VecDeque::new();
+        RAF_TASKS.with(|t| tasks = t.borrow_mut().drain(..).collect());
+
+        if !tasks.is_empty() {
+            did_work = true;
+            for task in tasks {
+                task(&mut self.context, timestamp);
+                // Microtask checkpoint after each rAF callback
+                self.run_microtasks();
+            }
+        }
+
+        did_work
     }
 
     pub fn execute(&mut self, source: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ struct BrowserApp {
     /// Accumulated JS style overrides (element id → property → value).
     js_style_overrides: HashMap<String, HashMap<String, String>>,
     is_loading: bool,
+    start_time: std::time::Instant,
 }
 
 struct StaticPageData {
@@ -94,6 +95,7 @@ impl BrowserApp {
             js_runtime: js::JsRuntime::new(None),
             js_style_overrides: HashMap::new(),
             is_loading: false,
+            start_time: std::time::Instant::now(),
         }
     }
 
@@ -361,7 +363,15 @@ fn process_html_with_cache(
 impl eframe::App for BrowserApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Poll JS event loop tasks
-        if self.js_runtime.poll_tasks() {
+        let mut needs_re_render = self.js_runtime.poll_tasks();
+
+        // Run animation frames
+        let timestamp = self.start_time.elapsed().as_secs_f64() * 1000.0;
+        if self.js_runtime.poll_raf_tasks(timestamp) {
+            needs_re_render = true;
+        }
+
+        if needs_re_render {
             self.trigger_re_render(ctx, 800.0); // Using standard width
         }
 

--- a/tests/test_event_loop.rs
+++ b/tests/test_event_loop.rs
@@ -30,8 +30,27 @@ fn test_macro_micro_task_order() {
     
     // Poll again to run the macro task
     js.poll_tasks();
+}
 
-    // Verify order via internal state if we had access, 
-    // or just check if it doesn't panic for now.
-    // In a real browser test, we'd check `order` array.
+#[test]
+fn test_raf_timestamp() {
+    let mut js = JsRuntime::new(None);
+
+    js.execute(r#"
+        var ts = 0;
+        requestAnimationFrame((t) => {
+            ts = t;
+            log("rAF called with: " + t);
+        });
+    "#);
+
+    // Initial execute should NOT have run rAF
+    js.poll_tasks(); // Runs microtasks
+
+    // Explicitly poll rAF
+    js.poll_raf_tasks(1234.5);
+
+    // Check ts via eval
+    let val = js.context.eval(boa_engine::Source::from_bytes(b"ts")).unwrap();
+    assert_eq!(val.as_number().unwrap(), 1234.5);
 }


### PR DESCRIPTION
## Summary
- Implemented `requestAnimationFrame` in JS.
- Orchestrated the render step in the event loop.
- Added timestamps to rAF callbacks.

Closes #38