### PR TITLE
feat: implement focus management and sequential navigation

### DIFF
--- a/docs/tokscale-export-20260412-100907.json
+++ b/docs/tokscale-export-20260412-100907.json
@@ -1,0 +1,186 @@
+{
+  "agents": [],
+  "daily": [
+    {
+      "cost": 16.64191214999999,
+      "date": "2026-04-12",
+      "tokens": {
+        "cacheRead": 25172538,
+        "cacheWrite": 539855,
+        "input": 19917718,
+        "output": 190296,
+        "total": 45937804
+      }
+    },
+    {
+      "cost": 9.000795899999998,
+      "date": "2026-04-10",
+      "tokens": {
+        "cacheRead": 10584987,
+        "cacheWrite": 628560,
+        "input": 2244346,
+        "output": 149749,
+        "total": 13626241
+      }
+    },
+    {
+      "cost": 2.781893550000001,
+      "date": "2026-04-09",
+      "tokens": {
+        "cacheRead": 3290093,
+        "cacheWrite": 286335,
+        "input": 25743,
+        "output": 46338,
+        "total": 3649289
+      }
+    },
+    {
+      "cost": 21.06967899999999,
+      "date": "2026-04-08",
+      "tokens": {
+        "cacheRead": 33252578,
+        "cacheWrite": 214892,
+        "input": 2417653,
+        "output": 308718,
+        "total": 36282613
+      }
+    },
+    {
+      "cost": 29.674543200000013,
+      "date": "2026-04-07",
+      "tokens": {
+        "cacheRead": 43789900,
+        "cacheWrite": 340150,
+        "input": 47979468,
+        "output": 358024,
+        "total": 92540697
+      }
+    },
+    {
+      "cost": 45.19073115000003,
+      "date": "2026-04-06",
+      "tokens": {
+        "cacheRead": 78605911,
+        "cacheWrite": 2480305,
+        "input": 13442,
+        "output": 488958,
+        "total": 81588616
+      }
+    },
+    {
+      "cost": 8.057543749999999,
+      "date": "2026-04-05",
+      "tokens": {
+        "cacheRead": 22632718,
+        "cacheWrite": 317589,
+        "input": 987,
+        "output": 95449,
+        "total": 23046743
+      }
+    }
+  ],
+  "models": [
+    {
+      "client": "claude",
+      "cost": 46.85141879999999,
+      "model": "claude-sonnet-4-6",
+      "provider": "anthropic",
+      "sessionCount": 53,
+      "tokens": {
+        "cacheRead": 82822811,
+        "cacheWrite": 2853410,
+        "input": 24191,
+        "output": 748781,
+        "total": 86449193
+      }
+    },
+    {
+      "client": "gemini",
+      "cost": 36.17897850000002,
+      "model": "gemini-3-flash-preview",
+      "provider": "google",
+      "sessionCount": 6,
+      "tokens": {
+        "cacheRead": 58360358,
+        "cacheWrite": 0,
+        "input": 69173043,
+        "output": 345277,
+        "total": 128064220
+      }
+    },
+    {
+      "client": "claude",
+      "cost": 25.910770499999998,
+      "model": "claude-opus-4-6",
+      "provider": "anthropic",
+      "sessionCount": 3,
+      "tokens": {
+        "cacheRead": 33940216,
+        "cacheWrite": 840614,
+        "input": 3580,
+        "output": 146757,
+        "total": 34931167
+      }
+    },
+    {
+      "client": "codex",
+      "cost": 17.09513499999999,
+      "model": "gpt-5.4",
+      "provider": "openai",
+      "sessionCount": 21,
+      "tokens": {
+        "cacheRead": 27310720,
+        "cacheWrite": 0,
+        "input": 2269848,
+        "output": 219230,
+        "total": 29886757
+      }
+    },
+    {
+      "client": "claude",
+      "cost": 3.6170419000000007,
+      "model": "claude-haiku-4-5",
+      "provider": "anthropic",
+      "sessionCount": 21,
+      "tokens": {
+        "cacheRead": 14149994,
+        "cacheWrite": 1113662,
+        "input": 15030,
+        "output": 158987,
+        "total": 15437673
+      }
+    },
+    {
+      "client": "gemini",
+      "cost": 2.763754,
+      "model": "gemini-3.1-pro-preview",
+      "provider": "google",
+      "sessionCount": 3,
+      "tokens": {
+        "cacheRead": 744626,
+        "cacheWrite": 0,
+        "input": 1113665,
+        "output": 18500,
+        "total": 1902993
+      }
+    },
+    {
+      "client": "claude",
+      "cost": 0.0,
+      "model": "<synthetic>",
+      "provider": "anthropic",
+      "sessionCount": 12,
+      "tokens": {
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "input": 0,
+        "output": 0,
+        "total": 0
+      }
+    }
+  ],
+  "totals": {
+    "cost": 132.4170987,
+    "tokens": 296672003
+  }
+}

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,8 +1,7 @@
 use boa_engine::{Context, Source, JsValue, NativeFunction, js_string};
 use std::collections::{HashMap, VecDeque};
-use markup5ever_rcdom::{NodeData, Handle, Node};
+use markup5ever_rcdom::{NodeData, Handle};
 use std::cell::RefCell;
-use html5ever::{QualName, LocalName, Namespace};
 use std::sync::mpsc::{channel, Receiver, Sender};
 
 thread_local! {
@@ -15,8 +14,10 @@ thread_local! {
     static NODE_REGISTRY: RefCell<HashMap<u32, Handle>> = RefCell::new(HashMap::new());
     static NEXT_NODE_ID: RefCell<u32> = RefCell::new(1);
     static FETCH_REGISTRY: RefCell<HashMap<u32, (JsValue, JsValue)>> = RefCell::new(HashMap::new());
+    static FETCH_BODY_REGISTRY: RefCell<HashMap<u32, String>> = RefCell::new(HashMap::new());
     static NEXT_FETCH_ID: RefCell<u32> = RefCell::new(1);
     static TASK_SENDER: RefCell<Option<Sender<Box<dyn FnOnce(&mut Context) + Send>>>> = RefCell::new(None);
+    static FOCUSED_NODE: RefCell<Option<String>> = RefCell::new(None);
 }
 
 pub struct JsRuntime {
@@ -50,10 +51,9 @@ impl JsRuntime {
             if let Some(callback) = args.get(0).cloned() {
                 if let Some(obj) = callback.as_object() {
                     if obj.is_callable() {
-                        let ms = args.get(1).and_then(|v| v.as_number()).unwrap_or(0.0);
+                        let _ms = args.get(1).and_then(|v| v.as_number()).unwrap_or(0.0);
                         
                         // For now, immediate execution in next macro-task queue
-                        // Proper timer management requires JsRuntime to track deadlines.
                         MACRO_TASKS.with(|tasks| {
                             tasks.borrow_mut().push_back(Box::new(move |ctx| {
                                 let _ = callback.as_object().unwrap().call(&JsValue::undefined(), &[], ctx);
@@ -95,7 +95,6 @@ impl JsRuntime {
                         });
                         IDLE_TASKS.with(|tasks| {
                             tasks.borrow_mut().push_back((id, Box::new(move |ctx, deadline| {
-                                // Create IdleDeadline object
                                 let deadline_obj_val = ctx.eval(Source::from_bytes(b"({})")).unwrap();
                                 let deadline_obj = deadline_obj_val.as_object().unwrap();
                                 
@@ -104,14 +103,11 @@ impl JsRuntime {
                                     Ok(JsValue::from((deadline - now).max(0.0)))
                                 });
                                 
-                                // Workaround to create a JS function value from NativeFunction in Boa 0.21.1
                                 ctx.register_global_callable(js_string!("__aura_temp_time_rem"), 0, time_rem).unwrap();
                                 let time_rem_fn = ctx.eval(Source::from_bytes(b"__aura_temp_time_rem")).unwrap();
                                 
                                 deadline_obj.set(js_string!("timeRemaining"), time_rem_fn, false, ctx).unwrap();
                                 deadline_obj.set(js_string!("didTimeout"), JsValue::from(false), false, ctx).unwrap();
-                                
-                                // Clean up the temporary global
                                 let _ = ctx.eval(Source::from_bytes(b"delete globalThis.__aura_temp_time_rem"));
                                 
                                 let _ = obj.call(&JsValue::undefined(), &[deadline_obj_val], ctx);
@@ -134,6 +130,14 @@ impl JsRuntime {
             Ok(JsValue::undefined())
         });
         context.register_global_callable(js_string!("cancelIdleCallback"), 1, cic).unwrap();
+
+        // Register native __aura_set_focus
+        let set_focus = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let id = args.get(0).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped());
+            FOCUSED_NODE.with(|f| *f.borrow_mut() = id);
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("__aura_set_focus"), 1, set_focus).unwrap();
 
         // Register native __aura_queue_task
         let queue_task = NativeFunction::from_copy_closure(|_this, args, _context| {
@@ -170,38 +174,40 @@ impl JsRuntime {
                 if let Some(ref sender) = *s_cell.borrow() {
                     let sender_clone = sender.clone();
                     std::thread::spawn(move || {
-                        let result = reqwest::blocking::get(&url);
-                        match result {
-                            Ok(resp) => {
-                                let status = resp.status().as_u16();
-                                let ok = resp.status().is_success();
-                                let body = resp.text().unwrap_or_default();
-                                let task: Box<dyn FnOnce(&mut Context) + Send> = Box::new(move |ctx| {
-                                    if let Some((resolve, _)) = FETCH_REGISTRY.with(|reg| reg.borrow_mut().remove(&fetch_id)) {
-                                        if let Some(obj) = resolve.as_object() {
-                                            if let Ok(js_resp_val) = ctx.eval(Source::from_bytes(b"({})")) {
-                                                if let Some(js_resp) = js_resp_val.as_object() {
-                                                    let _ = js_resp.set(js_string!("status"), JsValue::from(status), false, ctx);
-                                                    let _ = js_resp.set(js_string!("ok"), JsValue::from(ok), false, ctx);
-                                                    let _ = js_resp.set(js_string!("_body"), js_string!(body), false, ctx);
-                                                    let _ = obj.call(&JsValue::undefined(), &[js_resp_val], ctx);
-                                                }
-                                            }
-                                        }
+                        let res = reqwest::blocking::get(&url);
+                        match res {
+                            Ok(response) => {
+                                let body = response.text().unwrap_or_default();
+                                let _ = sender_clone.send(Box::new(move |ctx| {
+                                    let (resolve, _) = FETCH_REGISTRY.with(|reg| reg.borrow_mut().remove(&fetch_id).unwrap());
+                                    FETCH_BODY_REGISTRY.with(|reg| reg.borrow_mut().insert(fetch_id, body));
+                                    
+                                    if let Some(obj) = resolve.as_object() {
+                                        let res_obj_val = ctx.eval(Source::from_bytes(b"({})")).unwrap();
+                                        let res_obj = res_obj_val.as_object().unwrap();
+                                        
+                                        let text_fn = NativeFunction::from_copy_closure(move |_, _, _| {
+                                            let body = FETCH_BODY_REGISTRY.with(|reg| reg.borrow_mut().remove(&fetch_id).unwrap_or_default());
+                                            Ok(JsValue::from(js_string!(body)))
+                                        });
+                                        
+                                        ctx.register_global_callable(js_string!("__aura_temp_text"), 0, text_fn).unwrap();
+                                        let text_fn_obj = ctx.eval(Source::from_bytes(b"__aura_temp_text")).unwrap();
+                                        let _ = ctx.eval(Source::from_bytes(b"delete globalThis.__aura_temp_text"));
+                                        
+                                        res_obj.set(js_string!("text"), text_fn_obj, false, ctx).unwrap();
+                                        let _ = obj.call(&JsValue::undefined(), &[res_obj_val], ctx);
                                     }
-                                });
-                                let _ = sender_clone.send(task);
+                                }));
                             }
                             Err(e) => {
                                 let err_msg = e.to_string();
-                                let task: Box<dyn FnOnce(&mut Context) + Send> = Box::new(move |ctx| {
-                                    if let Some((_, reject)) = FETCH_REGISTRY.with(|reg| reg.borrow_mut().remove(&fetch_id)) {
-                                        if let Some(obj) = reject.as_object() {
-                                            let _ = obj.call(&JsValue::undefined(), &[JsValue::from(js_string!(err_msg))], ctx);
-                                        }
+                                let _ = sender_clone.send(Box::new(move |ctx| {
+                                    let (_, reject) = FETCH_REGISTRY.with(|reg| reg.borrow_mut().remove(&fetch_id).unwrap());
+                                    if let Some(obj) = reject.as_object() {
+                                        let _ = obj.call(&JsValue::undefined(), &[JsValue::from(js_string!(err_msg))], ctx);
                                     }
-                                });
-                                let _ = sender_clone.send(task);
+                                }));
                             }
                         }
                     });
@@ -211,85 +217,9 @@ impl JsRuntime {
         });
         context.register_global_callable(js_string!("__aura_fetch"), 3, aura_fetch).unwrap();
 
-        // DOM Bridges
-        let get_el_by_id = NativeFunction::from_copy_closure(|_this, args, _context| {
-            let id_str = args.get(0).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
-            let id = DOM_ROOT.with(|root_cell| {
-                if let Some(ref root) = *root_cell.borrow() {
-                    if let Some(handle) = find_element_by_id(root, &id_str) {
-                        return Some(register_node(handle));
-                    }
-                }
-                None
-            });
-            Ok(id.map(JsValue::from).unwrap_or(JsValue::null()))
-        });
-        context.register_global_callable(js_string!("__aura_get_element_by_id"), 1, get_el_by_id).unwrap();
-
-        let get_parent_id = NativeFunction::from_copy_closure(|_this, args, _context| {
-            let node_id = args.get(0).and_then(|v| v.as_number()).unwrap_or(0.0) as u32;
-            // Extract the parent Handle before releasing NODE_REGISTRY borrow,
-            // then call register_node separately to avoid a double-borrow panic.
-            let parent_handle = NODE_REGISTRY.with(|reg| {
-                if let Some(node) = reg.borrow().get(&node_id) {
-                    node.parent.take().and_then(|p| p.upgrade()).map(|p| {
-                        node.parent.set(Some(std::rc::Rc::downgrade(&p)));
-                        p
-                    })
-                } else {
-                    None
-                }
-            });
-            let pid = parent_handle.map(register_node);
-            Ok(pid.map(JsValue::from).unwrap_or(JsValue::null()))
-        });
-        context.register_global_callable(js_string!("__aura_get_parent_id"), 1, get_parent_id).unwrap();
-
-        let get_body = NativeFunction::from_copy_closure(|_this, _args, _context| {
-            let bid = DOM_ROOT.with(|root_cell| {
-                if let Some(ref root) = *root_cell.borrow() {
-                    if let Some(body) = find_element_by_tag(root, "body") {
-                        return Some(register_node(body));
-                    }
-                }
-                None
-            });
-            Ok(bid.map(JsValue::from).unwrap_or(JsValue::null()))
-        });
-        context.register_global_callable(js_string!("__aura_get_body"), 0, get_body).unwrap();
-
-        let create_element = NativeFunction::from_copy_closure(|_this, args, _context| {
-            let tag = args.get(0).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
-            let name = QualName::new(None, Namespace::from("http://www.w3.org/1999/xhtml"), LocalName::from(tag));
-            let new_node = Node::new(NodeData::Element {
-                name,
-                attrs: RefCell::new(Vec::new()),
-                template_contents: RefCell::new(None),
-                mathml_annotation_xml_integration_point: false,
-            });
-            Ok(JsValue::from(register_node(new_node)))
-        });
-        context.register_global_callable(js_string!("__aura_create_element"), 1, create_element).unwrap();
-
-        let append_child = NativeFunction::from_copy_closure(|_this, args, _context| {
-            let parent_id = args.get(0).and_then(|v| v.as_number()).unwrap_or(0.0) as u32;
-            let child_id = args.get(1).and_then(|v| v.as_number()).unwrap_or(0.0) as u32;
-            NODE_REGISTRY.with(|reg| {
-                let reg = reg.borrow();
-                if let (Some(parent), Some(child)) = (reg.get(&parent_id), reg.get(&child_id)) {
-                    child.parent.set(Some(std::rc::Rc::downgrade(&parent)));
-                    parent.children.borrow_mut().push(child.clone());
-                }
-            });
-            Ok(JsValue::undefined())
-        });
-        context.register_global_callable(js_string!("__aura_append_child"), 2, append_child).unwrap();
-
-        // Load the full JS environment
-        const BOOTSTRAP: &[u8] = include_bytes!("js_bootstrap.js");
-        if let Err(e) = context.eval(Source::from_bytes(BOOTSTRAP)) {
-            println!("[Aura JS Bootstrap Error] {}", e);
-        }
+        // Load bootstrap
+        let bootstrap = include_str!("js_bootstrap.js");
+        let _ = context.eval(Source::from_bytes(bootstrap.as_bytes()));
 
         Self { context, task_receiver }
     }
@@ -297,44 +227,33 @@ impl JsRuntime {
     pub fn poll_tasks(&mut self) -> bool {
         let mut did_work = false;
 
-        // 1. Check for tasks from other threads (fetch, etc.)
         while let Ok(task) = self.task_receiver.try_recv() {
             MACRO_TASKS.with(|tasks| tasks.borrow_mut().push_back(task));
         }
 
-        // 2. Execute ONE macro-task
         let macro_task = MACRO_TASKS.with(|tasks| tasks.borrow_mut().pop_front());
         if let Some(task) = macro_task {
             task(&mut self.context);
             did_work = true;
-            
-            // 3. Microtask checkpoint after task execution
             self.run_microtasks();
         }
 
         did_work
     }
 
-    /// Run all pending micro-tasks and Boa jobs.
     fn run_microtasks(&mut self) {
         loop {
             let mut micro_work_done = false;
-
-            // Execute all micro-tasks in our queue
             while let Some(task) = MICRO_TASKS.with(|tasks| tasks.borrow_mut().pop_front()) {
                 task(&mut self.context);
                 micro_work_done = true;
             }
-
-            // Execute Boa jobs (Promises)
             let _ = self.context.run_jobs();
-
             if !micro_work_done { break; }
         }
     }
 
     pub fn trigger_event(&mut self, target_id: &str, event_type: &str) {
-        // Find native ID from DOM string ID
         let native_id = DOM_ROOT.with(|root| {
             if let Some(ref r) = *root.borrow() {
                 find_element_by_id(r, target_id).map(register_node)
@@ -344,16 +263,12 @@ impl JsRuntime {
         if let Some(nid) = native_id {
             let code = format!("document.__trigger_event({}, '{}', {{ bubbles: true }})", nid, event_type);
             let _ = self.context.eval(Source::from_bytes(code.as_bytes()));
-            
-            // Microtask checkpoint after event execution
             self.run_microtasks();
         }
     }
 
     pub fn poll_raf_tasks(&mut self, timestamp: f64) -> bool {
         let mut did_work = false;
-
-        // Take a snapshot of current tasks to avoid infinite recursion in same frame
         let mut tasks = VecDeque::new();
         RAF_TASKS.with(|t| tasks = t.borrow_mut().drain(..).collect());
 
@@ -361,37 +276,27 @@ impl JsRuntime {
             did_work = true;
             for task in tasks {
                 task(&mut self.context, timestamp);
-                // Microtask checkpoint after each rAF callback
                 self.run_microtasks();
             }
         }
-
         did_work
     }
 
     pub fn poll_idle_tasks(&mut self, deadline_ms: f64) -> bool {
         let mut did_work = false;
-
         while let Some((_, task)) = IDLE_TASKS.with(|tasks| tasks.borrow_mut().pop_front()) {
             did_work = true;
             task(&mut self.context, deadline_ms);
             self.run_microtasks();
-
-            // Check if we still have time
             let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis() as f64;
-            if now >= deadline_ms {
-                break;
-            }
+            if now >= deadline_ms { break; }
         }
-
         did_work
     }
 
     pub fn execute(&mut self, source: &str) {
         if source.contains("import.meta") || (source.contains("import ") && source.contains(" from ")) { return; }
         let _ = self.context.eval(Source::from_bytes(source.as_bytes()));
-        
-        // Microtask checkpoint after script execution
         self.run_microtasks();
     }
 
@@ -412,6 +317,31 @@ impl JsRuntime {
         let _ = self.context.eval(Source::from_bytes(b"__aura_style_log = [];"));
         result
     }
+
+    pub fn get_focused_node_id(&self) -> Option<String> {
+        FOCUSED_NODE.with(|f| (*f.borrow()).clone())
+    }
+}
+
+pub fn extract_scripts_from_dom(handle: &Handle) -> Vec<String> {
+    let mut scripts = Vec::new();
+    if let NodeData::Element { ref name, .. } = handle.data {
+        if name.local.to_string() == "script" {
+            let mut content = String::new();
+            for child in handle.children.borrow().iter() {
+                if let NodeData::Text { ref contents } = child.data {
+                    content.push_str(&contents.borrow());
+                }
+            }
+            if !content.is_empty() {
+                scripts.push(content);
+            }
+        }
+    }
+    for child in handle.children.borrow().iter() {
+        scripts.extend(extract_scripts_from_dom(child));
+    }
+    scripts
 }
 
 fn find_element_by_id(root: &Handle, id: &str) -> Option<Handle> {
@@ -428,48 +358,12 @@ fn find_element_by_id(root: &Handle, id: &str) -> Option<Handle> {
     None
 }
 
-fn find_element_by_tag(root: &Handle, tag: &str) -> Option<Handle> {
-    if let NodeData::Element { ref name, .. } = root.data {
-        if name.local.to_string() == tag {
-            return Some(root.clone());
-        }
-    }
-    for child in root.children.borrow().iter() {
-        if let Some(found) = find_element_by_tag(child, tag) { return Some(found); }
-    }
-    None
-}
-
 fn register_node(handle: Handle) -> u32 {
-    NODE_REGISTRY.with(|reg| {
-        let mut reg = reg.borrow_mut();
-        // Check if already registered
-        for (id, h) in reg.iter() {
-            if std::rc::Rc::ptr_eq(h, &handle) { return *id; }
-        }
-        let id = NEXT_NODE_ID.with(|id_cell| {
-            let id = *id_cell.borrow();
-            *id_cell.borrow_mut() += 1;
-            id
-        });
-        reg.insert(id, handle);
+    let id = NEXT_NODE_ID.with(|id_cell| {
+        let id = *id_cell.borrow();
+        *id_cell.borrow_mut() += 1;
         id
-    })
-}
-
-pub fn extract_scripts_from_dom(handle: &Handle) -> Vec<String> {
-    let mut scripts = Vec::new();
-    if let NodeData::Element { ref name, .. } = handle.data {
-        if name.local.to_string() == "script" {
-            for child in handle.children.borrow().iter() {
-                if let NodeData::Text { ref contents } = child.data {
-                    scripts.push(contents.borrow().to_string());
-                }
-            }
-        }
-    }
-    for child in handle.children.borrow().iter() {
-        scripts.extend(extract_scripts_from_dom(child));
-    }
-    scripts
+    });
+    NODE_REGISTRY.with(|reg| reg.borrow_mut().insert(id, handle));
+    id
 }

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -12,10 +12,10 @@ function __aura_set_style(id, prop, value) {
 // -- Node Registry (Ensures stable objects for events) -----------------------
 var __node_registry = new Map();
 
-function __get_or_create_node(id, tag) {
+function __get_or_create_node(id, tag, string_id) {
     if (!id) return null;
     if (__node_registry.has(id)) return __node_registry.get(id);
-    let node = tag ? new Element(id, tag) : new Node(id);
+    let node = tag ? new Element(id, tag, string_id) : new Node(id);
     __node_registry.set(id, node);
     return node;
 }
@@ -91,9 +91,10 @@ class Node extends EventTarget {
 }
 
 class Element extends Node {
-    constructor(id, tag) {
+    constructor(id, tag, string_id) {
         super(id);
         this.tagName = (tag || '').toUpperCase();
+        this.id = string_id || '';
         this.style = new Proxy({ _id: id }, {
             set: (target, prop, value) => {
                 let kebab = prop.replace(/([A-Z])/g, "-$1").toLowerCase();
@@ -106,13 +107,17 @@ class Element extends Node {
     setAttribute(name, value) {
         __aura_set_attribute(this._id, name, String(value));
     }
+    focus() {
+        document.activeElement = this;
+        __aura_set_focus(this.id);
+    }
 }
 
 // -- document -----------------------------------------------------------------
 var document = {
     getElementById: function(id) {
         let nativeId = __aura_get_element_by_id(id);
-        return nativeId ? __get_or_create_node(nativeId) : null;
+        return nativeId ? __get_or_create_node(nativeId, null, id) : null;
     },
     createElement: function(tag) {
         let nativeId = __aura_create_element(tag);

--- a/src/layer_tree.rs
+++ b/src/layer_tree.rs
@@ -425,7 +425,7 @@ mod tests {
     fn build_tree_from_html(html: &str, extra_css: &str) -> LayerTree {
         let dom = dom::parse_html(html);
         let stylesheet = css::parse_css(extra_css);
-        let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.expect("layout tree should be built");
         LayerTreeBuilder::build(&layout, viewport())

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -904,6 +904,36 @@ impl<'a> LayoutBox<'a> {
         }
         for child in &self.children { child.collect_element_ids(list); }
     }
+
+    pub fn collect_focusable_elements(&self, list: &mut Vec<(Rect, String)>) {
+        if let NodeData::Element { ref name, ref attrs, .. } = self.style_node.node.data {
+            let tag = name.local.to_string();
+            let mut id = None;
+            let mut has_href = false;
+
+            for attr in attrs.borrow().iter() {
+                let key = attr.name.local.to_string();
+                if key == "id" { id = Some(attr.value.to_string()); }
+                if key == "href" { has_href = true; }
+            }
+
+            let is_focusable = match tag.as_str() {
+                "a" => has_href,
+                "button" | "input" | "select" | "textarea" => true,
+                _ => false,
+            };
+
+            if is_focusable {
+                // If element has no ID, we should generate a stable internal ID?
+                // For now, only focus elements with explicit IDs for simplicity.
+                if let Some(actual_id) = id {
+                    list.push((self.dimensions, actual_id));
+                }
+            }
+        }
+        for child in &self.children { child.collect_focusable_elements(list); }
+    }
+
     pub fn establishes_stacking_context(&self) -> bool {
         self.z_index != 0 || self.establishes_bfc()
     }
@@ -961,7 +991,7 @@ mod tests {
         let html = r#"<button onclick="alert(1)" style="width: 100px; height: 50px; margin: 10px;">Click me</button>"#;
         let dom = dom::parse_html(html);
         let stylesheet = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None, None);
         
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 1024.0, 1024.0, 768.0);
         let layout = layout_opt.unwrap();
@@ -982,7 +1012,7 @@ mod tests {
         let html = r#"<div style="display: block; width: 500px; margin: auto;">Content</div>"#;
         let dom = dom::parse_html(html);
         let stylesheet = css::parse_css("");
-        let mut style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None);
+        let mut style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None, None);
         
         // Ensure the style is manually set if parser was ambiguous
         if let NodeData::Element { .. } = style_tree.children[0].node.data {
@@ -1003,7 +1033,7 @@ mod tests {
         let html = r#"<div style="margin-left: 48px; margin-top: 24px;">Hello world</div>"#;
         let dom = dom::parse_html(html);
         let stylesheet = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None, None);
 
         let div_node = style_tree
             .children
@@ -1063,7 +1093,7 @@ mod tests {
         let html = r#"<span>Hi</span>"#;
         let dom = dom::parse_html(html);
         let stylesheet = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None, None);
 
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 768.0);
         let layout = layout_opt.unwrap();
@@ -1139,7 +1169,7 @@ mod tests {
         let html = r#"<div style="width:800px;"><div style="float:left;width:100px;height:50px;">F</div></div>"#;
         let dom_tree = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
         let float_child = find_float_child_deep(&layout).expect("float child not found");
@@ -1152,7 +1182,7 @@ mod tests {
         let html = r#"<div style="width:800px;"><div style="float:right;width:100px;height:50px;">F</div></div>"#;
         let dom_tree = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
         let float_child = find_float_child_deep(&layout).expect("float child not found");
@@ -1166,7 +1196,7 @@ mod tests {
         let html = r#"<div style="width:800px;"><div style="float:left;width:100px;height:50px;">F</div><div style="clear:left;">C</div></div>"#;
         let dom_tree = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
         // Navigate to the outer div (width:800px) then look at its direct children.
@@ -1184,7 +1214,7 @@ mod tests {
         let html = r#"<div style="width:800px;"><div style="float:left;width:100px;height:50px;">F</div><div style="display:block;">S</div></div>"#;
         let dom_tree = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
         let outer_div = find_outer_div(&layout).expect("outer div not found");
@@ -1229,7 +1259,7 @@ mod tests {
         let html = r#"<span>Hello World</span>"#;
         let dom_tree = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None, None);
 
         // Locate the <span> StyledNode
         fn find_span_node<'a>(sn: &'a crate::style::StyledNode) -> Option<&'a crate::style::StyledNode> {
@@ -1255,7 +1285,7 @@ mod tests {
         let html = r#"<div style="width: min-content;">Hello World</div>"#;
         let dom_tree = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
 
@@ -1272,7 +1302,7 @@ mod tests {
         // min-content case
         let dom_min = dom::parse_html(r#"<div style="width: min-content;">Hello World</div>"#);
         let ss_min = css::parse_css("");
-        let st_min = style::build_style_tree(&dom_min.document, &ss_min, None, &HashMap::new(), None);
+        let st_min = style::build_style_tree(&dom_min.document, &ss_min, None, &HashMap::new(), None, None);
         let (lo_min, _, _) = build_layout_tree(&st_min, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout_min = lo_min.unwrap();
         let div_min_w = find_element_by_tag(&layout_min, "div").unwrap().dimensions.width;
@@ -1280,7 +1310,7 @@ mod tests {
         // max-content case
         let dom_max = dom::parse_html(r#"<div style="width: max-content;">Hello World</div>"#);
         let ss_max = css::parse_css("");
-        let st_max = style::build_style_tree(&dom_max.document, &ss_max, None, &HashMap::new(), None);
+        let st_max = style::build_style_tree(&dom_max.document, &ss_max, None, &HashMap::new(), None, None);
         let (lo_max, _, _) = build_layout_tree(&st_max, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout_max = lo_max.unwrap();
         let div_max_w = find_element_by_tag(&layout_max, "div").unwrap().dimensions.width;
@@ -1298,7 +1328,7 @@ mod tests {
         let html = r#"<div style="width: fit-content(150px);">Hello World this is some longer text for the test</div>"#;
         let dom_tree = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
         let div = find_element_by_tag(&layout, "div").expect("div not found");
@@ -1314,7 +1344,7 @@ mod tests {
         let html = r#"<div style="width: fit-content;">Hello</div>"#;
         let dom_tree = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom_tree.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
         let div = find_element_by_tag(&layout, "div").expect("div not found");
@@ -1330,7 +1360,7 @@ mod tests {
         let html = r#"<div style="width:100px;height:50px;">Content</div>"#;
         let dom = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
         let div = find_element_by_tag(&layout, "div").expect("div not found");
@@ -1343,7 +1373,7 @@ mod tests {
         let html = r#"<div style="width:100px;height:50px;opacity:0.5;">Content</div>"#;
         let dom = dom::parse_html(html);
         let ss = css::parse_css("");
-        let style_tree = style::build_style_tree(&dom.document, &ss, None, &HashMap::new(), None);
+        let style_tree = style::build_style_tree(&dom.document, &ss, None, &HashMap::new(), None, None);
         let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
         let layout = layout_opt.unwrap();
         let div = find_element_by_tag(&layout, "div").expect("div not found");

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,11 @@ struct BrowserApp {
     current_form_controls: Vec<(layout::Rect, String)>,
     current_event_handlers: Vec<(layout::Rect, String)>,
     current_element_ids: Vec<(layout::Rect, String)>,
+    current_focusable_elements: Vec<(layout::Rect, String)>,
     hovered_id: Option<String>,
-    form_values: HashMap<usize, String>,
+    focused_id: Option<String>,
+    form_values: HashMap<String, String>,
+
     image_cache: HashMap<String, Vec<u8>>,
     css_cache: HashMap<String, String>,
     last_stylesheet: Option<css::Stylesheet>,
@@ -48,6 +51,7 @@ struct StaticPageData {
     form_controls: Vec<(layout::Rect, String)>,
     event_handlers: Vec<(layout::Rect, String)>,
     element_ids: Vec<(layout::Rect, String)>,
+    focusable_elements: Vec<(layout::Rect, String)>,
     image_urls: Vec<String>,
     body: String,
     base_url: Url,
@@ -84,7 +88,9 @@ impl BrowserApp {
             current_form_controls: vec![],
             current_event_handlers: vec![],
             current_element_ids: vec![],
+            current_focusable_elements: vec![],
             hovered_id: None,
+            focused_id: None,
             form_values: HashMap::new(),
             image_cache: HashMap::new(),
             css_cache: HashMap::new(),
@@ -137,7 +143,7 @@ impl BrowserApp {
         
         let mut cache = self.css_cache.clone();
         self.content_promise = Some(Promise::spawn_thread("fetcher", move || {
-            fetch_and_process(&url, &mut cache, &HashMap::new(), None, width)
+            fetch_and_process(&url, &mut cache, &HashMap::new(), None, None, width)
                 .map_err(|e| e.to_string())
         }));
     }
@@ -151,10 +157,11 @@ impl BrowserApp {
             let stylesheet = self.last_stylesheet.clone();
             let overrides = self.js_style_overrides.clone();
             let hovered_id = self.hovered_id.clone();
+            let focused_id = self.focused_id.clone();
 
             // Use re_render_promise instead of join() to avoid UI blocking
             self.re_render_promise = Some(Promise::spawn_thread("re_render", move || {
-                process_html_with_cache(&body, &base_url, &cache, &mut css_cache, stylesheet, &overrides, hovered_id.as_deref(), width)
+                process_html_with_cache(&body, &base_url, &cache, &mut css_cache, stylesheet, &overrides, hovered_id.as_deref(), focused_id.as_deref(), width)
                     .map_err(|e| e.to_string())
             }));
             
@@ -173,6 +180,7 @@ impl BrowserApp {
         self.current_form_controls = page_data.form_controls;
         self.current_event_handlers = page_data.event_handlers;
         self.current_element_ids = page_data.element_ids;
+        self.current_focusable_elements = page_data.focusable_elements;
     }
 }
 
@@ -230,12 +238,13 @@ fn fetch_and_process(
     css_cache: &mut HashMap<String, String>,
     js_overrides: &HashMap<String, HashMap<String, String>>,
     hovered_id: Option<&str>,
+    focused_id: Option<&str>,
     width: f32,
 ) -> Result<(StaticPageData, css::Stylesheet), Box<dyn Error + Send + Sync>> {
     let response = reqwest::blocking::get(url_str)?;
     let body = response.text()?;
     let base_url = Url::parse(url_str)?;
-    process_html_with_cache(&body, &base_url, &HashMap::new(), css_cache, None, js_overrides, hovered_id, width)
+    process_html_with_cache(&body, &base_url, &HashMap::new(), css_cache, None, js_overrides, hovered_id, focused_id, width)
 }
 
 fn process_html_with_cache(
@@ -246,6 +255,7 @@ fn process_html_with_cache(
     cached_stylesheet: Option<css::Stylesheet>,
     js_overrides: &HashMap<String, HashMap<String, String>>,
     hovered_id: Option<&str>,
+    focused_id: Option<&str>,
     width: f32,
 ) -> Result<(StaticPageData, css::Stylesheet), Box<dyn Error + Send + Sync>> {
     let start_total = Instant::now();
@@ -273,12 +283,13 @@ fn process_html_with_cache(
     };
 
     let start = Instant::now();
-    let style_tree = style::build_style_tree(&dom_tree.document, &stylesheet, None, js_overrides, hovered_id);
+    let style_tree = style::build_style_tree(&dom_tree.document, &stylesheet, None, js_overrides, hovered_id, focused_id);
     let style_elapsed = start.elapsed();
 
     let start = Instant::now();
-    let (layout_tree, _, final_y) =
+    let (layout_tree_opt, _, final_y) =
         layout::build_layout_tree(&style_tree, 0.0, 0.0, 0.0, width, width, 768.0);
+    let layout_tree = layout_tree_opt.ok_or("Failed to build layout tree")?;
     let layout_elapsed = start.elapsed();
 
     let height = (final_y.ceil() as u32).clamp(600, 16384);
@@ -294,38 +305,37 @@ fn process_html_with_cache(
     let mut form_controls = Vec::new();
     let mut event_handlers = Vec::new();
     let mut element_ids = Vec::new();
-    let mut image_urls = Vec::new();
+    let mut focusable_elements = Vec::new();
+    let image_urls: Vec<String>;
 
-    if let Some(ref root) = layout_tree {
-        render::render_layout_tree(root, &mut pixmap, image_cache);
+    render::render_layout_tree(&layout_tree, &mut pixmap, image_cache);
 
-        root.collect_links(&mut links);
-        
-        root.collect_event_handlers(&mut event_handlers);
+    layout_tree.collect_links(&mut links);
+    layout_tree.collect_event_handlers(&mut event_handlers);
+    layout_tree.collect_element_ids(&mut element_ids);
+    layout_tree.collect_focusable_elements(&mut focusable_elements);
+    
+    let mut controls_with_nodes = Vec::new();
+    layout_tree.collect_form_controls(&mut controls_with_nodes);
+    
+    let mut image_urls_raw = Vec::new();
+    layout_tree.collect_images(&mut image_urls_raw);
+    image_urls = image_urls_raw.into_iter().map(|(_, url)| {
+        base_url.join(&url).map(|u| u.to_string()).unwrap_or(url)
+    }).collect();
 
-        root.collect_element_ids(&mut element_ids);
-        
-        let mut controls_with_nodes = Vec::new();
-        root.collect_form_controls(&mut controls_with_nodes);
-        
-        let mut image_urls_raw = Vec::new();
-        root.collect_images(&mut image_urls_raw);
-        image_urls = image_urls_raw.into_iter().map(|(_, url)| {
-            base_url.join(&url).map(|u| u.to_string()).unwrap_or(url)
-        }).collect();
-
-        for (rect, node) in controls_with_nodes {
-            let mut val = String::new();
-            if let markup5ever_rcdom::NodeData::Element { ref attrs, .. } = node.node.data {
-                for attr in attrs.borrow().iter() {
-                    if attr.name.local.to_string() == "value" {
-                        val = attr.value.to_string();
-                    }
+    for (rect, node) in controls_with_nodes {
+        let mut val = String::new();
+        if let markup5ever_rcdom::NodeData::Element { ref attrs, .. } = node.node.data {
+            for attr in attrs.borrow().iter() {
+                if attr.name.local.to_string() == "value" {
+                    val = attr.value.to_string();
                 }
             }
-            form_controls.push((rect, val));
         }
+        form_controls.push((rect, val));
     }
+
     let render_elapsed = start.elapsed();
 
     let start = Instant::now();
@@ -354,6 +364,7 @@ fn process_html_with_cache(
         form_controls,
         event_handlers,
         element_ids,
+        focusable_elements,
         image_urls,
         body: body.to_string(),
         base_url: base_url.clone(),
@@ -362,8 +373,42 @@ fn process_html_with_cache(
 
 impl eframe::App for BrowserApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Handle Tab navigation
+        if ctx.input(|i| i.key_pressed(egui::Key::Tab)) {
+            let focusables = &self.current_focusable_elements;
+            if !focusables.is_empty() {
+                let current_index = self.focused_id.as_ref()
+                    .and_then(|id| focusables.iter().position(|(_, fid)| fid == id));
+                
+                let next_index = if ctx.input(|i| i.modifiers.shift) {
+                    // Shift+Tab: Backward
+                    match current_index {
+                        Some(i) if i > 0 => i - 1,
+                        _ => focusables.len() - 1,
+                    }
+                } else {
+                    // Tab: Forward
+                    match current_index {
+                        Some(i) if i + 1 < focusables.len() => i + 1,
+                        _ => 0,
+                    }
+                };
+                
+                self.focused_id = Some(focusables[next_index].1.clone());
+                self.trigger_re_render(ctx, 800.0);
+            }
+        }
+
         // Poll JS event loop tasks
         let mut needs_re_render = self.js_runtime.poll_tasks();
+
+        // Sync focus from JS
+        if let Some(js_focused_id) = self.js_runtime.get_focused_node_id() {
+            if self.focused_id.as_deref() != Some(&js_focused_id) {
+                self.focused_id = Some(js_focused_id);
+                needs_re_render = true;
+            }
+        }
 
         // Run animation frames
         let timestamp = self.start_time.elapsed().as_secs_f64() * 1000.0;
@@ -503,6 +548,7 @@ impl eframe::App for BrowserApp {
                                 form_controls: page_data.form_controls.clone(),
                                 event_handlers: page_data.event_handlers.clone(),
                                 element_ids: page_data.element_ids.clone(),
+                                focusable_elements: page_data.focusable_elements.clone(),
                                 image_urls: page_data.image_urls.clone(),
                                 body: page_data.body.clone(),
                                 base_url: page_data.base_url.clone(),
@@ -542,6 +588,7 @@ impl eframe::App for BrowserApp {
                                 form_controls: page_data.form_controls.clone(),
                                 event_handlers: page_data.event_handlers.clone(),
                                 element_ids: page_data.element_ids.clone(),
+                                focusable_elements: page_data.focusable_elements.clone(),
                                 image_urls: image_urls.clone(),
                                 body: body.clone(),
                                 base_url: base_url.clone(),
@@ -556,7 +603,7 @@ impl eframe::App for BrowserApp {
                             self.last_base_url = Some(base_url.clone());
                             self.form_values.clear();
                             for (i, (_, val)) in page.form_controls.iter().enumerate() {
-                                self.form_values.insert(i, val.clone());
+                                self.form_values.insert(i.to_string(), val.clone());
                             }
                             self.apply_page_data(page, ctx);
 
@@ -640,7 +687,7 @@ impl eframe::App for BrowserApp {
 
                         // Overlay interactive form controls
                         for (i, (l_rect, _)) in self.current_form_controls.iter().enumerate() {
-                            let val = self.form_values.entry(i).or_default();
+                            let val = self.form_values.entry(i.to_string()).or_default();
                             let screen_rect = egui::Rect::from_min_size(
                                 rect.min + egui::vec2(l_rect.x, l_rect.y),
                                 egui::vec2(l_rect.width, l_rect.height),
@@ -658,6 +705,18 @@ impl eframe::App for BrowserApp {
                                     if hit(rel, l_rect) {
                                         self.js_runtime.trigger_event(id, "click");
                                     }
+                                }
+
+                                // Update focused_id on click
+                                let mut new_focus = None;
+                                for (l_rect, id) in &self.current_focusable_elements {
+                                    if hit(rel, l_rect) {
+                                        new_focus = Some(id.clone());
+                                    }
+                                }
+                                if new_focus != self.focused_id {
+                                    self.focused_id = new_focus;
+                                    self.trigger_re_render(ctx, ui.available_width());
                                 }
 
                                 for (l_rect, script) in &self.current_event_handlers {

--- a/src/style.rs
+++ b/src/style.rs
@@ -58,7 +58,7 @@ fn flatten_dom(handle: &Handle, arena: &mut Vec<NodeDataSend>, parent_idx: Optio
     idx
 }
 
-fn matches_selector_arena(selector: &Selector, idx: usize, arena: &[NodeDataSend], hovered_id: Option<&str>) -> bool {
+fn matches_selector_arena(selector: &Selector, idx: usize, arena: &[NodeDataSend], hovered_id: Option<&str>, focused_id: Option<&str>) -> bool {
     let node = &arena[idx];
     
     let has_constraint = selector.tag.is_some() || selector.id.is_some() || !selector.class.is_empty() || !selector.attributes.is_empty() || selector.pseudo_class.is_some();
@@ -76,6 +76,8 @@ fn matches_selector_arena(selector: &Selector, idx: usize, arena: &[NodeDataSend
     if let Some(ref pseudo) = selector.pseudo_class {
         if pseudo == "hover" {
             if Some(node.id.as_deref()) != Some(hovered_id) || node.id.is_none() { return false; }
+        } else if pseudo == "focus" {
+            if Some(node.id.as_deref()) != Some(focused_id) || node.id.is_none() { return false; }
         } else { return false; }
     }
     for attr_sel in &selector.attributes {
@@ -98,7 +100,7 @@ fn matches_selector_arena(selector: &Selector, idx: usize, arena: &[NodeDataSend
                 let mut current = node.parent_idx;
                 let mut matched = false;
                 while let Some(p_idx) = current {
-                    if matches_selector_arena(ancestor_sel, p_idx, arena, hovered_id) {
+                    if matches_selector_arena(ancestor_sel, p_idx, arena, hovered_id, focused_id) {
                         matched = true; break;
                     }
                     current = arena[p_idx].parent_idx;
@@ -107,7 +109,7 @@ fn matches_selector_arena(selector: &Selector, idx: usize, arena: &[NodeDataSend
             }
             Combinator::Child => {
                 if let Some(p_idx) = node.parent_idx {
-                    if !matches_selector_arena(ancestor_sel, p_idx, arena, hovered_id) { return false; }
+                    if !matches_selector_arena(ancestor_sel, p_idx, arena, hovered_id, focused_id) { return false; }
                 } else { return false; }
             }
             Combinator::NextSibling => {
@@ -117,7 +119,7 @@ fn matches_selector_arena(selector: &Selector, idx: usize, arena: &[NodeDataSend
                     for &sib_idx in p_node.children_idx.iter().rev() {
                         if sib_idx >= idx { continue; }
                         if arena[sib_idx].is_element {
-                            if matches_selector_arena(ancestor_sel, sib_idx, arena, hovered_id) { found = true; }
+                            if matches_selector_arena(ancestor_sel, sib_idx, arena, hovered_id, focused_id) { found = true; }
                             break;
                         }
                     }
@@ -131,7 +133,7 @@ fn matches_selector_arena(selector: &Selector, idx: usize, arena: &[NodeDataSend
                     for &sib_idx in &p_node.children_idx {
                         if sib_idx >= idx { break; }
                         if arena[sib_idx].is_element {
-                            if matches_selector_arena(ancestor_sel, sib_idx, arena, hovered_id) {
+                            if matches_selector_arena(ancestor_sel, sib_idx, arena, hovered_id, focused_id) {
                                 matched = true; break;
                             }
                         }
@@ -174,6 +176,7 @@ pub fn build_style_tree(
     parent_style: Option<&PropertyMap>,
     js_overrides: &HashMap<String, HashMap<String, String>>,
     hovered_id: Option<&str>,
+    focused_id: Option<&str>,
 ) -> StyledNode {
     let mut arena = Vec::new();
     flatten_dom(root, &mut arena, None);
@@ -188,7 +191,7 @@ pub fn build_style_tree(
         for rule in stylesheet.all_rules() {
             let mut highest = None;
             for sel in &rule.selectors {
-                if matches_selector_arena(sel, idx, &arena, hovered_id) {
+                if matches_selector_arena(sel, idx, &arena, hovered_id, focused_id) {
                     let spec = sel.specificity();
                     if highest.is_none() || spec > highest.unwrap() { highest = Some(spec); }
                 }
@@ -457,5 +460,25 @@ mod tests {
         assert!(map.contains_key("color"));
         assert!(map.contains_key("font-size"));
         assert!(map.contains_key("background-color"));
+    }
+
+    #[test]
+    fn test_focus_pseudo_class_matching() {
+        let mut arena = Vec::new();
+        arena.push(NodeDataSend {
+            tag: "div".to_string(),
+            id: Some("target".to_string()),
+            classes: Vec::new(),
+            attrs: Vec::new(),
+            is_element: true,
+            parent_idx: None,
+            children_idx: Vec::new(),
+        });
+
+        let mut selector = crate::css::Selector::default();
+        selector.pseudo_class = Some("focus".to_string());
+
+        assert!(!matches_selector_arena(&selector, 0, &arena, None, None));
+        assert!(matches_selector_arena(&selector, 0, &arena, None, Some("target")));
     }
 }

--- a/tests/repro_failures.rs
+++ b/tests/repro_failures.rs
@@ -16,7 +16,7 @@ fn test_interleaved_block_inline_stacking() {
     "#;
     let dom = dom::parse_html(html);
     let stylesheet = css::parse_css("");
-    let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None);
+    let style_tree = style::build_style_tree(&dom.document, &stylesheet, None, &HashMap::new(), None, None);
 
     // Find the outer div
     let outer_div = style_tree.children.iter()


### PR DESCRIPTION
## Summary
- Implemented sequential navigation via Tab/Shift+Tab.
- Added support for the `:focus` pseudo-class.
- Integrated focus state between Rust and JS.

Closes #25