### PR TITLE
feat: implement overflow:hidden clipping (#87)

### DIFF
--- a/src/layer_tree.rs
+++ b/src/layer_tree.rs
@@ -47,6 +47,12 @@ pub enum PaintCommand {
     },
     /// Outer box-shadow
     Shadow(LayoutRect, BoxShadow),
+    /// Push a clip region onto the clip stack.
+    /// All subsequent commands are clipped to `rect` (optionally with rounded corners
+    /// when `radius` > 0). Paired with `PopClip`.
+    PushClip { rect: LayoutRect, radius: f32 },
+    /// Pop the most recently pushed clip region from the clip stack.
+    PopClip,
 }
 
 // ── Compositing Triggers ──────────────────────────────────────────────────────
@@ -250,57 +256,128 @@ impl LayerTreeBuilder {
     /// each write touches a single distinct index, so there is no simultaneous
     /// aliasing of two entries.
     fn traverse(layout: &LayoutBox, tree: &mut LayerTree, current_layer_id: usize, clip: LayoutRect) {
-        struct Frame<'f> {
-            layout: &'f LayoutBox<'f>,
-            layer_id: usize,
-            clip: LayoutRect,
+        enum Frame<'f> {
+            /// Process a layout box and push its children.
+            Process {
+                layout: &'f LayoutBox<'f>,
+                layer_id: usize,
+                clip: LayoutRect,
+            },
+            /// Emit a PopClip command into the given layer after children are done.
+            PopClip {
+                layer_id: usize,
+                is_background: bool,
+            },
         }
 
-        let mut stack: Vec<Frame> = vec![Frame { layout, layer_id: current_layer_id, clip }];
+        let mut stack: Vec<Frame> = vec![Frame::Process { layout, layer_id: current_layer_id, clip }];
 
         while let Some(frame) = stack.pop() {
-            let d = frame.layout.dimensions;
-
-            // Skip zero-sized boxes but still visit children.
-            if d.width < 0.1 || d.height < 0.1 {
-                let next_clip = frame.clip.intersect(&frame.layout.get_content_rect());
-                // Push children in reverse order so the first child is processed first.
-                for child in frame.layout.children.iter().rev() {
-                    stack.push(Frame { layout: child, layer_id: frame.layer_id, clip: next_clip });
+            match frame {
+                Frame::PopClip { layer_id, is_background } => {
+                    let cmd = PaintCommand::PopClip;
+                    if is_background {
+                        tree.layers[layer_id].background_commands.push(cmd.clone());
+                    } else {
+                        tree.layers[layer_id].content_commands.push(cmd.clone());
+                    }
+                    // Also add to overlapping tiles
+                    for tile in &mut tree.layers[layer_id].tiles {
+                        if is_background {
+                            tile.background_commands.push(cmd.clone());
+                        } else {
+                            tile.content_commands.push(cmd.clone());
+                        }
+                        tile.dirty = true;
+                    }
                 }
-                continue;
+
+                Frame::Process { layout: frame_layout, layer_id: frame_layer_id, clip: frame_clip } => {
+                    let d = frame_layout.dimensions;
+
+                    // Skip zero-sized boxes but still visit children.
+                    if d.width < 0.1 || d.height < 0.1 {
+                        let next_clip = frame_clip.intersect(&frame_layout.get_content_rect());
+                        // Push children in reverse order so the first child is processed first.
+                        for child in frame_layout.children.iter().rev() {
+                            stack.push(Frame::Process { layout: child, layer_id: frame_layer_id, clip: next_clip });
+                        }
+                        continue;
+                    }
+
+                    // Check if this box clips its overflow.
+                    let overflow_hidden = Self::has_overflow_hidden(frame_layout);
+                    let border_radius = match frame_layout.style_node.specified_values.get(&crate::css::intern("border-radius")) {
+                        Some(Value::Length(v, _)) => *v,
+                        _ => 0.0,
+                    };
+
+                    let (triggers, matrix) = Self::detect_triggers(frame_layout);
+
+                    if !triggers.is_empty() {
+                        // This box establishes a new compositing layer.
+                        let new_id = tree.layers.len();
+                        let opacity = frame_layout.get_opacity();
+                        let new_layer = Layer::new(new_id, frame_layout.z_index, opacity, d, triggers, matrix);
+                        tree.add_layer(new_layer);
+
+                        // Record parent → child relationship: access parent index first,
+                        // then new_id — both are distinct indices so no aliasing.
+                        tree.layers[frame_layer_id].child_layer_ids.push(new_id);
+
+                        // Collect this box's paint commands into the new layer as BACKGROUND.
+                        Self::collect_paint_commands(frame_layout, &mut tree.layers[new_id], frame_clip, true);
+
+                        // If overflow:hidden, emit PushClip before children and schedule PopClip after.
+                        if overflow_hidden && !frame_layout.children.is_empty() {
+                            let clip_rect = frame_layout.dimensions;
+                            let push_cmd = PaintCommand::PushClip { rect: clip_rect, radius: border_radius };
+                            tree.layers[new_id].background_commands.push(push_cmd.clone());
+                            for tile in &mut tree.layers[new_id].tiles {
+                                tile.background_commands.push(push_cmd.clone());
+                                tile.dirty = true;
+                            }
+                            // Schedule PopClip to be emitted after all children finish.
+                            stack.push(Frame::PopClip { layer_id: new_id, is_background: true });
+                        }
+
+                        // All children belong to the new layer's stacking context.
+                        let next_clip = frame_clip.intersect(&frame_layout.get_content_rect());
+                        for child in frame_layout.children.iter().rev() {
+                            stack.push(Frame::Process { layout: child, layer_id: new_id, clip: next_clip });
+                        }
+                    } else {
+                        // No trigger — paint into the current ancestor layer as CONTENT.
+                        Self::collect_paint_commands(frame_layout, &mut tree.layers[frame_layer_id], frame_clip, false);
+
+                        // If overflow:hidden, emit PushClip before children and schedule PopClip after.
+                        if overflow_hidden && !frame_layout.children.is_empty() {
+                            let clip_rect = frame_layout.dimensions;
+                            let push_cmd = PaintCommand::PushClip { rect: clip_rect, radius: border_radius };
+                            tree.layers[frame_layer_id].content_commands.push(push_cmd.clone());
+                            for tile in &mut tree.layers[frame_layer_id].tiles {
+                                tile.content_commands.push(push_cmd.clone());
+                                tile.dirty = true;
+                            }
+                            // Schedule PopClip to be emitted after all children finish.
+                            stack.push(Frame::PopClip { layer_id: frame_layer_id, is_background: false });
+                        }
+
+                        let next_clip = frame_clip.intersect(&frame_layout.get_content_rect());
+                        for child in frame_layout.children.iter().rev() {
+                            stack.push(Frame::Process { layout: child, layer_id: frame_layer_id, clip: next_clip });
+                        }
+                    }
+                }
             }
+        }
+    }
 
-            let (triggers, matrix) = Self::detect_triggers(frame.layout);
-
-            if !triggers.is_empty() {
-                // This box establishes a new compositing layer.
-                let new_id = tree.layers.len();
-                let opacity = frame.layout.get_opacity();
-                let new_layer = Layer::new(new_id, frame.layout.z_index, opacity, d, triggers, matrix);
-                tree.add_layer(new_layer);
-
-                // Record parent → child relationship: access parent index first,
-                // then new_id — both are distinct indices so no aliasing.
-                tree.layers[frame.layer_id].child_layer_ids.push(new_id);
-
-                // Collect this box's paint commands into the new layer as BACKGROUND.
-                Self::collect_paint_commands(frame.layout, &mut tree.layers[new_id], frame.clip, true);
-
-                // All children belong to the new layer's stacking context.
-                let next_clip = frame.clip.intersect(&frame.layout.get_content_rect());
-                for child in frame.layout.children.iter().rev() {
-                    stack.push(Frame { layout: child, layer_id: new_id, clip: next_clip });
-                }
-            } else {
-                // No trigger — paint into the current ancestor layer as CONTENT.
-                Self::collect_paint_commands(frame.layout, &mut tree.layers[frame.layer_id], frame.clip, false);
-
-                let next_clip = frame.clip.intersect(&frame.layout.get_content_rect());
-                for child in frame.layout.children.iter().rev() {
-                    stack.push(Frame { layout: child, layer_id: frame.layer_id, clip: next_clip });
-                }
-            }
+    /// Returns `true` if this box has `overflow: hidden` set.
+    fn has_overflow_hidden(layout: &LayoutBox) -> bool {
+        match layout.style_node.specified_values.get(&crate::css::intern("overflow")) {
+            Some(Value::Keyword(k)) => **k == *"hidden",
+            _ => false,
         }
     }
 
@@ -461,12 +538,16 @@ impl LayerTreeBuilder {
 
         // Also distribute to overlapping tiles
         for cmd in commands {
+            // PushClip/PopClip are emitted directly in traverse(); they never appear in
+            // the `commands` Vec built by collect_paint_commands. Handle them defensively.
             let cmd_rect = match &cmd {
                 PaintCommand::Rect(r, ..) => *r,
                 PaintCommand::Border(r, ..) => *r,
                 PaintCommand::Image { rect, .. } => *rect,
                 PaintCommand::Text { rect, .. } => *rect,
                 PaintCommand::Shadow(r, ..) => *r,
+                PaintCommand::PushClip { rect, .. } => *rect,
+                PaintCommand::PopClip => continue,
             };
 
             for tile in &mut layer.tiles {
@@ -634,5 +715,77 @@ mod tests {
             .flat_map(|l| l.content_commands.iter().chain(l.background_commands.iter()))
             .any(|cmd| matches!(cmd, PaintCommand::Image { object_fit: ObjectFit::Fill, .. }));
         assert!(has_fill, "image with no object-fit must default to ObjectFit::Fill");
+    }
+
+    /// A plain div without `overflow: hidden` must not emit any PushClip/PopClip commands.
+    #[test]
+    fn test_no_clip_commands_for_visible_overflow() {
+        let tree = build_tree_from_html(
+            r#"<div style="width:200px;height:100px;background-color:red;">
+                <div style="width:200px;height:200px;background-color:blue;">tall child</div>
+            </div>"#,
+            "",
+        );
+        let has_push_clip = tree.layers.iter()
+            .flat_map(|l| l.content_commands.iter().chain(l.background_commands.iter()))
+            .any(|cmd| matches!(cmd, PaintCommand::PushClip { .. }));
+        assert!(!has_push_clip, "overflow:visible (default) must not emit PushClip");
+    }
+
+    /// A div with `overflow: hidden` must emit a PushClip command followed by a PopClip.
+    #[test]
+    fn test_overflow_hidden_emits_push_pop_clip() {
+        let tree = build_tree_from_html(
+            r#"<div style="width:200px;height:100px;overflow:hidden;background-color:red;">
+                <div style="width:200px;height:200px;background-color:blue;">tall child</div>
+            </div>"#,
+            "",
+        );
+        let all_cmds: Vec<&PaintCommand> = tree.layers.iter()
+            .flat_map(|l| l.content_commands.iter().chain(l.background_commands.iter()))
+            .collect();
+
+        let push_count = all_cmds.iter().filter(|c| matches!(c, PaintCommand::PushClip { .. })).count();
+        let pop_count  = all_cmds.iter().filter(|c| matches!(c, PaintCommand::PopClip)).count();
+
+        assert!(push_count >= 1, "overflow:hidden must emit at least one PushClip; got {}", push_count);
+        assert_eq!(push_count, pop_count, "PushClip and PopClip must be balanced");
+    }
+
+    /// A div with `overflow: hidden` + `border-radius` must emit a PushClip with non-zero radius.
+    #[test]
+    fn test_overflow_hidden_with_border_radius_emits_rounded_clip() {
+        let tree = build_tree_from_html(
+            r#"<div style="width:200px;height:100px;overflow:hidden;border-radius:8px;">
+                <div style="width:300px;height:300px;background-color:blue;">overflow child</div>
+            </div>"#,
+            "",
+        );
+        let has_rounded_push = tree.layers.iter()
+            .flat_map(|l| l.content_commands.iter().chain(l.background_commands.iter()))
+            .any(|cmd| matches!(cmd, PaintCommand::PushClip { radius, .. } if *radius > 0.0));
+        assert!(has_rounded_push, "overflow:hidden + border-radius must emit PushClip with radius > 0");
+    }
+
+    /// Normal boxes without overflow:hidden must not be affected (regression guard).
+    #[test]
+    fn test_overflow_hidden_does_not_affect_sibling_boxes() {
+        let tree = build_tree_from_html(
+            r#"<div>
+                <div style="width:100px;height:50px;overflow:hidden;background:red;">
+                    <span>clipped</span>
+                </div>
+                <div style="width:100px;height:50px;background:green;">
+                    <span>not clipped</span>
+                </div>
+            </div>"#,
+            "",
+        );
+        // Verify there is exactly one PushClip (from the overflow:hidden div only).
+        let push_count = tree.layers.iter()
+            .flat_map(|l| l.content_commands.iter().chain(l.background_commands.iter()))
+            .filter(|c| matches!(c, PaintCommand::PushClip { .. }))
+            .count();
+        assert_eq!(push_count, 1, "only the overflow:hidden div should emit PushClip; got {}", push_count);
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,4 +1,4 @@
-use tiny_skia::{Pixmap, Paint, Transform, Stroke, PathBuilder, PixmapPaint};
+use tiny_skia::{Pixmap, Paint, Transform, Stroke, PathBuilder, PixmapPaint, Mask, FillRule};
 use ab_glyph::{Font, FontRef, PxScale, point};
 use crate::layout::{LayoutBox, Rect as LayoutRect};
 use crate::css::Color;
@@ -179,22 +179,84 @@ fn composite_layer_to_tile(
     }
 }
 
+/// Build a `Mask` (sized to the tile pixmap) for an overflow clip region.
+///
+/// The clip rect is in document space; `tx`/`ty` translate it to tile-local space.
+/// If `parent_mask` is provided the new mask is AND-ed with the parent so nested
+/// `overflow: hidden` containers accumulate correctly.
+fn build_clip_mask(
+    rect: LayoutRect,
+    radius: f32,
+    tx: f32,
+    ty: f32,
+    pw: u32,
+    ph: u32,
+    parent_mask: Option<&Mask>,
+) -> Option<Mask> {
+    if pw == 0 || ph == 0 { return None; }
+    let mut m = Mask::new(pw, ph)?;
+
+    let local_rect = LayoutRect { x: rect.x + tx, y: rect.y + ty, width: rect.width, height: rect.height };
+    let path = if radius > 0.0 {
+        create_rounded_rect_path(local_rect, radius)
+    } else {
+        tiny_skia::Rect::from_xywh(local_rect.x, local_rect.y, local_rect.width, local_rect.height)
+            .and_then(|tr| { let mut pb = PathBuilder::new(); pb.push_rect(tr); pb.finish() })
+    }?;
+    m.fill_path(&path, FillRule::Winding, true, Transform::identity());
+
+    // Intersect with parent clip by multiplying alpha values.
+    if let Some(pm) = parent_mask {
+        let pd = pm.data();
+        let md = m.data_mut();
+        for (d, s) in md.iter_mut().zip(pd.iter()) {
+            *d = ((*d as u32 * *s as u32) / 255) as u8;
+        }
+    }
+    Some(m)
+}
+
 fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile_rect: LayoutRect, image_cache: &HashMap<String, Vec<u8>>) {
     let tx = -tile_rect.x;
     let ty = -tile_rect.y;
     let transform = Transform::from_translate(tx, ty);
 
+    // Clip mask stack: each entry is the accumulated mask for that clip level.
+    // `None` means the clip region did not intersect this tile or allocation failed.
+    let mut clip_stack: Vec<Option<Mask>> = Vec::new();
+
+    // Returns the top active mask (or `None` if the stack is empty / top is None).
+    macro_rules! active_mask {
+        () => {
+            clip_stack.last().and_then(|m| m.as_ref())
+        }
+    }
+
     for cmd in commands {
         match cmd {
+            PaintCommand::PushClip { rect, radius } => {
+                let parent = clip_stack.last().and_then(|m| m.as_ref());
+                let mask = build_clip_mask(
+                    *rect, *radius, tx, ty,
+                    pixmap.width(), pixmap.height(),
+                    parent,
+                );
+                clip_stack.push(mask);
+            }
+
+            PaintCommand::PopClip => {
+                clip_stack.pop();
+            }
+
             PaintCommand::Rect(r, c, radius) => {
                 let mut paint = Paint::default();
                 paint.set_color_rgba8(c.r, c.g, c.b, c.a);
                 if *radius > 0.0 {
                     if let Some(path) = create_rounded_rect_path(*r, *radius) {
-                        pixmap.fill_path(&path, &paint, tiny_skia::FillRule::Winding, transform, None);
+                        pixmap.fill_path(&path, &paint, FillRule::Winding, transform, active_mask!());
                     }
                 } else if let Some(tr) = tiny_skia::Rect::from_xywh(r.x, r.y, r.width, r.height) {
-                    pixmap.fill_rect(tr, &paint, transform, None);
+                    pixmap.fill_rect(tr, &paint, transform, active_mask!());
                 }
             }
             PaintCommand::Border(r, w, c, radius) => {
@@ -204,13 +266,13 @@ fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile
                 stroke.width = *w;
                 if *radius > 0.0 {
                     if let Some(path) = create_rounded_rect_path(*r, *radius) {
-                        pixmap.stroke_path(&path, &paint, &stroke, transform, None);
+                        pixmap.stroke_path(&path, &paint, &stroke, transform, active_mask!());
                     }
                 } else if let Some(tr) = tiny_skia::Rect::from_xywh(r.x + w/2.0, r.y + w/2.0, (r.width - w).max(0.0), (r.height - w).max(0.0)) {
                     let mut pb = PathBuilder::new();
                     pb.push_rect(tr);
                     if let Some(path) = pb.finish() {
-                        pixmap.stroke_path(&path, &paint, &stroke, transform, None);
+                        pixmap.stroke_path(&path, &paint, &stroke, transform, active_mask!());
                     }
                 }
             }
@@ -227,7 +289,7 @@ fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile
                                     // Stretch to fill — existing behavior
                                     pixmap.draw_pixmap(r.x as i32, r.y as i32, img_pixmap.as_ref(),
                                         &PixmapPaint::default(),
-                                        transform.post_scale(r.width / img_w, r.height / img_h), None);
+                                        transform.post_scale(r.width / img_w, r.height / img_h), active_mask!());
                                 }
                                 ObjectFit::Contain => {
                                     // Scale uniformly to fit inside rect; letterbox with transparency
@@ -238,7 +300,7 @@ fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile
                                     let oy = r.y + (r.height - sh) / 2.0;
                                     pixmap.draw_pixmap(ox as i32, oy as i32, img_pixmap.as_ref(),
                                         &PixmapPaint::default(),
-                                        transform.post_scale(s, s), None);
+                                        transform.post_scale(s, s), active_mask!());
                                 }
                                 ObjectFit::Cover => {
                                     // Scale uniformly to fill rect; draw into a temp pixmap to clip overflow
@@ -254,7 +316,7 @@ fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile
                                             img_pixmap.as_ref(), &PixmapPaint::default(),
                                             Transform::from_scale(s, s), None);
                                         pixmap.draw_pixmap(r.x as i32, r.y as i32, tmp.as_ref(),
-                                            &PixmapPaint::default(), transform, None);
+                                            &PixmapPaint::default(), transform, active_mask!());
                                     }
                                 }
                                 ObjectFit::None => {
@@ -267,7 +329,7 @@ fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile
                                         tmp.draw_pixmap(ox as i32, oy as i32, img_pixmap.as_ref(),
                                             &PixmapPaint::default(), Transform::identity(), None);
                                         pixmap.draw_pixmap(r.x as i32, r.y as i32, tmp.as_ref(),
-                                            &PixmapPaint::default(), transform, None);
+                                            &PixmapPaint::default(), transform, active_mask!());
                                     }
                                 }
                             }
@@ -297,7 +359,7 @@ fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile
                 let sw = r.width + (*s.spread * 2.0);
                 let sh = r.height + (*s.spread * 2.0);
                 if let Some(tr) = tiny_skia::Rect::from_xywh(sx, sy, sw, sh) {
-                    pixmap.fill_rect(tr, &paint, transform, None);
+                    pixmap.fill_rect(tr, &paint, transform, active_mask!());
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add `PushClip { rect, radius }` and `PopClip` variants to `PaintCommand` in `layer_tree.rs`
- Modify `LayerTreeBuilder::traverse()` to emit `PushClip`/`PopClip` pairs around the children of any box with `overflow: hidden`
- Update `execute_commands_on_tile` in `render.rs` to maintain a clip mask stack using tiny_skia's `Mask` API — rectangular clips and rounded-corner clips (when `border-radius` is set) both work
- Nested `overflow: hidden` containers accumulate correctly by AND-ing parent and child mask alpha values
- 4 new tests verify: PushClip/PopClip emission, balanced pairs, rounded clip, and no impact on sibling boxes

## Test plan
- [x] `cargo test --lib` — 88 tests pass (84 pre-existing + 4 new `layer_tree` tests)
- [x] `cargo clippy` — no errors
- [x] `test_no_clip_commands_for_visible_overflow` — overflow:visible (default) does not emit any clip commands
- [x] `test_overflow_hidden_emits_push_pop_clip` — overflow:hidden box emits balanced PushClip/PopClip
- [x] `test_overflow_hidden_with_border_radius_emits_rounded_clip` — border-radius produces PushClip with radius > 0
- [x] `test_overflow_hidden_does_not_affect_sibling_boxes` — only the overflow:hidden div generates a clip region

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)