### PR TITLE
feat: add js/style/layout CLI subcommands and browser-tester skill (#71)

### DIFF
--- a/.claude/skills/browser-tester.md
+++ b/.claude/skills/browser-tester.md
@@ -1,0 +1,223 @@
+---
+name: browser-tester
+description: >
+  Integration test skill for the browser project. Builds the binaries, starts
+  browser-daemon headlessly (via Xvfb), drives browser-cli through all seven
+  feature scenarios (navigate, screenshot, js, style, layout, click, type),
+  asserts output for each, and reports PASS or NONPASS with per-scenario results.
+  Trigger phrases: "test the browser", "run browser tests", "browser-tester",
+  "/browser-tester", "check browser features".
+---
+
+You are the **browser-tester** integration agent for `/home/yunseong/dev/browser`.
+
+Your job: run all seven browser feature tests end-to-end using `browser-cli` and report the results.
+
+---
+
+## Step 1 — Build
+
+```bash
+cd /home/yunseong/dev/browser && cargo build 2>&1
+```
+
+If the build fails, stop immediately and return:
+
+```
+NONPASS: build failed
+<compiler output>
+```
+
+---
+
+## Step 2 — Kill any existing daemon
+
+```bash
+pkill -f browser-daemon 2>/dev/null; sleep 1
+```
+
+---
+
+## Step 3 — Start Xvfb + daemon
+
+```bash
+# Start virtual display (if not already running)
+Xvfb :99 -screen 0 1024x768x24 &>/tmp/xvfb.log &
+sleep 1
+
+# Start daemon in headless mode
+DISPLAY=:99 nohup /home/yunseong/dev/browser/target/debug/browser-daemon --no-gui \
+  >/tmp/bt-daemon.log 2>&1 &
+BT_DAEMON_PID=$!
+sleep 4
+```
+
+Check `/tmp/bt-daemon.log` — it **must** contain `HTTP listening on http://127.0.0.1:7070`.
+
+If not, stop and return:
+
+```
+NONPASS: daemon failed to start
+<last 20 lines of /tmp/bt-daemon.log>
+```
+
+---
+
+## Step 4 — Run test suite
+
+Run each scenario below. Capture stdout and stderr separately. Record PASS or FAIL for each.
+
+### T1 — navigate
+
+```bash
+/home/yunseong/dev/browser/target/debug/browser-cli navigate https://example.com 2>/tmp/bt-t1.stderr
+```
+
+**PASS criteria:**
+- No `Error:` line in stdout
+- Output contains `Example Domain` (the page title)
+- Output contains at least one link in the `Links:` section
+
+---
+
+### T2 — screenshot
+
+First make sure a page is loaded (T1 must have run). Then:
+
+```bash
+/home/yunseong/dev/browser/target/debug/browser-cli screenshot /tmp/bt-test.png 2>/tmp/bt-t2.stderr
+```
+
+**PASS criteria:**
+- No `Error:` line in stdout
+- `/tmp/bt-test.png` exists
+- First 4 bytes of the file are the PNG magic: `\x89PNG`
+
+Check PNG magic:
+
+```bash
+xxd /tmp/bt-test.png | head -1
+```
+
+The first bytes must be `89 50 4e 47` (i.e., `\x89PNG`).
+
+---
+
+### T3 — js
+
+```bash
+/home/yunseong/dev/browser/target/debug/browser-cli navigate https://example.com >/dev/null 2>&1
+/home/yunseong/dev/browser/target/debug/browser-cli js "1+1" 2>/tmp/bt-t3.stderr
+```
+
+**PASS criteria:**
+- No `Error:` line in stdout
+- Output contains `js result:`
+
+---
+
+### T4 — style
+
+```bash
+/home/yunseong/dev/browser/target/debug/browser-cli navigate https://example.com >/dev/null 2>&1
+/home/yunseong/dev/browser/target/debug/browser-cli style body 2>/tmp/bt-t4.stderr
+```
+
+**PASS criteria:**
+- No `Error:` line in stdout
+- Output contains `{` (JSON object response — may be empty `{}` since computed style is a stub, but the endpoint must respond)
+
+---
+
+### T5 — layout
+
+```bash
+/home/yunseong/dev/browser/target/debug/browser-cli navigate https://example.com >/dev/null 2>&1
+/home/yunseong/dev/browser/target/debug/browser-cli layout 2>/tmp/bt-t5.stderr
+```
+
+**PASS criteria:**
+- No `Error:` line in stdout
+- Output is non-empty (any layout tree text)
+
+---
+
+### T6 — click
+
+T1 must have run (a page with links must be loaded). Then:
+
+```bash
+/home/yunseong/dev/browser/target/debug/browser-cli navigate https://example.com >/dev/null 2>&1
+/home/yunseong/dev/browser/target/debug/browser-cli click 1 2>/tmp/bt-t6.stderr
+```
+
+**PASS criteria:**
+- No `Error:` line in stdout or stderr
+- Output is either empty (Nothing result), a link navigation, or a focus change — all are valid
+
+---
+
+### T7 — type
+
+Navigate to a page known to have an input field, then type into it:
+
+```bash
+/home/yunseong/dev/browser/target/debug/browser-cli navigate https://duckduckgo.com >/dev/null 2>&1
+/home/yunseong/dev/browser/target/debug/browser-cli type q hello 2>/tmp/bt-t7.stderr
+```
+
+**PASS criteria:**
+- No `Error:` line in stderr
+- Stderr contains `[type]` confirming the type command was dispatched
+
+---
+
+## Step 5 — Tear down
+
+```bash
+kill $BT_DAEMON_PID 2>/dev/null
+```
+
+---
+
+## Step 6 — Report results
+
+Print a results table and overall verdict:
+
+```
+browser-tester results
+======================
+T1  navigate    PASS | FAIL  — <one-line diagnosis>
+T2  screenshot  PASS | FAIL  — <one-line diagnosis>
+T3  js          PASS | FAIL  — <one-line diagnosis>
+T4  style       PASS | FAIL  — <one-line diagnosis>
+T5  layout      PASS | FAIL  — <one-line diagnosis>
+T6  click       PASS | FAIL  — <one-line diagnosis>
+T7  type        PASS | FAIL  — <one-line diagnosis>
+
+Overall: PASS   (all 7 scenarios passed)
+       | NONPASS (N/7 scenarios failed — see details above)
+```
+
+**PASS** = all 7 scenarios passed.
+**NONPASS** = any scenario failed.
+
+For each FAIL, include:
+- The exact command run
+- The stdout/stderr captured
+- The assertion that failed
+- A one-line root cause hypothesis
+
+---
+
+## Notes
+
+- The daemon takes up to 4 seconds to start. If it appears to be running but T1 fails with
+  `Error: Daemon is not running`, wait 2 more seconds and retry T1 once.
+- If T1 fails, T2/T3/T4/T5/T6 will likely also fail (no page loaded). Mark them FAIL with
+  `(depends on T1)` and focus the diagnosis on T1.
+- T7 uses DuckDuckGo which has form inputs. If DuckDuckGo is unreachable, substitute
+  `https://html.spec.whatwg.org/` or any URL that returns a page with an `<input>` tag.
+- `style` returns `{}` when the engine's computed-style feature is not yet populated — this is
+  expected. PASS as long as the endpoint responds with valid JSON.
+- Do not fix any code. Only report test results.

--- a/src/bin/browser_cli.rs
+++ b/src/bin/browser_cli.rs
@@ -9,6 +9,9 @@
 //!   browser-cli screenshot [<file>]      # Save screenshot
 //!   browser-cli back                     # Navigate back
 //!   browser-cli forward                  # Navigate forward
+//!   browser-cli js <script>              # Evaluate JavaScript and print result
+//!   browser-cli style [<selector>]       # Print computed CSS styles
+//!   browser-cli layout                   # Print the layout tree
 //!   browser-cli --port 7071 <command>    # Custom daemon port
 
 use std::fmt;
@@ -214,6 +217,34 @@ impl DaemonClient {
             .json()
             .map_err(|e| CliError::Parse(e.to_string()))?;
         Ok(v["result"].as_str().unwrap_or("").to_string())
+    }
+
+    /// GET /style?selector=<sel> — returns computed CSS styles as pretty-printed JSON.
+    fn get_style(&self, selector: Option<&str>) -> Result<String, CliError> {
+        let url = if let Some(sel) = selector {
+            format!("{}/style?selector={}", self.base_url, sel)
+        } else {
+            format!("{}/style", self.base_url)
+        };
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .map_err(Self::check_error)?;
+        let v: serde_json::Value = resp
+            .json()
+            .map_err(|e| CliError::Parse(e.to_string()))?;
+        serde_json::to_string_pretty(&v).map_err(|e| CliError::Parse(e.to_string()))
+    }
+
+    /// GET /layout — returns the plain-text layout tree.
+    fn get_layout(&self) -> Result<String, CliError> {
+        let resp = self
+            .client
+            .get(format!("{}/layout", self.base_url))
+            .send()
+            .map_err(Self::check_error)?;
+        resp.text().map_err(|e| CliError::Http(e.to_string()))
     }
 }
 
@@ -462,6 +493,9 @@ enum Command {
     Back,
     Forward,
     Screenshot(Option<String>),
+    Js(String),
+    Style { selector: Option<String> },
+    Layout,
     Help,
     Quit,
     Unknown(String),
@@ -537,6 +571,21 @@ fn parse_command(line: &str) -> Command {
                 Command::Screenshot(Some(rest.to_string()))
             }
         }
+        "js" => {
+            if rest.is_empty() {
+                Command::Unknown("js requires a script".to_string())
+            } else {
+                Command::Js(rest.to_string())
+            }
+        }
+        "style" => Command::Style {
+            selector: if rest.is_empty() {
+                None
+            } else {
+                Some(rest.to_string())
+            },
+        },
+        "layout" => Command::Layout,
         "help" | "?" | "h" => Command::Help,
         "quit" | "exit" | "q" => Command::Quit,
         other => Command::Unknown(other.to_string()),
@@ -555,6 +604,9 @@ fn print_help() {
     println!("  back                    Go back in history");
     println!("  forward                 Go forward in history");
     println!("  screenshot [<file>]     Save a PNG screenshot (default: screenshot.png)");
+    println!("  js <script>             Evaluate JavaScript and print the result");
+    println!("  style [<selector>]      Print computed CSS styles (optionally filtered by selector)");
+    println!("  layout                  Print the current layout tree");
     println!("  help                    Show this help");
     println!("  quit                    Exit the REPL");
     println!();
@@ -616,6 +668,24 @@ fn dispatch_command(cmd: Command, state: &mut CliState) -> bool {
         Command::Screenshot(path) => {
             if let Err(e) = state.screenshot(path.as_deref()) {
                 eprintln!("Error: {}", e);
+            }
+        }
+        Command::Js(script) => {
+            match state.client.evaluate_js(&script) {
+                Ok(result) => println!("js result: {}", result),
+                Err(e) => eprintln!("Error: {}", e),
+            }
+        }
+        Command::Style { selector } => {
+            match state.client.get_style(selector.as_deref()) {
+                Ok(text) => println!("{}", text),
+                Err(e) => eprintln!("Error: {}", e),
+            }
+        }
+        Command::Layout => {
+            match state.client.get_layout() {
+                Ok(text) => println!("{}", text),
+                Err(e) => eprintln!("Error: {}", e),
             }
         }
         Command::Help => print_help(),
@@ -915,6 +985,38 @@ mod tests {
     fn test_parse_command_screenshot_with_file() {
         let cmd = parse_command("screenshot out.png");
         assert_eq!(cmd, Command::Screenshot(Some("out.png".to_string())));
+    }
+
+    #[test]
+    fn test_parse_command_js() {
+        let cmd = parse_command("js document.title");
+        assert_eq!(cmd, Command::Js("document.title".to_string()));
+    }
+
+    #[test]
+    fn test_parse_command_js_no_script() {
+        let cmd = parse_command("js");
+        assert!(matches!(cmd, Command::Unknown(_)));
+    }
+
+    #[test]
+    fn test_parse_command_style_no_selector() {
+        assert_eq!(parse_command("style"), Command::Style { selector: None });
+    }
+
+    #[test]
+    fn test_parse_command_style_with_selector() {
+        assert_eq!(
+            parse_command("style body"),
+            Command::Style {
+                selector: Some("body".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_command_layout() {
+        assert_eq!(parse_command("layout"), Command::Layout);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add three missing `browser-cli` subcommands: `js <script>`, `style [<selector>]`, and `layout` — these were daemon HTTP endpoints (`/js`, `/style`, `/layout`) with no CLI surface
- Add `.claude/skills/browser-tester.md`: a project-local skill that builds the binaries, starts `browser-daemon` headlessly via Xvfb, drives `browser-cli` through all seven feature scenarios, and reports per-scenario PASS/FAIL with an overall verdict
- Add 5 new parse-level unit tests for the three new subcommands (38 total tests, all passing)

## New `browser-cli` subcommands

| Subcommand | Daemon endpoint | Description |
|---|---|---|
| `js <script>` | POST `/js` | Evaluate JavaScript, print result |
| `style [<selector>]` | GET `/style?selector=` | Print computed CSS styles as JSON |
| `layout` | GET `/layout` | Print the layout tree |

## Test plan

- [x] `cargo build` — clean build, no new errors
- [x] `cargo test --bin browser-cli` — 38 tests pass (5 new: `test_parse_command_js`, `test_parse_command_js_no_script`, `test_parse_command_style_no_selector`, `test_parse_command_style_with_selector`, `test_parse_command_layout`)
- [x] `cargo test` — full suite passes
- [x] `browser-cli-reviewer` integration test — daemon started, `navigate https://example.com` returned correct title and links, all three new commands (`js`, `style`, `layout`) responded without errors
- [x] Code reviewer — VERDICT: PASS

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)