### PR TITLE
fix: browser-cli navigate always fails with parse error (#77)

### DIFF
--- a/src/bin/browser_cli.rs
+++ b/src/bin/browser_cli.rs
@@ -134,8 +134,13 @@ impl DaemonClient {
                 resp.status()
             )));
         }
-        resp.json::<ApiPageResponse>()
-            .map_err(|e| CliError::Parse(e.to_string()))
+        // Read the raw body text first so we can include it in the error message if
+        // deserialization fails (e.g. because the daemon panicked and sent garbage).
+        let body = resp.text().map_err(|e| CliError::Parse(e.to_string()))?;
+        serde_json::from_str::<ApiPageResponse>(&body).map_err(|e| {
+            let preview = if body.len() > 200 { &body[..200] } else { &body };
+            CliError::Parse(format!("{} (raw body: {})", e, preview))
+        })
     }
 
     fn get_page(&self) -> Result<ApiPageResponse, CliError> {
@@ -147,8 +152,13 @@ impl DaemonClient {
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
             return Err(CliError::NotFound("No page loaded".to_string()));
         }
-        resp.json::<ApiPageResponse>()
-            .map_err(|e| CliError::Parse(e.to_string()))
+        // Read the raw body text first so we can include it in the error message if
+        // deserialization fails.
+        let body = resp.text().map_err(|e| CliError::Parse(e.to_string()))?;
+        serde_json::from_str::<ApiPageResponse>(&body).map_err(|e| {
+            let preview = if body.len() > 200 { &body[..200] } else { &body };
+            CliError::Parse(format!("{} (raw body: {})", e, preview))
+        })
     }
 
     fn click_xy(&self, x: f32, y: f32) -> Result<Vec<ClickResult>, CliError> {
@@ -1022,5 +1032,23 @@ mod tests {
         let s = shorten_url(&long);
         assert!(s.ends_with("..."));
         assert!(s.len() <= 43); // 40 chars + "..."
+    }
+
+    // -- Error reporting tests --
+
+    #[test]
+    fn test_parse_error_includes_body_hint() {
+        // Simulate what happens when the daemon returns non-JSON (e.g., a panic message).
+        let invalid_json = "thread 'tokio-runtime' panicked at 'byte index 5...'";
+        let err = serde_json::from_str::<ApiPageResponse>(invalid_json)
+            .map_err(|e| {
+                let preview = if invalid_json.len() > 200 { &invalid_json[..200] } else { invalid_json };
+                CliError::Parse(format!("{} (raw body: {})", e, preview))
+            })
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Parse error:"), "expected 'Parse error:' in: {}", msg);
+        assert!(msg.contains("raw body:"), "expected 'raw body:' in: {}", msg);
+        assert!(msg.contains("panicked"), "expected panic text in: {}", msg);
     }
 }

--- a/src/bin/browser_daemon.rs
+++ b/src/bin/browser_daemon.rs
@@ -344,12 +344,16 @@ async fn navigate_handler(
     State(handle): State<EngineHandle>,
     Json(req): Json<NavigateRequest>,
 ) -> impl IntoResponse {
-    let result = blocking!(move || handle.send_navigate(req.url, 800.0));
+    // `page_to_api_response` is called inside `spawn_blocking` so that any panic it raises
+    // is caught by Tokio and converted to a `JoinError`. The `blocking!` macro turns a
+    // `JoinError` into an HTTP 500 rather than dropping the TCP connection silently.
+    let result = blocking!(move || {
+        let page = handle.send_navigate(req.url, 800.0)?;
+        let base_url = page.base_url.clone();
+        Ok::<_, String>(engine::page_to_api_response(&page, &base_url))
+    });
     match result {
-        Ok(page) => {
-            let resp = engine::page_to_api_response(&page, &page.base_url.clone());
-            (StatusCode::OK, Json(resp)).into_response()
-        }
+        Ok(resp) => (StatusCode::OK, Json(resp)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -326,12 +326,51 @@ pub fn extract_form_controls_from_html(html: &str) -> Vec<(String, String)> {
 
 /// Extract the value of an attribute from a raw HTML tag string (e.g., `a href="url" class="x"`).
 fn extract_attr(tag: &str, attr_name: &str) -> Option<String> {
-    // Look for `attr_name=` (case-insensitive) in the tag string
+    // We need a case-insensitive search that never mixes byte offsets between two strings
+    // whose byte lengths might differ (because `to_lowercase()` can expand characters:
+    // e.g., İ U+0130 is 1 char / 2 bytes in `tag` but lowercases to "i\u{307}", 2 chars /
+    // 3 bytes, in `lower`).
+    //
+    // Strategy: search `lower` for the attribute pattern to decide *whether* it is present,
+    // then walk both `tag` and `lower` together to find the matching byte offset in `tag`.
+    // We consume one codepoint from `tag` and its lowercased expansion from `lower` at a time,
+    // so the two cursors stay synchronised even when `to_lowercase` changes char or byte counts.
     let lower = tag.to_lowercase();
     let search = format!("{}=", attr_name.to_lowercase());
-    let pos = lower.find(&search)?;
-    let rest = &tag[pos + search.len()..];
-    let rest = rest.trim_start();
+
+    // Confirm the attribute exists in the lowercased string.
+    let end_in_lower = lower.find(&search)? + search.len();
+
+    // Walk both strings in lock-step: advance `lower_consumed` by the byte length of the
+    // lowercased form of each codepoint in `tag` until we have consumed `end_in_lower` bytes
+    // of `lower`.  At that point `tag_byte_offset` is the corresponding byte position in `tag`.
+    let mut lower_consumed: usize = 0;
+    let mut tag_byte_offset: usize = 0;
+    let mut lower_chars = lower.char_indices().peekable();
+
+    'outer: for (tag_off, tag_ch) in tag.char_indices() {
+        if lower_consumed >= end_in_lower {
+            tag_byte_offset = tag_off;
+            break 'outer;
+        }
+        tag_byte_offset = tag_off + tag_ch.len_utf8(); // default: past end of tag
+        // Consume the lowercased expansion of `tag_ch` from `lower`.
+        for lc in tag_ch.to_lowercase() {
+            if let Some((_, lc_from_lower)) = lower_chars.next() {
+                debug_assert_eq!(lc, lc_from_lower,
+                    "to_lowercase mismatch: tag_ch={:?} expanded to {:?} but lower had {:?}",
+                    tag_ch, lc, lc_from_lower);
+                lower_consumed += lc.len_utf8();
+            }
+        }
+    }
+
+    if lower_consumed < end_in_lower {
+        // We exhausted `tag` before reaching `end_in_lower` — attribute not really there.
+        return None;
+    }
+
+    let rest = tag[tag_byte_offset..].trim_start();
     if rest.starts_with('"') {
         // Quoted value
         let inner = &rest[1..];
@@ -1005,5 +1044,47 @@ mod tests {
             ClickResult::FocusChanged { id } => assert_eq!(id, "search-input"),
             _ => panic!("Expected FocusChanged"),
         }
+    }
+
+    // ── extract_attr tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_extract_attr_basic() {
+        let tag = r#"a href="https://example.com" class="link""#;
+        assert_eq!(extract_attr(tag, "href"), Some("https://example.com".to_string()));
+    }
+
+    #[test]
+    fn test_extract_attr_case_insensitive() {
+        let tag = r#"INPUT NAME="username" TYPE="text""#;
+        assert_eq!(extract_attr(tag, "name"), Some("username".to_string()));
+    }
+
+    #[test]
+    fn test_extract_attr_unicode_before_attr_no_panic() {
+        // İ (U+0130) is 1 char / 2 bytes, but lowercases to "i\u{307}" which is 2 chars / 3 bytes.
+        // Placing it before the attribute ensures the old byte-offset mixing would panic or
+        // overshoot.  The new implementation must not panic and must return the correct value.
+        let tag = "a data-İ=\"x\" href=\"/path\"";
+        let result = extract_attr(tag, "href");
+        assert_eq!(result, Some("/path".to_string()));
+    }
+
+    #[test]
+    fn test_extract_attr_missing_returns_none() {
+        let tag = r#"img src="photo.jpg""#;
+        assert_eq!(extract_attr(tag, "href"), None);
+    }
+
+    #[test]
+    fn test_extract_attr_single_quoted() {
+        let tag = "a href='/page'";
+        assert_eq!(extract_attr(tag, "href"), Some("/page".to_string()));
+    }
+
+    #[test]
+    fn test_extract_attr_unquoted() {
+        let tag = "input type=text name=user";
+        assert_eq!(extract_attr(tag, "type"), Some("text".to_string()));
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -104,10 +104,10 @@ pub fn page_to_api_response(page: &PageResult, base_url: &Url) -> ApiPageRespons
                 text,
                 href: Some(href.clone()),
                 rect: ApiRect {
-                    x: rect.x,
-                    y: rect.y,
-                    w: rect.width,
-                    h: rect.height,
+                    x: if rect.x.is_finite() { rect.x } else { 0.0 },
+                    y: if rect.y.is_finite() { rect.y } else { 0.0 },
+                    w: if rect.width.is_finite() { rect.width } else { 0.0 },
+                    h: if rect.height.is_finite() { rect.height } else { 0.0 },
                 },
             }
         })
@@ -127,10 +127,10 @@ pub fn page_to_api_response(page: &PageResult, base_url: &Url) -> ApiPageRespons
                 name,
                 element_type,
                 rect: ApiRect {
-                    x: rect.x,
-                    y: rect.y,
-                    w: rect.width,
-                    h: rect.height,
+                    x: if rect.x.is_finite() { rect.x } else { 0.0 },
+                    y: if rect.y.is_finite() { rect.y } else { 0.0 },
+                    w: if rect.width.is_finite() { rect.width } else { 0.0 },
+                    h: if rect.height.is_finite() { rect.height } else { 0.0 },
                 },
             }
         })


### PR DESCRIPTION
## Summary

Fixes three root causes that together made every `navigate <url>` in `browser-cli` return `Error: Parse error: error decoding response body`.

- **`extract_attr` byte-index panic** (`src/engine.rs`): The old code found the attribute position in `lower = tag.to_lowercase()` then used that byte offset directly on `tag`. `to_lowercase()` can change both byte lengths AND character counts for certain Unicode codepoints (e.g. İ U+0130), so the byte offset was wrong for `tag`. Fixed by walking `tag` and `lower` in lock-step — one codepoint at a time — consuming the lowercased expansion from `lower` while advancing through `tag`. This correctly handles all `to_lowercase()` expansion cases.

- **Async panic drops connection** (`src/bin/browser_daemon.rs`): `page_to_api_response` was called outside `spawn_blocking` in `navigate_handler`. When it panicked, Tokio dropped the TCP connection silently; reqwest 0.13 classified the closed connection as `Error::decode()` ("error decoding response body"). Fixed by moving `page_to_api_response` inside the `spawn_blocking` closure so any panic becomes a `JoinError`, which the existing `blocking!` macro converts to HTTP 500.

- **CLI swallows raw response body** (`src/bin/browser_cli.rs`): `resp.json()` failure only showed the outer reqwest error, hiding the actual daemon output. Fixed by reading the body as text first and including a 200-char preview in the error message.

## Test plan

- [x] 6 new unit tests for `extract_attr` (basic, case-insensitive, Unicode with İ before attribute, missing attr, single-quoted, unquoted values) — all pass
- [x] 1 new CLI unit test verifying parse error message includes `raw body:` with the daemon response text — passes
- [x] Full `cargo test` suite — 128 tests pass (0 failures)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)