### PR TITLE
feat: browser-daemon — engine + GUI + HTTP server in one process (Issue #70)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +826,7 @@ name = "browser"
 version = "0.1.0"
 dependencies = [
  "ab_glyph",
+ "axum",
  "boa_engine",
  "cssparser",
  "eframe",
@@ -787,6 +843,7 @@ dependencies = [
  "stacker",
  "tiny-skia 0.12.0",
  "tokio",
+ "tower 0.4.13",
  "url",
 ]
 
@@ -2132,6 +2189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,6 +2208,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2661,6 +2725,12 @@ dependencies = [
  "tendril",
  "xml5ever",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "maybe-rayon"
@@ -3862,7 +3932,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -4030,6 +4100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "ryu-js"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4166,6 +4242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,6 +4261,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4783,6 +4882,21 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -4794,6 +4908,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4809,7 +4924,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "browser"
 path = "src/main.rs"
 
+[[bin]]
+name = "browser-daemon"
+path = "src/bin/browser_daemon.rs"
 
 [dependencies]
 ab_glyph = "0.2.32"
@@ -27,3 +30,7 @@ tiny-skia = "0.12.0"
 tokio = { version = "1.51.0", features = ["full"] }
 stacker = "0.1"
 url = "2.5.8"
+axum = { version = "0.7" }
+
+[dev-dependencies]
+tower = { version = "0.4", features = ["util"] }

--- a/src/bin/browser_daemon.rs
+++ b/src/bin/browser_daemon.rs
@@ -1,0 +1,1215 @@
+//! browser-daemon — engine + GUI + HTTP server in one process.
+//!
+//! Usage:
+//!   browser-daemon              # GUI window + HTTP server on :7070
+//!   browser-daemon --no-gui     # headless HTTP server only
+//!   browser-daemon --port 7071  # custom port
+
+use std::collections::HashMap;
+use std::sync::mpsc;
+
+use browser::{engine, layout};
+use eframe::egui;
+use poll_promise::Promise;
+
+// ── CLI argument parsing ───────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct DaemonArgs {
+    no_gui: bool,
+    port: u16,
+}
+
+fn parse_args_from(args: &[&str]) -> DaemonArgs {
+    let mut no_gui = false;
+    let mut port = 7070u16;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i] {
+            "--no-gui" => no_gui = true,
+            "--port" => {
+                i += 1;
+                if let Some(p) = args.get(i) {
+                    port = p.parse().unwrap_or(7070);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    DaemonArgs { no_gui, port }
+}
+
+fn parse_args() -> DaemonArgs {
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let refs: Vec<&str> = raw.iter().map(|s| s.as_str()).collect();
+    parse_args_from(&refs)
+}
+
+// ── Engine actor — command protocol ───────────────────────────────────────────
+
+/// Commands sent to the engine actor thread.
+/// All engine work (including blocking HTTP fetches and JS) happens on that thread.
+pub enum EngineCmd {
+    Navigate {
+        url: String,
+        width: f32,
+        reply: mpsc::Sender<Result<engine::PageResult, String>>,
+    },
+    ReRender {
+        hovered_id: Option<String>,
+        focused_id: Option<String>,
+        width: f32,
+        reply: mpsc::Sender<Result<engine::PageResult, String>>,
+    },
+    Click {
+        x: f32,
+        y: f32,
+        reply: mpsc::Sender<Vec<engine::ClickResult>>,
+    },
+    TypeText {
+        text: String,
+    },
+    EvaluateJs {
+        script: String,
+        reply: mpsc::Sender<String>,
+    },
+    Screenshot {
+        reply: mpsc::Sender<Option<Vec<u8>>>,
+    },
+    DomTree {
+        reply: mpsc::Sender<String>,
+    },
+    LayoutTree {
+        reply: mpsc::Sender<String>,
+    },
+    ComputedStyle {
+        selector: String,
+        reply: mpsc::Sender<HashMap<String, String>>,
+    },
+    GetPage {
+        reply: mpsc::Sender<Option<engine::ApiPageResponse>>,
+    },
+    GetElements {
+        reply: mpsc::Sender<Vec<engine::ApiElement>>,
+    },
+    LoadImage {
+        url: String,
+        bytes: Vec<u8>,
+    },
+    Tick {
+        timestamp: f64,
+        deadline: Option<f64>,
+        reply: mpsc::Sender<bool>,
+    },
+    #[allow(dead_code)]
+    Shutdown,
+}
+
+/// Run the engine actor — owns `BrowserEngine` exclusively.
+/// Processes commands sequentially from the receiver.
+/// This guarantees all `reqwest::blocking` calls and `thread_local!` JS state
+/// are confined to a single thread.
+pub fn run_engine_actor(rx: mpsc::Receiver<EngineCmd>) {
+    let mut eng = engine::BrowserEngine::new();
+    for cmd in rx {
+        match cmd {
+            EngineCmd::Navigate { url, width, reply } => {
+                let result = eng.navigate(&url, width);
+                let _ = reply.send(result);
+            }
+            EngineCmd::ReRender { hovered_id, focused_id, width, reply } => {
+                let result = eng.re_render(hovered_id.as_deref(), focused_id.as_deref(), width);
+                let _ = reply.send(result);
+            }
+            EngineCmd::Click { x, y, reply } => {
+                let result = eng.click(x, y);
+                let _ = reply.send(result);
+            }
+            EngineCmd::TypeText { text } => {
+                eng.type_text(&text);
+            }
+            EngineCmd::EvaluateJs { script, reply } => {
+                let result = eng.evaluate_js(&script);
+                let _ = reply.send(result);
+            }
+            EngineCmd::Screenshot { reply } => {
+                let png = eng.screenshot().and_then(|pm| pm.encode_png().ok());
+                let _ = reply.send(png);
+            }
+            EngineCmd::DomTree { reply } => {
+                let _ = reply.send(eng.dom_tree());
+            }
+            EngineCmd::LayoutTree { reply } => {
+                let _ = reply.send(eng.layout_tree());
+            }
+            EngineCmd::ComputedStyle { selector, reply } => {
+                let _ = reply.send(eng.computed_style(&selector));
+            }
+            EngineCmd::GetPage { reply } => {
+                let resp = eng.last_page.as_ref().map(|p| {
+                    engine::page_to_api_response(p, &p.base_url.clone())
+                });
+                let _ = reply.send(resp);
+            }
+            EngineCmd::GetElements { reply } => {
+                // Reuse page_to_api_response to avoid duplicating the link→ApiElement mapping.
+                let elems = eng.last_page.as_ref().map(|p| {
+                    engine::page_to_api_response(p, &p.base_url.clone()).elements
+                }).unwrap_or_default();
+                let _ = reply.send(elems);
+            }
+            EngineCmd::LoadImage { url, bytes } => {
+                eng.image_cache.insert(url, bytes);
+            }
+            EngineCmd::Tick { timestamp, deadline, reply } => {
+                let needs = eng.tick_js(Some(timestamp), deadline);
+                // Drain JS style overrides produced during this tick
+                let overrides = eng.get_style_overrides();
+                for (id, props) in overrides {
+                    eng.js_style_overrides.entry(id).or_default().extend(props);
+                }
+                let _ = reply.send(needs);
+            }
+            EngineCmd::Shutdown => break,
+        }
+    }
+}
+
+// ── EngineHandle — shared across GUI and HTTP threads ─────────────────────────
+
+/// Cloneable handle used by GUI and HTTP threads to send commands to the engine actor.
+#[derive(Clone)]
+pub struct EngineHandle {
+    pub tx: mpsc::SyncSender<EngineCmd>,
+}
+
+impl EngineHandle {
+    fn send_navigate(&self, url: String, width: f32) -> Result<engine::PageResult, String> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(EngineCmd::Navigate { url, width, reply: reply_tx })
+            .map_err(|_| "engine disconnected".to_string())?;
+        reply_rx.recv().map_err(|_| "engine disconnected".to_string())?
+    }
+
+    fn send_re_render(
+        &self,
+        hovered_id: Option<String>,
+        focused_id: Option<String>,
+        width: f32,
+    ) -> Result<engine::PageResult, String> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(EngineCmd::ReRender { hovered_id, focused_id, width, reply: reply_tx })
+            .map_err(|_| "engine disconnected".to_string())?;
+        reply_rx.recv().map_err(|_| "engine disconnected".to_string())?
+    }
+
+    fn send_get_page(&self) -> Option<engine::ApiPageResponse> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx.send(EngineCmd::GetPage { reply: reply_tx }).ok()?;
+        reply_rx.recv().ok()?
+    }
+
+    fn send_get_elements(&self) -> Vec<engine::ApiElement> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::GetElements { reply: reply_tx }).is_err() {
+            return vec![];
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
+
+    fn send_click(&self, x: f32, y: f32) -> Vec<engine::ClickResult> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::Click { x, y, reply: reply_tx }).is_err() {
+            return vec![];
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
+
+    fn send_evaluate_js(&self, script: String) -> String {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::EvaluateJs { script, reply: reply_tx }).is_err() {
+            return String::new();
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
+
+    fn send_screenshot(&self) -> Option<Vec<u8>> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx.send(EngineCmd::Screenshot { reply: reply_tx }).ok()?;
+        reply_rx.recv().ok()?
+    }
+
+    fn send_dom_tree(&self) -> String {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::DomTree { reply: reply_tx }).is_err() {
+            return String::new();
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
+
+    fn send_layout_tree(&self) -> String {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::LayoutTree { reply: reply_tx }).is_err() {
+            return String::new();
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
+
+    fn send_computed_style(&self, selector: String) -> HashMap<String, String> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx
+            .send(EngineCmd::ComputedStyle { selector, reply: reply_tx })
+            .is_err()
+        {
+            return HashMap::new();
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
+
+    fn send_tick(&self, timestamp: f64, deadline: Option<f64>) -> bool {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::Tick { timestamp, deadline, reply: reply_tx }).is_err() {
+            return false;
+        }
+        reply_rx.recv().unwrap_or(false)
+    }
+}
+
+// ── axum HTTP server ──────────────────────────────────────────────────────────
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+
+#[derive(serde::Deserialize)]
+struct NavigateRequest {
+    url: String,
+}
+
+#[derive(serde::Deserialize)]
+struct ClickRequest {
+    x: f32,
+    y: f32,
+}
+
+#[derive(serde::Deserialize)]
+struct TypeRequest {
+    text: String,
+}
+
+#[derive(serde::Deserialize)]
+struct JsRequest {
+    script: String,
+}
+
+#[derive(serde::Deserialize)]
+struct StyleQuery {
+    selector: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+struct StatusResponse {
+    url: String,
+    loading: bool,
+}
+
+#[derive(serde::Serialize)]
+struct JsResponse {
+    result: String,
+}
+
+#[derive(serde::Serialize)]
+struct OkResponse {
+    ok: bool,
+}
+
+/// Helper: run a blocking closure in spawn_blocking, converting a JoinError into an HTTP 500.
+macro_rules! blocking {
+    ($f:expr) => {
+        match tokio::task::spawn_blocking($f).await {
+            Ok(v) => v,
+            Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        }
+    };
+}
+
+async fn navigate_handler(
+    State(handle): State<EngineHandle>,
+    Json(req): Json<NavigateRequest>,
+) -> impl IntoResponse {
+    let result = blocking!(move || handle.send_navigate(req.url, 800.0));
+    match result {
+        Ok(page) => {
+            let resp = engine::page_to_api_response(&page, &page.base_url.clone());
+            (StatusCode::OK, Json(resp)).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+    }
+}
+
+async fn page_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
+    let resp = blocking!(move || handle.send_get_page());
+    match resp {
+        Some(page) => (StatusCode::OK, Json(page)).into_response(),
+        None => (StatusCode::NOT_FOUND, "No page loaded").into_response(),
+    }
+}
+
+async fn status_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
+    let page_opt = blocking!(move || handle.send_get_page());
+    let url = page_opt.map(|p| p.url).unwrap_or_default();
+    (StatusCode::OK, Json(StatusResponse { url, loading: false })).into_response()
+}
+
+async fn click_handler(
+    State(handle): State<EngineHandle>,
+    Json(req): Json<ClickRequest>,
+) -> impl IntoResponse {
+    let results = blocking!(move || handle.send_click(req.x, req.y));
+    (StatusCode::OK, Json(results)).into_response()
+}
+
+async fn type_handler(
+    State(handle): State<EngineHandle>,
+    Json(req): Json<TypeRequest>,
+) -> impl IntoResponse {
+    blocking!(move || { let _ = handle.tx.send(EngineCmd::TypeText { text: req.text }); });
+    (StatusCode::OK, Json(OkResponse { ok: true })).into_response()
+}
+
+async fn js_handler(
+    State(handle): State<EngineHandle>,
+    Json(req): Json<JsRequest>,
+) -> impl IntoResponse {
+    let result = blocking!(move || handle.send_evaluate_js(req.script));
+    (StatusCode::OK, Json(JsResponse { result })).into_response()
+}
+
+async fn screenshot_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
+    let png_opt = blocking!(move || handle.send_screenshot());
+    match png_opt {
+        Some(bytes) => (
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "image/png")],
+            bytes,
+        )
+            .into_response(),
+        None => (StatusCode::NOT_FOUND, "No page loaded").into_response(),
+    }
+}
+
+async fn dom_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
+    let text = blocking!(move || handle.send_dom_tree());
+    (StatusCode::OK, [(axum::http::header::CONTENT_TYPE, "text/plain")], text).into_response()
+}
+
+async fn layout_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
+    let text = blocking!(move || handle.send_layout_tree());
+    (StatusCode::OK, [(axum::http::header::CONTENT_TYPE, "text/plain")], text).into_response()
+}
+
+async fn style_handler(
+    State(handle): State<EngineHandle>,
+    Query(params): Query<StyleQuery>,
+) -> impl IntoResponse {
+    let selector = params.selector.unwrap_or_default();
+    let style = blocking!(move || handle.send_computed_style(selector));
+    (StatusCode::OK, Json(style)).into_response()
+}
+
+async fn elements_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
+    let elems = blocking!(move || handle.send_get_elements());
+    (StatusCode::OK, Json(elems)).into_response()
+}
+
+/// Build the axum Router — extracted for testability.
+pub fn build_router(handle: EngineHandle) -> Router {
+    Router::new()
+        .route("/navigate", post(navigate_handler))
+        .route("/page", get(page_handler))
+        .route("/status", get(status_handler))
+        .route("/click", post(click_handler))
+        .route("/type", post(type_handler))
+        .route("/js", post(js_handler))
+        .route("/screenshot", get(screenshot_handler))
+        .route("/dom", get(dom_handler))
+        .route("/layout", get(layout_handler))
+        .route("/style", get(style_handler))
+        .route("/elements", get(elements_handler))
+        .with_state(handle)
+}
+
+async fn run_http_server(handle: EngineHandle, port: u16) {
+    let addr = format!("127.0.0.1:{}", port);
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    println!("[browser-daemon] HTTP listening on http://{}", addr);
+    axum::serve(listener, build_router(handle)).await.unwrap();
+}
+
+// ── DaemonBrowserApp — GUI front-end ──────────────────────────────────────────
+
+struct DaemonBrowserApp {
+    handle: EngineHandle,
+    url: String,
+    history: Vec<String>,
+    history_index: usize,
+    texture: Option<egui::TextureHandle>,
+    error: Option<String>,
+    current_links: Vec<(layout::Rect, String)>,
+    current_form_controls: Vec<(layout::Rect, String)>,
+    current_event_handlers: Vec<(layout::Rect, String)>,
+    current_element_ids: Vec<(layout::Rect, String)>,
+    current_focusable_elements: Vec<(layout::Rect, String)>,
+    hovered_id: Option<String>,
+    focused_id: Option<String>,
+    is_loading: bool,
+    content_promise: Option<Promise<Result<engine::PageResult, String>>>,
+    re_render_promise: Option<Promise<Result<engine::PageResult, String>>>,
+    /// Bounded JS tick promise — prevents unbounded thread spawns per frame.
+    tick_promise: Option<Promise<bool>>,
+    /// Pending click result — triggers re-render when a ScriptExecuted click resolves.
+    click_promise: Option<Promise<Vec<engine::ClickResult>>>,
+    image_promises: HashMap<String, Promise<Result<(String, Vec<u8>), String>>>,
+    form_values: HashMap<String, String>,
+    start_time: std::time::Instant,
+}
+
+impl DaemonBrowserApp {
+    fn new(cc: &eframe::CreationContext<'_>, handle: EngineHandle) -> Self {
+        // Load Korean font (same as BrowserApp)
+        let mut fonts = egui::FontDefinitions::default();
+        let nanum_data = include_bytes!("../../assets/fonts/NanumGothic.ttf");
+        fonts.font_data.insert(
+            "nanum".to_owned(),
+            egui::FontData::from_static(nanum_data),
+        );
+        fonts
+            .families
+            .get_mut(&egui::FontFamily::Proportional)
+            .unwrap()
+            .insert(0, "nanum".to_owned());
+        fonts
+            .families
+            .get_mut(&egui::FontFamily::Monospace)
+            .unwrap()
+            .push("nanum".to_owned());
+        cc.egui_ctx.set_fonts(fonts);
+
+        Self {
+            handle,
+            url: "https://yunseong.dev".to_string(),
+            history: vec![],
+            history_index: 0,
+            texture: None,
+            error: None,
+            current_links: vec![],
+            current_form_controls: vec![],
+            current_event_handlers: vec![],
+            current_element_ids: vec![],
+            current_focusable_elements: vec![],
+            hovered_id: None,
+            focused_id: None,
+            is_loading: false,
+            content_promise: None,
+            re_render_promise: None,
+            tick_promise: None,
+            click_promise: None,
+            image_promises: HashMap::new(),
+            form_values: HashMap::new(),
+            start_time: std::time::Instant::now(),
+        }
+    }
+
+    fn load_url(&mut self, url: String, width: f32) {
+        if self.history.is_empty() || self.history[self.history_index] != url {
+            self.history.truncate(self.history_index + 1);
+            self.history.push(url.clone());
+            self.history_index = self.history.len() - 1;
+        }
+        self.load_url_direct(url, width);
+    }
+
+    fn navigate_back(&mut self, width: f32) {
+        if self.history_index > 0 {
+            self.history_index -= 1;
+            let url = self.history[self.history_index].clone();
+            self.load_url_direct(url, width);
+        }
+    }
+
+    fn navigate_forward(&mut self, width: f32) {
+        if self.history_index + 1 < self.history.len() {
+            self.history_index += 1;
+            let url = self.history[self.history_index].clone();
+            self.load_url_direct(url, width);
+        }
+    }
+
+    fn load_url_direct(&mut self, url: String, width: f32) {
+        self.url = url.clone();
+        self.error = None;
+        self.image_promises.clear();
+        self.hovered_id = None;
+        self.is_loading = true;
+
+        let handle = self.handle.clone();
+        self.content_promise = Some(Promise::spawn_thread("daemon-navigate", move || {
+            handle.send_navigate(url, width)
+        }));
+    }
+
+    fn trigger_re_render(&mut self, ctx: &egui::Context, width: f32) {
+        let handle = self.handle.clone();
+        let hovered_id = self.hovered_id.clone();
+        let focused_id = self.focused_id.clone();
+
+        self.re_render_promise = Some(Promise::spawn_thread("daemon-re-render", move || {
+            handle.send_re_render(hovered_id, focused_id, width)
+        }));
+        ctx.request_repaint();
+    }
+
+    fn apply_page_data(&mut self, page: engine::PageResult, ctx: &egui::Context) {
+        let image = egui::ColorImage::from_rgba_unmultiplied(
+            [page.width as usize, page.height as usize],
+            &page.pixmap_bytes,
+        );
+        self.texture = Some(ctx.load_texture("daemon-page", image, Default::default()));
+        self.current_links = page.links;
+        self.current_form_controls = page.form_controls;
+        self.current_event_handlers = page.event_handlers;
+        self.current_element_ids = page.element_ids;
+        self.current_focusable_elements = page.focusable_elements;
+    }
+}
+
+impl eframe::App for DaemonBrowserApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // JS tick — at most one in-flight at a time to prevent unbounded thread spawns.
+        let timestamp = self.start_time.elapsed().as_secs_f64() * 1000.0;
+        if self.tick_promise.is_none()
+            && self.content_promise.is_none()
+            && self.re_render_promise.is_none()
+        {
+            let handle = self.handle.clone();
+            self.tick_promise = Some(Promise::spawn_thread("daemon-tick", move || {
+                handle.send_tick(timestamp, None)
+            }));
+        }
+        if let Some(tick_p) = &self.tick_promise {
+            if let Some(needs) = tick_p.ready() {
+                if *needs {
+                    ctx.request_repaint();
+                }
+                self.tick_promise = None;
+            }
+        }
+
+        // Tab navigation
+        if ctx.input(|i| i.key_pressed(egui::Key::Tab)) {
+            let focusables = &self.current_focusable_elements;
+            if !focusables.is_empty() {
+                let current_index = self.focused_id.as_ref().and_then(|id| {
+                    focusables.iter().position(|(_, fid)| fid == id)
+                });
+                let next_index = if ctx.input(|i| i.modifiers.shift) {
+                    match current_index {
+                        Some(i) if i > 0 => i - 1,
+                        _ => focusables.len() - 1,
+                    }
+                } else {
+                    match current_index {
+                        Some(i) if i + 1 < focusables.len() => i + 1,
+                        _ => 0,
+                    }
+                };
+                self.focused_id = Some(focusables[next_index].1.clone());
+                self.trigger_re_render(ctx, 800.0);
+            }
+        }
+
+        // Browser chrome
+        let toolbar_fill = egui::Color32::from_rgb(50, 50, 55);
+        let url_bar_fill = egui::Color32::from_rgb(72, 72, 78);
+
+        egui::TopBottomPanel::top("daemon_chrome")
+            .frame(
+                egui::Frame::none()
+                    .fill(toolbar_fill)
+                    .inner_margin(egui::Margin::symmetric(8.0, 6.0)),
+            )
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 4.0;
+
+                    let btn_style =
+                        |ui: &mut egui::Ui, label: &str, enabled: bool| -> egui::Response {
+                            ui.add_enabled(
+                                enabled,
+                                egui::Button::new(
+                                    egui::RichText::new(label)
+                                        .color(if enabled {
+                                            egui::Color32::WHITE
+                                        } else {
+                                            egui::Color32::DARK_GRAY
+                                        })
+                                        .size(14.0),
+                                )
+                                .fill(egui::Color32::from_rgb(70, 70, 76))
+                                .rounding(egui::Rounding::same(4.0))
+                                .min_size(egui::vec2(28.0, 28.0)),
+                            )
+                        };
+
+                    if btn_style(ui, "←", self.history_index > 0).clicked() {
+                        self.navigate_back(800.0);
+                    }
+                    if btn_style(ui, "→", self.history_index + 1 < self.history.len()).clicked() {
+                        self.navigate_forward(800.0);
+                    }
+                    if btn_style(ui, "⟳", true).clicked() {
+                        let url = self.url.clone();
+                        self.load_url_direct(url, 800.0);
+                    }
+
+                    ui.spacing_mut().item_spacing.x = 8.0;
+
+                    let url_frame = egui::Frame::none()
+                        .fill(url_bar_fill)
+                        .rounding(egui::Rounding::same(14.0))
+                        .inner_margin(egui::Margin::symmetric(10.0, 4.0));
+
+                    url_frame.show(ui, |ui| {
+                        ui.visuals_mut().override_text_color = Some(egui::Color32::WHITE);
+                        let edit = egui::TextEdit::singleline(&mut self.url)
+                            .desired_width(ui.available_width() - 60.0)
+                            .frame(false)
+                            .font(egui::TextStyle::Monospace);
+                        let resp = ui.add(edit);
+                        if resp.lost_focus()
+                            && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                        {
+                            let url = self.url.clone();
+                            self.load_url(url, 800.0);
+                        }
+                    });
+
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                egui::RichText::new("이동")
+                                    .color(egui::Color32::WHITE)
+                                    .size(13.0),
+                            )
+                            .fill(egui::Color32::from_rgb(0, 120, 212))
+                            .rounding(egui::Rounding::same(14.0))
+                            .min_size(egui::vec2(50.0, 28.0)),
+                        )
+                        .clicked()
+                    {
+                        let url = self.url.clone();
+                        self.load_url(url, 800.0);
+                    }
+
+                    // Daemon badge
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        ui.label(
+                            egui::RichText::new("daemon")
+                                .color(egui::Color32::from_rgb(150, 200, 255))
+                                .size(11.0),
+                        );
+                    });
+                });
+
+                if self.is_loading {
+                    let progress = egui::ProgressBar::new(f32::INFINITY)
+                        .animate(true)
+                        .desired_width(ui.available_width())
+                        .desired_height(3.0);
+                    ui.add(progress);
+                }
+            });
+
+        // Content area
+        egui::CentralPanel::default()
+            .frame(egui::Frame::none().fill(egui::Color32::WHITE))
+            .show(ctx, |ui| {
+                // Poll click promise — trigger re-render if onclick fired JS style changes
+                if let Some(click_p) = &self.click_promise {
+                    if let Some(results) = click_p.ready() {
+                        let had_script = results.iter().any(|r| matches!(r, engine::ClickResult::ScriptExecuted));
+                        self.click_promise = None;
+                        if had_script {
+                            self.trigger_re_render(ctx, 800.0);
+                        }
+                    }
+                }
+
+                // Poll re-render promise
+                if let Some(promise) = &self.re_render_promise {
+                    match promise.ready() {
+                        None => ctx.request_repaint(),
+                        Some(Err(e)) => {
+                            self.error = Some(format!("Re-render error: {}", e));
+                            self.re_render_promise = None;
+                        }
+                        Some(Ok(page)) => {
+                            self.apply_page_data(page.clone(), ctx);
+                            self.re_render_promise = None;
+                        }
+                    }
+                }
+
+                // Poll content (navigate) promise
+                if let Some(promise) = &self.content_promise {
+                    match promise.ready() {
+                        None => {
+                            ui.centered_and_justified(|ui| { ui.spinner(); });
+                            ctx.request_repaint();
+                        }
+                        Some(Err(e)) => {
+                            self.error = Some(e.clone());
+                            self.content_promise = None;
+                            self.is_loading = false;
+                        }
+                        Some(Ok(page)) => {
+                            let page = page.clone();
+                            let image_urls = page.image_urls.clone();
+
+                            self.is_loading = false;
+                            self.form_values.clear();
+                            for (i, (_, val)) in page.form_controls.iter().enumerate() {
+                                self.form_values.insert(i.to_string(), val.clone());
+                            }
+                            self.apply_page_data(page, ctx);
+                            self.content_promise = None;
+
+                            // Start async image fetches
+                            for url in &image_urls {
+                                if !self.image_promises.contains_key(url) {
+                                    let url_clone = url.clone();
+                                    self.image_promises.insert(
+                                        url.clone(),
+                                        Promise::spawn_thread("daemon-img", move || {
+                                            match reqwest::blocking::get(&url_clone) {
+                                                Ok(resp) => match resp.bytes() {
+                                                    Ok(bytes) => Ok((url_clone, bytes.to_vec())),
+                                                    Err(e) => Err(e.to_string()),
+                                                },
+                                                Err(e) => Err(e.to_string()),
+                                            }
+                                        }),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Resolved image promises → send bytes to engine actor, trigger re-render
+                let mut newly_loaded = false;
+                let handle = self.handle.clone();
+                self.image_promises.retain(|_url, promise| match promise.ready() {
+                    Some(Ok((url, bytes))) => {
+                        let _ = handle.tx.send(EngineCmd::LoadImage {
+                            url: url.clone(),
+                            bytes: bytes.clone(),
+                        });
+                        newly_loaded = true;
+                        false
+                    }
+                    Some(Err(_)) => false,
+                    None => true,
+                });
+                if newly_loaded {
+                    self.trigger_re_render(ctx, 800.0);
+                }
+
+                // Error
+                if let Some(err) = &self.error {
+                    ui.add_space(20.0);
+                    ui.centered_and_justified(|ui| {
+                        ui.colored_label(
+                            egui::Color32::from_rgb(200, 50, 50),
+                            format!("페이지를 불러올 수 없습니다: {}", err),
+                        );
+                    });
+                }
+
+                // Render page texture + interactive overlay
+                let texture_info =
+                    self.texture.as_ref().map(|t| (t.id(), t.size_vec2()));
+                if let Some((texture_id, texture_size)) = texture_info {
+                    let mut url_to_load: Option<String> = None;
+
+                    egui::ScrollArea::both()
+                        .auto_shrink([false, false])
+                        .show(ui, |ui| {
+                            let (rect, response) = ui.allocate_at_least(
+                                texture_size,
+                                egui::Sense::click(),
+                            );
+                            ui.painter().image(
+                                texture_id,
+                                rect,
+                                egui::Rect::from_min_max(
+                                    egui::pos2(0.0, 0.0),
+                                    egui::pos2(1.0, 1.0),
+                                ),
+                                egui::Color32::WHITE,
+                            );
+
+                            // Form controls overlay
+                            for (i, (l_rect, _)) in
+                                self.current_form_controls.iter().enumerate()
+                            {
+                                let val = self.form_values.entry(i.to_string()).or_default();
+                                let screen_rect = egui::Rect::from_min_size(
+                                    rect.min + egui::vec2(l_rect.x, l_rect.y),
+                                    egui::vec2(l_rect.width, l_rect.height),
+                                );
+                                ui.put(screen_rect, egui::TextEdit::singleline(val).id_source(i));
+                            }
+
+                            // Click handling
+                            if response.clicked() {
+                                if let Some(ptr) = response.interact_pointer_pos() {
+                                    let rel = ptr - rect.min;
+
+                                    // Dispatch full click to engine actor — this handles
+                                    // JS click events, focus changes, links, and onclick handlers
+                                    // in a single coordinated call using actual pixel coordinates.
+                                    // Use click_promise so we can check results for re-render.
+                                    if self.click_promise.is_none() {
+                                        let handle = self.handle.clone();
+                                        let rel_x = rel.x;
+                                        let rel_y = rel.y;
+                                        self.click_promise = Some(Promise::spawn_thread(
+                                            "daemon-click",
+                                            move || handle.send_click(rel_x, rel_y),
+                                        ));
+                                    }
+
+                                    // Update GUI-side focused_id from click
+                                    let mut new_focus = None;
+                                    for (l_rect, id) in &self.current_focusable_elements {
+                                        if daemon_hit(rel, l_rect) {
+                                            new_focus = Some(id.clone());
+                                        }
+                                    }
+                                    if new_focus != self.focused_id {
+                                        self.focused_id = new_focus;
+                                        self.trigger_re_render(ctx, 800.0);
+                                    }
+
+                                    // GUI-side link navigation
+                                    for (l_rect, link) in &self.current_links {
+                                        if daemon_hit(rel, l_rect) {
+                                            url_to_load = Some(link.clone());
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Hover
+                            if let Some(ptr) = response.hover_pos() {
+                                let rel = ptr - rect.min;
+                                let hovering = self.current_links.iter().any(|(r, _)| daemon_hit(rel, r))
+                                    || self.current_event_handlers.iter().any(|(r, _)| daemon_hit(rel, r));
+                                if hovering {
+                                    ctx.set_cursor_icon(egui::CursorIcon::PointingHand);
+                                }
+
+                                let mut new_hovered_id = None;
+                                for (l_rect, id) in self.current_element_ids.iter().rev() {
+                                    if daemon_hit(rel, l_rect) {
+                                        new_hovered_id = Some(id.clone());
+                                        break;
+                                    }
+                                }
+                                if new_hovered_id != self.hovered_id {
+                                    self.hovered_id = new_hovered_id;
+                                    self.trigger_re_render(ctx, 800.0);
+                                }
+                            } else if self.hovered_id.is_some() {
+                                self.hovered_id = None;
+                                self.trigger_re_render(ctx, 800.0);
+                            }
+                        });
+
+                    if let Some(url) = url_to_load {
+                        self.load_url(url, 800.0);
+                    }
+                }
+            });
+    }
+}
+
+#[inline]
+fn daemon_hit(rel: egui::Vec2, r: &layout::Rect) -> bool {
+    rel.x >= r.x && rel.x <= r.x + r.width && rel.y >= r.y && rel.y <= r.y + r.height
+}
+
+// ── Main entry point ──────────────────────────────────────────────────────────
+
+fn main() {
+    let args = parse_args();
+
+    let (tx, rx) = mpsc::sync_channel::<EngineCmd>(64);
+    let handle = EngineHandle { tx };
+
+    // Engine actor thread — owns BrowserEngine exclusively
+    std::thread::Builder::new()
+        .name("engine-actor".into())
+        .spawn(move || run_engine_actor(rx))
+        .expect("failed to start engine actor thread");
+
+    // HTTP server thread — runs its own tokio runtime
+    let handle_for_http = handle.clone();
+    let port = args.port;
+    std::thread::Builder::new()
+        .name("http-server".into())
+        .spawn(move || {
+            let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+            rt.block_on(run_http_server(handle_for_http, port));
+        })
+        .expect("failed to start HTTP server thread");
+
+    if args.no_gui {
+        println!("[browser-daemon] Running headless on http://127.0.0.1:{}", port);
+        println!("[browser-daemon] Press Ctrl+C to stop.");
+        // Block main thread forever; signal handlers (Ctrl+C) terminate the process
+        loop {
+            std::thread::park();
+        }
+    } else {
+        // eframe requires the GUI on the main thread (OS requirement on most platforms)
+        let options = eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default()
+                .with_inner_size([1024.0, 768.0])
+                .with_title("browser-daemon"),
+            ..Default::default()
+        };
+        eframe::run_native(
+            "browser-daemon",
+            options,
+            Box::new(|cc| Ok(Box::new(DaemonBrowserApp::new(cc, handle)))),
+        )
+        .expect("eframe error");
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower::ServiceExt;
+
+    // ── Arg parsing ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_args_defaults() {
+        let args = parse_args_from(&[]);
+        assert!(!args.no_gui);
+        assert_eq!(args.port, 7070);
+    }
+
+    #[test]
+    fn test_parse_args_no_gui() {
+        let args = parse_args_from(&["--no-gui"]);
+        assert!(args.no_gui);
+    }
+
+    #[test]
+    fn test_parse_args_custom_port() {
+        let args = parse_args_from(&["--port", "8080"]);
+        assert_eq!(args.port, 8080);
+    }
+
+    #[test]
+    fn test_parse_args_combined() {
+        let args = parse_args_from(&["--no-gui", "--port", "9000"]);
+        assert!(args.no_gui);
+        assert_eq!(args.port, 9000);
+    }
+
+    // ── Engine actor ─────────────────────────────────────────────────────────
+
+    fn make_test_handle() -> EngineHandle {
+        let (tx, rx) = mpsc::sync_channel(16);
+        std::thread::spawn(move || run_engine_actor(rx));
+        EngineHandle { tx }
+    }
+
+    #[test]
+    fn test_engine_actor_get_page_empty() {
+        let handle = make_test_handle();
+        let (reply_tx, reply_rx) = mpsc::channel();
+        handle.tx.send(EngineCmd::GetPage { reply: reply_tx }).unwrap();
+        let result = reply_rx.recv().unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_engine_actor_get_elements_empty() {
+        let handle = make_test_handle();
+        let elems = handle.send_get_elements();
+        assert!(elems.is_empty());
+    }
+
+    #[test]
+    fn test_engine_actor_dom_tree_empty() {
+        let handle = make_test_handle();
+        let dom = handle.send_dom_tree();
+        assert!(dom.is_empty());
+    }
+
+    #[test]
+    fn test_engine_actor_layout_tree_empty() {
+        let handle = make_test_handle();
+        let layout = handle.send_layout_tree();
+        assert!(layout.is_empty());
+    }
+
+    #[test]
+    fn test_engine_actor_computed_style_empty() {
+        let handle = make_test_handle();
+        let style = handle.send_computed_style("body".to_string());
+        assert!(style.is_empty());
+    }
+
+    #[test]
+    fn test_engine_actor_screenshot_empty() {
+        let handle = make_test_handle();
+        let result = handle.send_screenshot();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_engine_actor_click_empty() {
+        let handle = make_test_handle();
+        let results = handle.send_click(0.0, 0.0);
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0], engine::ClickResult::Nothing));
+    }
+
+    #[test]
+    fn test_engine_actor_tick_empty() {
+        let handle = make_test_handle();
+        let needs = handle.send_tick(0.0, None);
+        assert!(!needs);
+    }
+
+    #[test]
+    fn test_engine_actor_load_image() {
+        let handle = make_test_handle();
+        // Just verify it doesn't panic
+        handle
+            .tx
+            .send(EngineCmd::LoadImage {
+                url: "https://example.com/img.png".into(),
+                bytes: vec![0u8; 100],
+            })
+            .unwrap();
+        // Give actor a moment to process
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    // ── HTTP endpoints ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_http_status_no_page() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/status")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["loading"], false);
+    }
+
+    #[tokio::test]
+    async fn test_http_page_no_page_returns_404() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/page")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_http_screenshot_no_page_returns_404() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/screenshot")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_http_elements_empty() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/elements")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_http_dom_empty() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/dom")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_http_style_empty() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/style?selector=body")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.as_object().unwrap().is_empty());
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,7 +26,8 @@ pub struct PageResult {
 }
 
 /// Result of a click action in headless mode.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
 pub enum ClickResult {
     /// A link was clicked; contains the absolute URL.
     Navigate(String),
@@ -36,6 +37,152 @@ pub enum ClickResult {
     FocusChanged(String),
     /// No interactive element at the given position.
     Nothing,
+}
+
+// ── HTTP API response types ───────────────────────────────────────────────────
+
+/// A rectangle suitable for JSON serialization in HTTP API responses.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ApiRect {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+/// A single interactive element returned by GET /elements.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ApiElement {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub element_type: String,
+    pub text: String,
+    pub href: Option<String>,
+    pub rect: ApiRect,
+}
+
+/// The full page response returned by HTTP navigation/page endpoints.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ApiPageResponse {
+    pub url: String,
+    pub title: String,
+    pub markdown: String,
+    pub elements: Vec<ApiElement>,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Convert a `PageResult` into an `ApiPageResponse` for HTTP clients.
+/// Title is extracted by scanning the raw HTML for a `<title>` element.
+pub fn page_to_api_response(page: &PageResult, base_url: &Url) -> ApiPageResponse {
+    let title = extract_title_from_html(&page.body);
+    let markdown = markdown_from_html(&page.body);
+    let elements = page
+        .links
+        .iter()
+        .enumerate()
+        .map(|(i, (rect, href))| ApiElement {
+            id: format!("e{}", i),
+            element_type: "link".to_string(),
+            text: String::new(),
+            href: Some(href.clone()),
+            rect: ApiRect {
+                x: rect.x,
+                y: rect.y,
+                w: rect.width,
+                h: rect.height,
+            },
+        })
+        .collect();
+
+    ApiPageResponse {
+        url: base_url.to_string(),
+        title,
+        markdown,
+        elements,
+        width: page.width,
+        height: page.height,
+    }
+}
+
+/// Extract the text content of the `<title>` element from raw HTML.
+/// Returns an empty string if no title is found.
+pub fn extract_title_from_html(html: &str) -> String {
+    let lower = html.to_lowercase();
+    if let Some(start) = lower.find("<title>") {
+        let after = &html[start + 7..];
+        if let Some(end) = after.to_lowercase().find("</title>") {
+            return after[..end].trim().to_string();
+        }
+    }
+    String::new()
+}
+
+/// Naive HTML-to-markdown converter: strips tags, collapses whitespace.
+/// Not a full converter — suitable for CLI display of page content.
+pub fn markdown_from_html(html: &str) -> String {
+    let mut out = String::with_capacity(html.len() / 2);
+    let mut in_tag = false;
+    let mut in_script = false;
+    let mut in_style = false;
+    let mut tag_buf = String::new();
+
+    let mut chars = html.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '<' {
+            in_tag = true;
+            tag_buf.clear();
+        } else if ch == '>' && in_tag {
+            in_tag = false;
+            let tag_lower = tag_buf.to_lowercase();
+            let tag_lower = tag_lower.trim();
+            if tag_lower == "script" || tag_lower.starts_with("script ") {
+                in_script = true;
+            } else if tag_lower == "/script" {
+                in_script = false;
+            } else if tag_lower == "style" || tag_lower.starts_with("style ") {
+                in_style = true;
+            } else if tag_lower == "/style" {
+                in_style = false;
+            } else if !in_script && !in_style {
+                // Insert newline for block-level tags
+                if matches!(tag_lower, "p" | "br" | "/p" | "div" | "/div"
+                    | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+                    | "/h1" | "/h2" | "/h3" | "/h4" | "/h5" | "/h6"
+                    | "li" | "/li" | "tr" | "/tr") {
+                    out.push('\n');
+                }
+            }
+        } else if in_tag {
+            tag_buf.push(ch);
+        } else if !in_script && !in_style {
+            out.push(ch);
+        }
+    }
+
+    // Collapse runs of whitespace (but preserve newlines)
+    let mut result = String::with_capacity(out.len());
+    let mut last_was_space = false;
+    let mut last_was_newline = false;
+    for ch in out.chars() {
+        if ch == '\n' {
+            if !last_was_newline {
+                result.push('\n');
+            }
+            last_was_newline = true;
+            last_was_space = false;
+        } else if ch.is_whitespace() {
+            if !last_was_space && !last_was_newline {
+                result.push(' ');
+            }
+            last_was_space = true;
+        } else {
+            result.push(ch);
+            last_was_space = false;
+            last_was_newline = false;
+        }
+    }
+    result.trim().to_string()
 }
 
 /// Source of a CSS stylesheet, in document order.


### PR DESCRIPTION
## Summary

- Implements Issue #70: single `browser-daemon` binary that runs the `BrowserEngine` on a dedicated actor thread and shares it between an eframe GUI window and an axum HTTP server via `mpsc` channels
- Engine actor thread owns `BrowserEngine` exclusively — all blocking HTTP fetches, JS execution, and layout are serialized there; GUI and HTTP threads communicate via typed `EngineCmd` commands
- `DaemonBrowserApp` replaces `BrowserApp` for the GUI path; functionally equivalent (navigation, history, forms, hover, focus, tab nav, image async loading)
- HTTP server exposes 11 endpoints for CLI/automation use: `POST /navigate`, `GET /page /status /screenshot /dom /layout /style /elements`, `POST /click /type /js`
- API response types (`ApiPageResponse`, `ApiElement`, `ApiRect`) and HTML→Markdown/title helpers added to `src/engine.rs` for reuse by the upcoming CLI binary (Issue #69)
- `--no-gui` flag enables headless mode (HTTP-only, no eframe window)
- `--port` flag allows custom port (default: 7070)

## Test plan

- [x] All 19 tests pass (`cargo test`): arg parsing (4), engine actor protocol (8), HTTP endpoint integration via `tower::ServiceExt::oneshot` (7)
- [x] `cargo check` clean (only pre-existing warnings)
- [x] Compile-tested: `cargo build` succeeds with new `axum` dep

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)