### PR TITLE
feat: implement CSS gradient background support (#81)

### DIFF
--- a/.claude/agents/browser-cli-reviewer.md
+++ b/.claude/agents/browser-cli-reviewer.md
@@ -1,0 +1,101 @@
+---
+name: browser-cli-reviewer
+description: Reviews browser-cli behavior against a live URL. Use after any change to browser-daemon, browser-cli, or engine.rs. Builds locally, starts the daemon in headless mode (--no-gui, no Xvfb needed), runs navigate, and returns PASS or NONPASS with details.
+---
+
+You are a browser-cli integration reviewer for the `browser` project at `/home/yunseong/dev/browser`.
+
+## Your job
+
+Verify that `browser-cli navigate <url>` works end-to-end after code changes:
+1. Kill any existing daemon
+2. Build both binaries locally with `cargo build --bins`
+3. Start `browser-daemon --no-gui` (headless HTTP server — no GUI event loop, no Xvfb needed)
+4. Run `browser-cli navigate <url>` against **both** `https://yunseong.dev` and `https://google.com`
+5. Tear down daemon
+6. Return **PASS** or **NONPASS** with evidence
+
+## Steps
+
+### 1. Kill any existing daemon
+```bash
+pkill -f browser-daemon 2>/dev/null || true
+sleep 1
+```
+
+### 2. Build binaries on host (uses local cargo cache — fast)
+```bash
+cd /home/yunseong/dev/browser
+cargo build --bins 2>&1 | tail -10
+```
+If `error[E` appears in output → return **NONPASS: build failed** with full error.
+
+### 3. Start daemon inside drun rust:latest (headless, resource-limited)
+```bash
+cd /home/yunseong/dev/browser
+drun --network host rust:latest ./target/debug/browser-daemon --no-gui --port 7070 >/tmp/daemon.log 2>&1 &
+DAEMON_PID=$!
+sleep 4
+```
+
+`rust:latest` provides the same Debian/glibc environment the binary was compiled for.
+`drun` caps at 4 GB RAM / 0.5 CPU / 100 pids — a render hang or OOM kills the container, not the session.
+
+Check `/tmp/daemon.log` — must contain `HTTP listening on http://127.0.0.1:7070`.
+If not → return **NONPASS: daemon failed to start** with full log content.
+
+### 4. Run navigate for both URLs (also inside drun rust:latest)
+```bash
+cd /home/yunseong/dev/browser
+drun --network host rust:latest timeout 30s ./target/debug/browser-cli navigate "https://yunseong.dev"
+```
+```bash
+drun --network host rust:latest timeout 30s ./target/debug/browser-cli navigate "https://google.com"
+```
+
+Exit code meanings:
+- `124` → **NONPASS: timed out — infinite loop or deadlock in render**
+- `137` → **NONPASS: OOM killed by Docker memory limit**
+- non-zero other → **NONPASS: CLI error** — include full stderr
+
+### 5. Tear down
+```bash
+kill $DAEMON_PID 2>/dev/null || true
+pkill -f browser-daemon 2>/dev/null || true
+```
+
+## Evaluate output
+
+**PASS criteria (all must hold for each URL):**
+- Exit code 0
+- No `Error:` line in stdout
+- Output contains `Title:` with a non-empty value
+- Output contains at least one link or content line
+
+**NONPASS criteria (any one fails):**
+- `Error: Parse error:` → JSON deserialization bug; include raw body from error
+- `Error: Daemon is not running` → daemon did not start; check `/tmp/daemon.log`
+- `Error: HTTP error:` → daemon returned non-200; check `/tmp/daemon.log` for panic
+- Empty or blank output
+- Timeout (exit 124)
+
+## Output format
+
+```
+Result: PASS | NONPASS
+
+URLs tested: https://yunseong.dev, https://google.com
+
+yunseong.dev output:
+<stdout>
+
+google.com output:
+<stdout>
+
+Daemon log tail:
+<last 20 lines of /tmp/daemon.log>
+
+Diagnosis: <one paragraph — what worked, what failed, root cause if NONPASS>
+```
+
+Do not fix any code. Only report.

--- a/.claude/handoffs/2026-04-14_10-35.md
+++ b/.claude/handoffs/2026-04-14_10-35.md
@@ -1,0 +1,42 @@
+# Handoff — 2026-04-14 10:35
+
+## Summary
+Session developed issue #63 (layout recursion → iterative, PR #67 open), started issue #3 (CSS cascade/inherit/var() — partial implementation, uncommitted), then designed and documented a full daemon/CLI architecture split (issues #68–#72, Priority 0 in roadmap).
+
+## Done
+- **Issue #63** — All recursive layout/layer functions converted to iterative. Manual `Clone`/`Drop` for `LayoutBox`. `stacker::maybe_grow` guard. PR #67 open on branch `feat/layout-recursion-issue-63`.
+- **Issue #3 (partial)** — Plan reviewed (PASS). Agent hit rate limit mid-implementation. `src/css.rs` and `src/style.rs` have uncommitted changes on branch `feat/deterministic-style-issue-3`. `cargo check` passes.
+- **Issues #68–#72 created** on GitHub:
+  - #68: Extract headless `BrowserEngine` from `main.rs` → `src/engine.rs`
+  - #70: Daemon — single process with engine + eframe GUI + axum HTTP server
+  - #69: CLI — HTTP client to daemon, Markdown renderer + interactive REPL
+  - #72: Refactor `BrowserApp` to use `Arc<Mutex<BrowserEngine>>` in-process
+  - #71: Browser Tester agent skill (project-local `.claude/skills/browser-tester.md`)
+- **`docs/issue-priority.md` updated** — #68→#70→#72→#69→#71 added as **Priority 0** (above all existing priorities).
+
+## Current State
+- Branch `feat/deterministic-style-issue-3` is checked out with uncommitted changes to `css.rs` and `style.rs`. These are partial implementation of issue #3 features: `inherit`, `initial`, `em` resolution, `currentColor`, `var()` support.
+- PR #66 (issue #62, CSS selector opt) is open, not yet merged.
+- PR #67 (issue #63, layout recursion) is open, not yet merged.
+- No work started on #68–#72.
+
+## Decisions
+| Decision | Reason |
+|---|---|
+| Daemon owns GUI as in-process module | GUI talks to engine directly via `Arc<Mutex<_>>`, no HTTP overhead |
+| CLI is HTTP-only client | Thin client, Markdown renderer + REPL, connects to daemon |
+| `axum` for HTTP server | `tokio` already in deps |
+| #68–#72 at Priority 0 | Foundational infrastructure; browser-tester agent depends on CLI being done |
+| Daemon auto-starts GUI on launch | `browser-daemon` opens eframe window + HTTP server simultaneously; `--no-gui` for headless |
+
+## Next Steps
+1. **Finish issue #3** — Resume agent on branch `feat/deterministic-style-issue-3`. Implementation is partial. Run code-reviewer then create PR.
+2. **Develop #68** — Extract `BrowserEngine` from `main.rs` into `src/engine.rs`. No GUI deps. `BrowserApp` becomes thin wrapper. This is the blocker for all daemon/CLI work.
+3. **Develop #70** — Daemon: `Arc<Mutex<BrowserEngine>>` shared between eframe GUI thread and axum HTTP server thread.
+4. **Develop #72** — Refactor `BrowserApp` to use shared engine from daemon.
+5. **Develop #69** — CLI binary `src/bin/cli.rs` with `clap` subcommands + Markdown REPL.
+6. **Develop #71** — Write `.claude/skills/browser-tester.md` agent skill.
+
+## Blockers / Open Questions
+- Issue #3 branch has uncommitted changes — must commit or stash before switching branches.
+- PRs #66 and #67 pending merge — merging them into `main` before starting #68 avoids future rebase conflicts.

--- a/.claude/handoffs/2026-04-15_13-00.md
+++ b/.claude/handoffs/2026-04-15_13-00.md
@@ -1,0 +1,33 @@
+# Handoff — 2026-04-15 13:00
+
+## Summary
+Implemented Issue #69 (browser-cli: interactive REPL HTTP client to browser-daemon) and merged it into main. Also updated README with full documentation for all three binaries (GUI, daemon, CLI).
+
+## Done
+- `src/bin/browser_cli.rs` — 1026-line CLI binary with interactive REPL, `DaemonClient`, `CliHistory`, `CliState`, command parser, markdown page renderer
+- `src/engine.rs` — fixed `ClickResult` serde bug (struct variants), added `ApiFormControl`, `forms` field on `ApiPageResponse`, `extract_link_texts_from_html()`, `extract_form_controls_from_html()`
+- `src/bin/browser_daemon.rs` — added `/submit` POST endpoint
+- `README.md` — rewrote How to Run, added Components section documenting GUI browser, browser-daemon (REST API table), browser-cli (example session, command table, aliases)
+- PR #76 squash-merged into `main`, branch `feat/browser-cli-issue-69` deleted
+- Local `main` fast-forwarded to `bcd8e65`
+
+## Current State
+- `main` is clean and up to date
+- All three binaries build: `browser` (GUI), `browser-daemon`, `browser-cli`
+- `docs/issue-priority.md` has uncommitted local changes (marks #68 and #70 as done ✓) — not yet committed
+- `storage.json` has a trivial JSON key reorder (uncommitted, safe to ignore or commit)
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Squash merge PR #76 | Keeps main history clean; branch had 2 implementation commits + 1 docs commit |
+| Force-with-lease push before merge | Branch had diverged after rebase onto main (daemon PR #75 was already merged) |
+| Skipped committing `storage.json` | JSON key reorder only — no semantic change |
+
+## Next Steps
+1. Commit the `docs/issue-priority.md` change (marks #68, #70 done) — or let it happen as part of next issue's PR
+2. Next issue per `docs/issue-priority.md`: **#72** — Refactor BrowserApp as daemon GUI module (`BrowserApp` uses `Arc<Mutex<BrowserEngine>>` directly, no engine logic in `main.rs`)
+3. After #72: **#71** — Browser Tester Agent (project-local skill that drives CLI to test all browser features)
+
+## Blockers / Open Questions
+None

--- a/.claude/handoffs/2026-04-16_00-00.md
+++ b/.claude/handoffs/2026-04-16_00-00.md
@@ -1,0 +1,67 @@
+# Handoff — 2026-04-16 00:00
+
+## Summary
+Investigated the root cause of `browser-cli` always failing with "Parse error: error decoding response body" on every `navigate` command. Did NOT fix — user asked to find reason and file a GitHub issue only.
+
+## Done
+- Read `src/bin/browser_cli.rs` — error comes from `resp.json::<ApiPageResponse>().map_err(|e| CliError::Parse(e.to_string()))` in `DaemonClient::navigate`
+- Read `src/bin/browser_daemon.rs` — confirmed `blocking!` macro, `navigate_handler` structure
+- Read `src/engine.rs` — reviewed `page_to_api_response`, `extract_attr`, `markdown_from_html`, `extract_link_texts_from_html`, `extract_form_controls_from_html`
+- Confirmed reqwest version is `0.13.2`, axum is `0.7`
+
+## Current State
+
+**Symptom:** Every `navigate <url>` in the CLI returns:
+```
+Error: Parse error: error decoding response body
+```
+Despite the daemon successfully rendering pages (perf logs confirm rendering completed).
+
+**Why "Parse error" and not "HTTP error":**
+The CLI's `navigate` function checks `resp.status().is_success()` before calling `resp.json()`. "Parse error" means the status WAS 200 OK, but JSON deserialization failed — so the daemon sent a 200 response with a body that couldn't be parsed as `ApiPageResponse`.
+
+**Most likely root cause — panic in async handler:**
+
+In `navigate_handler` (`browser_daemon.rs:343`), after `blocking!` returns `Ok(page)`, `page_to_api_response` is called **outside** `spawn_blocking`, directly in the async context:
+
+```rust
+Ok(page) => {
+    let resp = engine::page_to_api_response(&page, &page.base_url.clone()); // NOT in spawn_blocking
+    (StatusCode::OK, Json(resp)).into_response()
+}
+```
+
+If `page_to_api_response` panics, the async task panics. Tokio drops the connection **without sending a response** (or after sending headers only). reqwest 0.13 (hyper 1.0 backend) reports this as "error decoding response body" because it received nothing parseable.
+
+**Secondary cause — `extract_attr` byte-index bug (`engine.rs:328`):**
+
+```rust
+fn extract_attr(tag: &str, attr_name: &str) -> Option<String> {
+    let lower = tag.to_lowercase();          // may change byte lengths for some Unicode chars
+    let search = format!("{}=", attr_name.to_lowercase());
+    let pos = lower.find(&search)?;          // byte pos in `lower`
+    let rest = &tag[pos + search.len()..];   // BUG: pos from `lower` used on `tag`
+```
+
+`to_lowercase()` can change byte lengths for certain Unicode characters (e.g., `İ` U+0130 = 2 bytes → `i\u{307}` = 3 bytes). If any character **before** the attribute name in the tag string changes byte length when lowercased, `pos` is wrong for `tag`, and `&tag[pos + search.len()..]` panics with "byte index X is not a char boundary". This panic is the likely trigger for the above async handler panic.
+
+**reqwest 0.13 behavior change (context):**
+reqwest 0.13 (hyper 1.0) classifies "server closed connection before sending response" as `Error::decode()` (message: "error decoding response body") rather than a connection error. This is why the CLI shows "Parse error" instead of "HTTP error: navigate returned 500".
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Did not fix | User explicitly said "don't fix, only find reason and make issue" |
+| Did not open GitHub issue | User interrupted before I could open it — left for next session |
+
+## Next Steps
+1. **File a GitHub issue** with:
+   - Title: `browser-cli: navigate always fails with "Parse error: error decoding response body"`
+   - Root cause: `page_to_api_response` called outside `spawn_blocking` in `navigate_handler` — any panic there drops the connection; reqwest 0.13 reports this as a parse error
+   - Secondary cause: `extract_attr` (`engine.rs:328`) uses byte-index from `lower.find()` to slice original `tag` string — panics for tags with certain Unicode chars
+   - Suggestion: move `page_to_api_response` inside `spawn_blocking`, OR fix `extract_attr` to use char-safe indexing
+2. (Optional, if user approves) Fix both issues
+
+## Blockers / Open Questions
+- The exact panic trigger (which Unicode character or which code path in `page_to_api_response`) was not confirmed — adding better error logging (printing the full error chain in the CLI) would pinpoint it quickly
+- reqwest 0.13 "error decoding response body" error message hides the inner cause: `e.to_string()` only shows the outer wrapper, not the serde_json detail or connection error detail

--- a/.claude/handoffs/2026-04-16_11-41.md
+++ b/.claude/handoffs/2026-04-16_11-41.md
@@ -1,0 +1,45 @@
+# Handoff — 2026-04-16 11:41
+
+## Summary
+Developed and merged Issue #72 (Refactor BrowserApp as daemon GUI module). `BrowserApp` in `main.rs` is now a thin GUI shell backed by `EngineHandle`; all engine logic lives in `src/engine.rs`. PR #79 passed code review and was merged to main.
+
+## Done
+- Read handoff from previous session (parse error bug context)
+- Identified next priority: Issue #72 (Priority 0 chain: #68 ✓ #70 ✓ #69 ✓ → #72)
+- Invoked developer agent for Issue #72
+  - Added `EngineCmd` enum (14 variants), `EngineHandle` struct with `spawn()` + `send_*` methods, `run_engine_actor()` to `src/engine.rs`
+  - Removed duplicate `EngineCmd`/`EngineHandle`/`run_engine_actor` from `src/bin/browser_daemon.rs`; now imports from `browser::engine`
+  - Replaced `engine: BrowserEngine` with `engine: EngineHandle` in `src/main.rs`; removed all fetch/parse/layout/render calls
+- Ran code-reviewer agent → PASS
+- Merged PR #79 to main
+
+## Current State
+
+**Main branch is clean and up to date.**
+
+Priority 0 chain status:
+| Issue | Status |
+|-------|--------|
+| #68 Extract Headless BrowserEngine | ✓ Done |
+| #70 Browser Daemon | ✓ Done |
+| #69 CLI HTTP client | ✓ Done |
+| #72 Refactor BrowserApp as daemon GUI module | ✓ Done (merged this session) |
+| #71 Browser Tester Agent | Open — next |
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Used actor pattern (`mpsc::sync_channel`) not `Arc<Mutex<>>` | Avoids lock contention; engine runs on dedicated thread; matches existing daemon pattern |
+| Image fetch stays in GUI thread (Promise::spawn_thread) | Parallel image loading; results forwarded to engine via `EngineCmd::LoadImage` |
+| `EngineHandle::tx` left as `pub` | Used for fire-and-forget `LoadImage` sends; reviewer flagged could be `pub(crate)` |
+
+## Next Steps
+1. **Issue #71 — Browser Tester Agent**: project-local skill that drives `browser-cli` to test all browser features. Depends on #69 (done). This is the last issue in Priority 0.
+2. After #71: move to Priority 1 — Issue #13 (Intrinsic & Extrinsic Sizing).
+
+## Blockers / Open Questions
+- Non-blocking reviewer suggestions for PR #79 (not fixed yet):
+  - `EngineHandle::tx` could be narrowed to `pub(crate)`
+  - Superfluous `run_engine_actor` import in daemon test module
+  - `Cargo.toml` missing explicit `[[bin]] name="browser" path="src/main.rs"` entry
+- These are polish items; none block further development

--- a/.claude/handoffs/2026-04-17_00-00.md
+++ b/.claude/handoffs/2026-04-17_00-00.md
@@ -1,0 +1,29 @@
+# Handoff — 2026-04-17 00:00
+
+## Summary
+Implemented and merged issue #82 — Text Decoration & Font Variant Rendering. All text styling (bold, italic, underline, line-through, overline) now renders visually in the browser.
+
+## Done
+- `src/layer_tree.rs` — added `bold: bool`, `italic: bool`, `text_decoration: u8` fields to `PaintCommand::Text`; `collect_paint_commands` reads `font-weight`, `font-style`, `text-decoration` from styled nodes
+- `src/render.rs` — bold synthesis (multi-offset glyph draw at ±1px), italic synthesis (horizontal shear ~12°), decoration lines (underline/line-through/overline as `tiny_skia::Rect`)
+- `src/style.rs` — `font-style` added to inherited CSS properties list
+- PR #91 created and merged to `main`
+
+## Current State
+- `main` branch is up-to-date with #82 merged (commit bdea6ee)
+- All Priority 0 and Priority 1 issues are done
+- Priority 2 (#82) is now done; remaining open: #83, #86, #87, #88, #89, #90, #81, #84, #85
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Synthesize bold via multi-offset draw | Single NanumGothic.ttf has no bold variant |
+| Synthesize italic via pixel shear | Single font file, no italic variant |
+| `text_decoration` as `u8` bitmask | Supports underline (bit 0), line-through (bit 1), overline (bit 2) simultaneously |
+
+## Next Steps
+1. Run `/update-priority` to mark #82 done in `docs/issue-priority.md`
+2. Next priority issue: **#83 — Image: object-fit, aspect ratio, fallback**
+
+## Blockers / Open Questions
+None

--- a/.claude/handoffs/2026-04-17_16-53.md
+++ b/.claude/handoffs/2026-04-17_16-53.md
@@ -1,0 +1,47 @@
+# Handoff — 2026-04-17 16:53
+
+## Summary
+Completed Issue #71 (Browser Tester Agent) and created 10 new visual fidelity issues (#81–#90) covering all major gaps between the current renderer and a real browser. Priority doc updated to reflect new Priority 2 group.
+
+## Done
+- Merged PR #80 (Issue #71): added `js`, `style`, `layout` subcommands to `browser-cli`; created `.claude/skills/browser-tester.md` with 7 test scenarios
+- Created issues #81–#85 (visual improvements: gradients, text decoration, image rendering, DOM API, flexbox)
+- Created issues #86–#90 (box model gaps: position, overflow:hidden, z-index stacking, box-shadow blur, margin collapsing)
+- Updated `docs/issue-priority.md`:
+  - Marked #72 #69 #71 #13 as ✓ done
+  - Added new **Priority 2 — Visual Fidelity** group with #81–#90
+  - Renumbered old Priority 2→3, 3→4, 4→5, 5→6, 6→7
+  - Updated dependency graph and domain closure table
+
+## Current State
+
+**Main branch is clean. All Priority 0 and Priority 1 issues done.**
+
+Priority 2 (Visual Fidelity) status — all open:
+| Issue | Title |
+|-------|-------|
+| #82 | Text Decoration & Font Variants |
+| #83 | Image: object-fit, aspect ratio, fallback |
+| #86 | position: absolute / fixed / relative / sticky |
+| #87 | overflow: hidden |
+| #88 | z-index stacking context |
+| #90 | Margin collapsing |
+| #81 | CSS Gradient Background |
+| #89 | box-shadow Gaussian blur |
+| #85 | Flexbox Completion |
+| #84 | DOM API completeness |
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Priority 2 issues are independent (no strict order) | Each fixes a distinct visual gap; can be done in any order or in parallel |
+| Ordered #82 first within Priority 2 | Bold/italic/underline visible on every single page — highest bang for effort |
+| #86 (position) before #87/#88 | Absolute/fixed positioning is a prerequisite for overflow and z-index to be meaningful |
+
+## Next Steps
+1. **Issue #82** — Text Decoration & Font Variants: synthesize bold (stroke glyph), italic (shear transform), underline/strikethrough (draw line at baseline). Files: `render.rs`, `layer_tree.rs`
+2. **Issue #83** — Image rendering: aspect ratio, object-fit, broken image fallback. Files: `render.rs`, `layout.rs`, `layer_tree.rs`
+3. Continue through Priority 2 list in order shown in `docs/issue-priority.md`
+
+## Blockers / Open Questions
+- None blocking. All issues are greenfield — no merge conflicts expected.

--- a/.claude/handoffs/2026-04-17_19-19.md
+++ b/.claude/handoffs/2026-04-17_19-19.md
@@ -1,0 +1,1 @@
+# Test handoff

--- a/.claude/handoffs/2026-04-17_19-20.md
+++ b/.claude/handoffs/2026-04-17_19-20.md
@@ -1,0 +1,32 @@
+# Handoff — 2026-04-17 19:20
+
+## Summary
+Implemented and merged #82 (Text Decoration & Font Variant Rendering). Created a `handoff.sh` shell script and updated the handoff skill/command to use it.
+
+## Done
+- PR #91 merged to `main`: bold/italic synthesis + underline/line-through/overline decorations
+  - `src/layer_tree.rs` — `PaintCommand::Text` gets `bold`, `italic`, `text_decoration: u8` fields
+  - `src/render.rs` — bold via multi-offset draw, italic via pixel shear, decorations via `tiny_skia::Rect`
+  - `src/style.rs` — `font-style` added to inherited CSS properties
+- Created `~/.local/bin/handoff.sh` — reads stdin, saves to `<cwd>/.claude/handoffs/YYYY-MM-DD_HH-MM.md` + `LATEST.md`
+- Updated `~/.claude/skills/handoff/SKILL.md` — skill now pipes content through `handoff.sh`
+- Updated `~/.claude/commands/handoff.md` — command doc updated to match
+
+## Current State
+- `main` branch: PR #91 merged (bdea6ee → includes #82)
+- `handoff.sh` live at `~/.local/bin/handoff.sh`, executable, smoke-tested
+- Priority 2 open issues remaining: #83, #86, #87, #88, #89, #90, #81, #84, #85
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Script at `~/.local/bin/` | Global utility, not project-specific |
+| Stdin interface | Composable — works with echo, cat, heredoc |
+| `set -euo pipefail` | Fail fast on bad state |
+
+## Next Steps
+1. Run `/update-priority` to mark #82 done in `docs/issue-priority.md`
+2. Next priority issue: **#83 — Image: object-fit, aspect ratio, fallback**
+
+## Blockers / Open Questions
+None

--- a/.claude/handoffs/2026-04-18_12-44.md
+++ b/.claude/handoffs/2026-04-18_12-44.md
@@ -1,0 +1,34 @@
+# Handoff — 2026-04-18 00:00
+
+## Summary
+Implemented and opened PRs for #83 (image rendering) and #86 (CSS positioned layout). #83 merged; #86 open and under review — user flagged it may not be perfect.
+
+## Done
+- PR #92 merged (#83): aspect-ratio preservation, object-fit (fill/contain/cover/none), broken-image fallback with alt text
+  - `src/layout.rs` — image sizing logic
+  - `src/layer_tree.rs` — ObjectFit enum + PaintCommand::Image struct variant
+  - `src/render.rs` — all 4 object-fit modes + draw_broken_image()
+- PR #93 opened (#86): position: relative/absolute/fixed/sticky
+  - `src/layout.rs` — PositionType enum, containing block threading, positioned children removed from normal flow
+  - `src/layer_tree.rs` — comment update only
+- docs/issue-priority.md NOT updated yet — #82 and #83 still missing ✓
+
+## Current State
+- `main` branch: PR #92 merged (clean)
+- PR #93 open: user says it may not be correct — needs investigation/testing
+- position: sticky implemented as relative only (scroll-aware sticky deferred)
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| sticky = relative for now | Scroll state not available in layout pass |
+| Keep #86 as one PR | relative/absolute/fixed/sticky are interdependent (absolute needs relative's containing block) |
+
+## Next Steps
+1. Run `/update-priority` to mark #82 and #83 done in `docs/issue-priority.md`
+2. Investigate PR #93 correctness — user flagged potential issues. Test with HTML fixture (position: absolute, fixed, relative)
+3. Fix #93 if broken, then merge
+4. Next priority after #86: #87 (overflow: hidden), #90 (margin collapsing), #85 (flexbox)
+
+## Blockers / Open Questions
+- PR #93 correctness unknown — user said "not perfect", no specific failure given yet

--- a/.claude/handoffs/2026-04-21_12-49.md
+++ b/.claude/handoffs/2026-04-21_12-49.md
@@ -1,0 +1,47 @@
+# Handoff — 2026-04-21 (end of session)
+
+## Summary
+Fixed multiple regressions introduced by the CSS margin-collapsing PR (#90): browser freeze on real pages (infinite tile loop from `f32::INFINITY` flex measurement), text clipped to every ancestor box, and flex children rendered at 10000px wide. PR #96 is open and all fixes are pushed. Also set up `drun` infrastructure and MinIO upload skill.
+
+## Done
+
+### Fixes on `feat/margin-collapsing-issue-90` (PR #96)
+- **6b1d088** `feat`: CSS margin collapsing — adjacent siblings (Case 1) and parent/first+last-child (Case 2) per spec §8.3.1
+- **a083f90** `perf`: OOM fix — reduce per-node allocations in CSS matching
+- **33880ba** `perf`: O(n²) freeze fix — restore HashMap for `sig_cache` dedup
+- **aecf899** `fix`: `layer_tree.rs` `Layer::new()` — clamp non-finite bounds to 0 to stop infinite tile loop; `layout.rs:706` — replace `f32::INFINITY` flex sentinel with `inner_width.max(vw*10).max(10_000)` (GH issue #98 created)
+- **d8b15c0** `fix`: `layer_tree.rs` traverse — stop narrowing `next_clip` at every ancestor; text was being clipped to parent content-box even with `overflow:visible`
+- **2734ccf** `fix`: `layout.rs` flex measurement — use `inner_width` instead of 10000 sentinel; clamp child widths to `inner_width` after measurement so nav links don't render at 10000px wide
+
+### Infrastructure
+- `drun` alias (`docker run --rm -v $(pwd):/app -w /app --memory=4g --cpus=0.5 --pids-limit 100`) auto-installed via `SessionStart` hook in `.claude/settings.local.json`
+- `browser-cli-reviewer` agent updated to use `drun rust:latest cargo run` — no separate build step, resource-limited
+- CLAUDE.md updated to document `drun`
+- MinIO skill created at `~/.claude/skills/minio/SKILL.md`; default bucket `agent-artifacts` at `https://s3.yunseong.dev`
+
+### Screenshots
+- Before fix: https://s3.yunseong.dev/agent-artifacts/yunseong-dev-after-fix.png (actually the "after" — no before was saved)
+
+## Current State
+- PR #96 open, all 6 commits pushed, `cargo test` passes (15 unit + integration tests)
+- `browser-cli-reviewer` returns PASS for both `https://yunseong.dev` and `https://google.com`
+- Rendering visually improved: navbar horizontal, text not clipped — but some content still missing (project title links inside flex containers may not be rendering)
+- `drun` SessionStart hook written but requires session restart to activate
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Use `inner_width` for flex measurement (not INFINITY or 10000 sentinel) | Block children expand to fill sentinel; caused 10000px-wide elements clipping off viewport |
+| Keep `Layer::new()` INFINITY guard | Defense-in-depth even after fixing the source |
+| Stop propagating `next_clip` through every ancestor | CSS default is `overflow:visible`; clipping should only apply for explicit `overflow:hidden` |
+| Use `drun rust:latest cargo run` in reviewer (not pre-built binary) | Ensures Docker resource limits on dangerous CLI test execution |
+
+## Next Steps
+1. Merge PR #96 after review
+2. Investigate remaining missing content: project title links (e.g. "Metropolitan Ring Road System") inside flex containers not rendering — likely another flex layout bug
+3. Update issue priority doc (`/update-priority`) — issues #90, #98 may be closable after merge
+4. Continue with next priority issue from `docs/issue-priority.md`
+
+## Blockers / Open Questions
+- Some project section headings still missing in rendered output — root cause not yet identified (flex row children with block links?)
+- `drun` hook needs session restart to take effect — verify it works at next session start

--- a/.claude/handoffs/2026-04-21_14-35.md
+++ b/.claude/handoffs/2026-04-21_14-35.md
@@ -1,0 +1,32 @@
+# Handoff — 2026-04-21 (session end)
+
+## Summary
+Fixed the development pipeline: synced issue priority doc with GitHub, identified render hang root cause (~200ms/test in debug), and hardened the CLI review process by removing Xvfb in favor of `--no-gui` + `drun rust:latest` for safe, resource-limited execution.
+
+## Done
+- `docs/issue-priority.md`: marked 18 newly closed issues ✓ (#82, #83, #90, #30–#33, #22, #25, #38, #40, #27–#29, #19, #60–#62). Domains #4, #6, #7, #2 now complete.
+- `.claude/agents/browser-cli-reviewer.md`: removed Xvfb + `drun rust:latest cargo run` approach. New flow: `cargo build --bins` on host → `drun rust:latest ./target/debug/browser-daemon --no-gui` → `drun rust:latest timeout 30s ./target/debug/browser-cli navigate`. Tests both yunseong.dev and google.com.
+- `CLAUDE.md`: added safe test commands section (`cargo test --lib` for fast, `timeout 300s cargo test -- --test-threads=2` for full suite, `--skip test_large_css`). Added "Execution Safety Rules" table: build on host, run risky processes inside `drun rust:latest`.
+- `.claude/skills/develop-priority/SKILL.md`: removed wrong conditional "cli-reviewer only needed if daemon/cli changed" — now always runs reviewer before PR.
+
+## Current State
+- Branch: `feat/css-gradient-issue-81` — modified files `src/css.rs`, `src/layer_tree.rs`, `src/render.rs` (gradient work, uncommitted changes)
+- `tests/test_pipeline.rs` and `tests/test_perf_large_css.rs` exist as untracked files with gradient tests already written
+- All pipeline tests pass individually; full `cargo test` exceeds 120s due to ~200ms render cost per test in debug mode
+- `docs/issue-priority.md` is up to date with GitHub
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Build on host, run via `drun rust:latest` | Host build uses `~/.cargo` cache (fast); `rust:latest` provides compatible Debian/glibc env + hard resource caps (4GB/0.5CPU/100pids) |
+| `--no-gui` on daemon | Removes GUI event loop entirely — no Xvfb needed, no blocking `eframe::run_native` |
+| `cargo test --lib` for quick checks | Pipeline/integration tests each trigger a full 800px render (~200ms debug); unit tests skip render entirely |
+| Always run cli-reviewer before PR | Tests verify no crash, not visual correctness — only CLI reviewer confirms actual rendering |
+
+## Next Steps
+1. Commit or stash the uncommitted gradient changes in `src/css.rs`, `src/layer_tree.rs`, `src/render.rs`
+2. Run `/develop-priority` → next open issue is **#81 (CSS Gradient Background)** — already partially implemented per the modified files
+3. Before PR on #81: run `browser-cli-reviewer` agent using the new `--no-gui` + `drun rust:latest` flow
+
+## Blockers / Open Questions
+- Gradient implementation (#81) appears to be in-progress (modified src files, gradient tests exist) but no commit yet — verify current state before starting developer agent

--- a/.claude/handoffs/LATEST.md
+++ b/.claude/handoffs/LATEST.md
@@ -1,0 +1,32 @@
+# Handoff — 2026-04-21 (session end)
+
+## Summary
+Fixed the development pipeline: synced issue priority doc with GitHub, identified render hang root cause (~200ms/test in debug), and hardened the CLI review process by removing Xvfb in favor of `--no-gui` + `drun rust:latest` for safe, resource-limited execution.
+
+## Done
+- `docs/issue-priority.md`: marked 18 newly closed issues ✓ (#82, #83, #90, #30–#33, #22, #25, #38, #40, #27–#29, #19, #60–#62). Domains #4, #6, #7, #2 now complete.
+- `.claude/agents/browser-cli-reviewer.md`: removed Xvfb + `drun rust:latest cargo run` approach. New flow: `cargo build --bins` on host → `drun rust:latest ./target/debug/browser-daemon --no-gui` → `drun rust:latest timeout 30s ./target/debug/browser-cli navigate`. Tests both yunseong.dev and google.com.
+- `CLAUDE.md`: added safe test commands section (`cargo test --lib` for fast, `timeout 300s cargo test -- --test-threads=2` for full suite, `--skip test_large_css`). Added "Execution Safety Rules" table: build on host, run risky processes inside `drun rust:latest`.
+- `.claude/skills/develop-priority/SKILL.md`: removed wrong conditional "cli-reviewer only needed if daemon/cli changed" — now always runs reviewer before PR.
+
+## Current State
+- Branch: `feat/css-gradient-issue-81` — modified files `src/css.rs`, `src/layer_tree.rs`, `src/render.rs` (gradient work, uncommitted changes)
+- `tests/test_pipeline.rs` and `tests/test_perf_large_css.rs` exist as untracked files with gradient tests already written
+- All pipeline tests pass individually; full `cargo test` exceeds 120s due to ~200ms render cost per test in debug mode
+- `docs/issue-priority.md` is up to date with GitHub
+
+## Decisions
+| Decision | Reason |
+|----------|--------|
+| Build on host, run via `drun rust:latest` | Host build uses `~/.cargo` cache (fast); `rust:latest` provides compatible Debian/glibc env + hard resource caps (4GB/0.5CPU/100pids) |
+| `--no-gui` on daemon | Removes GUI event loop entirely — no Xvfb needed, no blocking `eframe::run_native` |
+| `cargo test --lib` for quick checks | Pipeline/integration tests each trigger a full 800px render (~200ms debug); unit tests skip render entirely |
+| Always run cli-reviewer before PR | Tests verify no crash, not visual correctness — only CLI reviewer confirms actual rendering |
+
+## Next Steps
+1. Commit or stash the uncommitted gradient changes in `src/css.rs`, `src/layer_tree.rs`, `src/render.rs`
+2. Run `/develop-priority` → next open issue is **#81 (CSS Gradient Background)** — already partially implemented per the modified files
+3. Before PR on #81: run `browser-cli-reviewer` agent using the new `--no-gui` + `drun rust:latest` flow
+
+## Blockers / Open Questions
+- Gradient implementation (#81) appears to be in-progress (modified src files, gradient tests exist) but no commit yet — verify current state before starting developer agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,24 +12,71 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Build
 cargo build
 
-# Run the browser
+# Build all binaries (daemon + cli + browser)
+cargo build --bins
+
+# Run the browser (opens GUI window — blocks until closed)
 cargo run
 
 # Run with release optimizations
 cargo run --release
-
-# Run tests
-cargo test
-
-# Run a single test
-cargo test <test_name>
 
 # Check for compile errors without building
 cargo check
 
 # Lint
 cargo clippy
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+# Fast: unit tests only — no render, completes in <5s
+cargo test --lib
+
+# Integration tests for a single file — each render call takes ~200ms in debug
+cargo test --test test_pipeline
+
+# Full suite — slow (~3+ min in debug due to render cost per test); always wrap
+# with timeout to prevent session hang
+timeout 300s cargo test -- --test-threads=2
+
+# Single test by name
+cargo test <test_name>
+
+# Skip the heavy perf tests (each takes 6+ seconds)
+cargo test -- --skip test_large_css --skip test_render_time_scaling
+
+# ── Manual CLI testing (headless, no GUI, no Xvfb) ──────────────────────────
+
+# Step 1: Build on host (uses local cargo cache — fast)
+cargo build --bins
+
+# Step 2: Run daemon inside drun rust:latest (resource-limited, compatible env)
+drun --network host rust:latest ./target/debug/browser-daemon --no-gui --port 7070 &
+
+# Step 3: Navigate — also inside drun rust:latest
+sleep 4 && drun --network host rust:latest timeout 30s ./target/debug/browser-cli navigate https://yunseong.dev
 ```
+
+## Execution Safety Rules
+
+**Always build on host, run risky processes inside `drun rust:latest`.**
+
+- Build on host: uses local `~/.cargo` cache — fast, incremental
+- Run inside `drun rust:latest`: same Rust/Debian environment the binary was compiled for, plus hard resource caps (4 GB RAM / 0.5 CPU / 100 pids) — a hang or OOM kills the container cleanly, not the session
+
+`drun` = `docker run --rm -v $(pwd):/app -w /app --memory=4g --cpus=0.5 --pids-limit 100`
+Installed by the SessionStart hook at `~/.local/bin/drun`.
+
+| Situation | Safe command |
+|---|---|
+| Compile / check / lint | `cargo build`, `cargo check`, `cargo clippy` — host only, safe |
+| Unit tests (no render) | `cargo test --lib` — host only, fast (<5s) |
+| Integration tests (render) | `timeout 300s cargo test -- --test-threads=2` — timeout required |
+| Run full browser (GUI) | **Never run directly** — GUI event loop blocks forever |
+| Run daemon headless | `cargo build --bins && drun --network host rust:latest ./target/debug/browser-daemon --no-gui` |
+| Run CLI navigate | `drun --network host rust:latest timeout 30s ./target/debug/browser-cli navigate <url>` |
+
+**Why drun for execution**: each render allocates a large Pixmap (~800×N×4 bytes). A hang or OOM in the render path kills the Docker container cleanly instead of freezing the session.
 
 ## Architecture
 
@@ -44,7 +91,8 @@ The pipeline runs: **Network → DOM → Style → Layout → Render → GUI**
 | `css.rs` | Custom CSS parser. Defines `Value`, `Unit`, `Color`, `Selector`, `Rule`, `Stylesheet`. Supports `px`/`vw`/`vh`/`em` units and color keywords. Selector specificity computed as `(id, class, tag)`. |
 | `style.rs` | Builds a `StyledNode` tree from a DOM `Handle` and a `Stylesheet`. Handles CSS inheritance (`color`, `font-size`, `font-family`), selector matching, and inline `style` attributes. Extracts `<style>` blocks and `<link rel=stylesheet>` hrefs. |
 | `layout.rs` | Converts a `StyledNode` tree into a `LayoutBox` tree with computed `Rect` positions. Supports `Block`, `Inline`, `InlineBlock`, `ListItem`, `Table`/`TableRow`/`TableCell`, `Input`, and `Image` display types. Returns `(layout_tree, _, final_y)` from `build_layout_tree`. |
-| `render.rs` | Walks the `LayoutBox` tree and paints into a `tiny_skia::Pixmap`. Handles text (via `ab_glyph`), background colors, borders, and images. |
+| `layer_tree.rs` | Builds a `PaintCommand` list from the `LayoutBox` tree. Emits `PushClip`/`PopClip` commands for boxes with `overflow: hidden` (with optional `border-radius` rounding). |
+| `render.rs` | Walks the `LayoutBox` tree and paints into a `tiny_skia::Pixmap`. Handles text (via `ab_glyph`), background colors, borders, images, and clip masks (`overflow: hidden`). |
 | `js.rs` | Wraps `boa_engine` (`Context`). `JsRuntime::new()` installs mock globals (`window`, `document`, `navigator`, `console.log`). `execute()` runs script strings, silently skipping `import.meta` and suppressing repetitive DOM errors. |
 
 ### Key data-flow details
@@ -57,6 +105,20 @@ The pipeline runs: **Network → DOM → Style → Layout → Render → GUI**
 ### Fixed viewport width
 
 The render width is hardcoded to **800 px** (`src/main.rs:155`). Height is computed from layout (clamped 600–16384 px).
+
+## CLI Review (browser-cli-reviewer agent)
+
+The developer agent **must always** invoke the `browser-cli-reviewer` agent before creating a PR — for every issue, regardless of which files changed. `cargo test` and `cargo clippy` verify code correctness only; the CLI reviewer verifies the browser actually runs and renders pages correctly.
+
+The `browser-cli-reviewer` agent:
+- Runs `cargo build --bins` to build fresh binaries
+- Starts `./target/debug/browser-daemon --no-gui --port 7070` (headless HTTP server — no GUI event loop, no Xvfb needed)
+- Runs `./target/debug/browser-cli navigate <url>` with `timeout 30s` against **both** `https://yunseong.dev` and `https://google.com`
+- Returns **PASS** or **NONPASS** with full output and diagnosis
+
+All CLI commands are wrapped with `timeout` to prevent infinite loops from hanging the session.
+
+If the reviewer returns **NONPASS**, fix the issue and re-run the reviewer before proceeding to PR.
 
 ## Issue Priority
 

--- a/docs/issue-priority.md
+++ b/docs/issue-priority.md
@@ -10,80 +10,98 @@ Must be done in order. Foundational infrastructure — unlocks headless testing,
 
 | # | Issue | Why first |
 |---|---|---|
-| #68 | Extract Headless BrowserEngine | Decouples engine from GUI. All other daemon/CLI work depends on this. |
-| #70 | Browser Daemon (engine + GUI + HTTP server) | Single process: engine + eframe GUI + axum HTTP. CLI and GUI share state. |
-| #72 | Refactor BrowserApp as daemon GUI module | BrowserApp uses `Arc<Mutex<BrowserEngine>>` directly. No engine logic in main.rs. |
-| #69 | CLI HTTP client (Markdown + REPL) | Thin HTTP client to daemon. Markdown renderer + interactive REPL. |
-| #71 | Browser Tester Agent | Project-local skill. Drives CLI to test all browser features. |
+| #68 | ~~Extract Headless BrowserEngine~~ ✓ | Decouples engine from GUI. All other daemon/CLI work depends on this. |
+| #70 | ~~Browser Daemon (engine + GUI + HTTP server)~~ ✓ | Single process: engine + eframe GUI + axum HTTP. CLI and GUI share state. |
+| #72 | ~~Refactor BrowserApp as daemon GUI module~~ ✓ | BrowserApp uses `Arc<Mutex<BrowserEngine>>` directly. No engine logic in main.rs. |
+| #69 | ~~CLI HTTP client (Markdown + REPL)~~ ✓ | Thin HTTP client to daemon. Markdown renderer + interactive REPL. |
+| #71 | ~~Browser Tester Agent~~ ✓ | Project-local skill. Drives CLI to test all browser features. |
 
 ---
 
 ## Priority 1 — Layout Correctness
 
-These unblock domain issue #4 (Complete Layout Contexts).
-
 | # | Issue | Why first |
 |---|---|---|
-| #13 | Intrinsic & Extrinsic Sizing | `min-content`/`max-content` needed for correct table, image, and shrink-wrap sizing. No dependencies. |
+| #13 | ~~Intrinsic & Extrinsic Sizing~~ ✓ | `min-content`/`max-content` needed for correct table, image, and shrink-wrap sizing. |
 
 ---
 
-## Priority 2 — Compositor Pipeline
+## Priority 2 — Visual Fidelity (Box Model & Rendering)
+
+Make the browser look like a real browser. Independent issues — do in any order within this group.
+Together they close domain issue #5 (High-Fidelity Rendering) and much of #4 (Layout Contexts).
+
+| # | Issue | Why this order |
+|---|---|---|
+| #82 | ~~Text Decoration & Font Variants~~ ✓ | Highest impact — bold/italic/underline visible on every page. No dependencies. |
+| #83 | ~~Image: object-fit, aspect ratio, fallback~~ ✓ | Fixes distorted images. No dependencies. |
+| #86 | ~~position: absolute / fixed / relative / sticky~~ ✓ | Modals, dropdowns, navbars all broken without this. |
+| #87 | ~~overflow: hidden — clip content to box~~ ✓ | Content bleeds outside cards/containers. |
+| #88 | ~~z-index stacking context~~ ✓ | Overlapping elements in wrong order. |
+| #90 | ~~Margin collapsing~~ ✓ | Doubled spacing everywhere on body text. |
+| #81 | CSS Gradient Background | Buttons, hero sections. No dependencies. |
+| #89 | box-shadow Gaussian blur | Soft shadow edges. No dependencies. |
+| #85 | Flexbox Completion — wrap, align, justify, gap | Navbars/card grids look wrong. |
+| #84 | DOM API — querySelector, classList, addEventListener | JS-driven UI. |
+
+---
+
+## Priority 3 — Compositor Pipeline
 
 Must be done in order — each issue depends on the previous.
 Together they close domain issue #5 (High-Fidelity Rendering).
 
 | # | Issue | Why this order |
 |---|---|---|
-| #30 | Layer Tree Builder | Defines `Layer`/`LayerTree` structs. Everything else builds on this. |
-| #32 | Compositor Transform & Matrix Engine | Matrix math needed by #33 for applying transforms/opacity. |
-| #31 | Tile & Texture Management | Texture pool needed by #33 for drawing layer content. |
-| #33 | Layer Blending & Composition Loop | Final step — composites all layers to screen. Requires #30, #31, #32. |
+| #30 | ~~Layer Tree Builder~~ ✓ | Defines `Layer`/`LayerTree` structs. Everything else builds on this. |
+| #32 | ~~Compositor Transform & Matrix Engine~~ ✓ | Matrix math needed by #33 for applying transforms/opacity. |
+| #31 | ~~Tile & Texture Management~~ ✓ | Texture pool needed by #33 for drawing layer content. |
+| #33 | ~~Layer Blending & Composition Loop~~ ✓ | Final step — composites all layers to screen. Requires #30, #31, #32. |
 
 ---
 
-## Priority 3 — Event Loop
+## Priority 4 — Event Loop
 
 Must be done in order. Closes domain issue #6 (Runtime & Interactivity).
 
 | # | Issue | Why this order |
 |---|---|---|
-| #22 | Event Loop: Macro/Micro Task Integration | Foundation. #38 and #40 both depend on this. |
-| #38 | Render-step Orchestrator | `requestAnimationFrame` — depends on #22's task queue. |
-| #40 | Idle Callback Scheduler | `requestIdleCallback` — depends on #22's idle slot detection. |
-| #25 | Focus Management & Sequential Navigation | Tab/focus state. Depends on event loop being stable. |
+| #22 | ~~Event Loop: Macro/Micro Task Integration~~ ✓ | Foundation. #38 and #40 both depend on this. |
+| #38 | ~~Render-step Orchestrator~~ ✓ | `requestAnimationFrame` — depends on #22's task queue. |
+| #40 | ~~Idle Callback Scheduler~~ ✓ | `requestIdleCallback` — depends on #22's idle slot detection. |
+| #25 | ~~Focus Management & Sequential Navigation~~ ✓ | Tab/focus state. Depends on event loop being stable. |
 
 ---
 
-## Priority 4 — Security Model
+## Priority 5 — Security Model
 
 All three are independent of each other. Closes domain issue #7.
 
 | # | Issue | Why this order |
 |---|---|---|
-| #27 | CORS Enforcement Layer | Most commonly hit by real pages. |
-| #28 | Origin-Based Storage & SOP | Builds on CORS concepts. |
-| #29 | Content Security Policy Engine | Additive on top of #27/#28. |
+| #27 | ~~CORS Enforcement Layer~~ ✓ | Most commonly hit by real pages. |
+| #28 | ~~Origin-Based Storage & SOP~~ ✓ | Builds on CORS concepts. |
+| #29 | ~~Content Security Policy Engine~~ ✓ | Additive on top of #27/#28. |
 
 ---
 
-## Priority 5 — Parser
+## Priority 6 — Parser
 
 | # | Issue | Why last |
 |---|---|---|
-| #19 | WHATWG-compliant HTML5 Tokenizer | `html5ever` already handles this correctly. Custom implementation is spec completeness, not a visible improvement. |
+| #19 | ~~WHATWG-compliant HTML5 Tokenizer~~ ✓ | `html5ever` already handles this correctly. Custom implementation is spec completeness, not a visible improvement. |
 
 ---
 
-## Priority 6 — HTML & CSS Engine Perfection (Performance & Stability)
+## Priority 7 — HTML & CSS Engine Perfection (Performance & Stability)
 
 Addresses severe crashes (OOM/Stack overflow) and massive rendering latency (>1.5s) on real-world pages.
 
 | # | Issue | Why this order |
 |---|---|---|
-| #60 | Parallel Async CSS Fetching & Processing | Blocking the main thread for 1.3s during CSS parsing makes the browser unusable. Fix network first. |
-| #61 | Style Tree Memory Optimization (OOM) | Creating HashMaps for every DOM node causes massive OOM on large sites. |
-| #62 | CSS Parser & Selector Matching Opt | O(N*M) selector matching is painfully slow. We need Right-to-Left matching and caches. |
+| #60 | ~~Parallel Async CSS Fetching & Processing~~ ✓ | Blocking the main thread for 1.3s during CSS parsing makes the browser unusable. Fix network first. |
+| #61 | ~~Style Tree Memory Optimization (OOM)~~ ✓ | Creating HashMaps for every DOM node causes massive OOM on large sites. |
+| #62 | ~~CSS Parser & Selector Matching Opt~~ ✓ | O(N*M) selector matching is painfully slow. We need Right-to-Left matching and caches. |
 | #63 | Layout Engine Recursion & Scalability | Deeply nested DOMs crash the layout engine with stack overflows. Convert to iterative trees. |
 
 ---
@@ -94,6 +112,8 @@ Addresses severe crashes (OOM/Stack overflow) and massive rendering latency (>1.
 #68 → #70 → #72
 #68 → #70 → #69 → #71
 #13
+#82, #83, #86, #87, #88, #89, #90 (independent)
+#81, #84, #85 (independent)
 #30 → #32 → #31 → #33
 #22 → #38
 #22 → #40
@@ -109,11 +129,11 @@ Addresses severe crashes (OOM/Stack overflow) and massive rendering latency (>1.
 
 | Domain issue | Closes when |
 |---|---|
-| Daemon/CLI Infrastructure | #68 #69 #70 #71 #72 done |
-| #4 Complete Layout Contexts | #13 done |
-| #5 High-Fidelity Rendering | #30 #31 #32 #33 done |
-| #6 Runtime & Interactivity | #22 #25 #38 #40 done |
-| #7 Resource Loading & Security | #27 #28 #29 done |
-| #2 Standard HTML5 & CSS Parsing | #19 done |
+| Daemon/CLI Infrastructure | #68 #69 #70 #71 #72 done ✓ |
+| #4 Complete Layout Contexts | #13 #86 #87 #90 done ✓ |
+| #5 High-Fidelity Rendering | #81 #82 #83 #85 #88 #89 #30 #31 #32 #33 done |
+| #6 Runtime & Interactivity | #22 #25 #38 #40 done ✓ |
+| #7 Resource Loading & Security | #27 #28 #29 done ✓ |
+| #2 Standard HTML5 & CSS Parsing | #19 done ✓ |
 | Perfecting Engine (Performance) | #60 #61 #62 #63 done |
 | #1 Vision | all domains done |

--- a/src/css.rs
+++ b/src/css.rs
@@ -17,6 +17,60 @@ pub fn intern(s: &str) -> Arc<str> {
     arc
 }
 
+/// A single color stop inside a CSS gradient.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CssColorStop {
+    pub color: Color,
+    /// Position in [0.0, 1.0]. `None` means "auto-distribute".
+    pub position: Option<f32>,
+}
+
+impl Hash for CssColorStop {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.color.hash(state);
+        match self.position {
+            Some(f) => f.to_bits().hash(state),
+            None => 0u32.hash(state),
+        }
+    }
+}
+
+impl Eq for CssColorStop {}
+
+/// The direction / angle for a linear gradient.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LinearDirection {
+    /// Angle in radians, measured clockwise from "up" (12 o'clock).
+    Angle(f32),
+    /// `to <side>` keyword: (dx, dy) unit vector in CSS geometry (+y = down).
+    ToSide(f32, f32),
+}
+
+impl Hash for LinearDirection {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            LinearDirection::Angle(f) => f.to_bits().hash(state),
+            LinearDirection::ToSide(x, y) => { x.to_bits().hash(state); y.to_bits().hash(state); }
+        }
+    }
+}
+
+impl Eq for LinearDirection {}
+
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+pub enum GradientValue {
+    Linear {
+        direction: LinearDirection,
+        stops: Vec<CssColorStop>,
+    },
+    Radial {
+        /// `true` = circle, `false` = ellipse (we render both as circle for simplicity).
+        circle: bool,
+        stops: Vec<CssColorStop>,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Keyword(Arc<str>),
@@ -34,6 +88,8 @@ pub enum Value {
     /// Used internally so that custom property values can be re-parsed when resolved
     /// by a `var()` reference on another property.
     RawCustomProp(Arc<str>),
+    /// CSS gradient: `linear-gradient(...)` or `radial-gradient(...)`.
+    Gradient(GradientValue),
 }
 
 impl Eq for Value {}
@@ -57,6 +113,7 @@ impl Hash for Value {
                 fallback.hash(state);
             }
             Value::RawCustomProp(s) => s.hash(state),
+            Value::Gradient(g) => g.hash(state),
         }
     }
 }
@@ -545,6 +602,187 @@ pub fn parse_box_shadow(s: &str) -> Option<BoxShadow> {
     })
 }
 
+/// Split gradient arguments by top-level commas (ignoring commas inside `rgb()` etc.).
+fn split_gradient_args(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut depth: i32 = 0;
+    for c in s.chars() {
+        match c {
+            '(' => { depth += 1; current.push(c); }
+            ')' => { depth -= 1; current.push(c); }
+            ',' if depth == 0 => {
+                let t = current.trim().to_string();
+                if !t.is_empty() { parts.push(t); }
+                current.clear();
+            }
+            _ => current.push(c),
+        }
+    }
+    let t = current.trim().to_string();
+    if !t.is_empty() { parts.push(t); }
+    parts
+}
+
+/// Parse a single color stop like `#ff0`, `red`, `blue 30%`, `rgba(0,0,0,0.5) 100%`.
+fn parse_color_stop(s: &str) -> Option<CssColorStop> {
+    let s = s.trim();
+    // Find the split point: last whitespace not inside parens.
+    let mut depth: i32 = 0;
+    let mut last_space: Option<usize> = None;
+    for (i, c) in s.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => depth -= 1,
+            ' ' | '\t' if depth == 0 => last_space = Some(i),
+            _ => {}
+        }
+    }
+
+    let (color_str, position) = if let Some(sp) = last_space {
+        let possible_pos = s[sp + 1..].trim();
+        if possible_pos.ends_with('%') || possible_pos.ends_with("px") {
+            (&s[..sp], Some(possible_pos))
+        } else {
+            (s, None)
+        }
+    } else {
+        (s, None)
+    };
+
+    let color = parse_color(color_str.trim())?;
+    let pos = position.map(|p| {
+        if p.ends_with('%') {
+            p.trim_end_matches('%').parse::<f32>().unwrap_or(0.0) / 100.0
+        } else {
+            // px positions are not normalized here; we treat them as ratios (best-effort)
+            p.trim_end_matches("px").parse::<f32>().unwrap_or(0.0) / 100.0
+        }
+    });
+
+    Some(CssColorStop { color, position: pos })
+}
+
+/// Parse `linear-gradient(...)` or `radial-gradient(...)`. Returns `None` on failure.
+pub fn parse_gradient(val: &str) -> Option<GradientValue> {
+    let val = val.trim();
+
+    let (is_linear, inner) = if let Some(rest) = val.strip_prefix("linear-gradient(").and_then(|r| r.strip_suffix(')')) {
+        (true, rest)
+    } else if let Some(rest) = val.strip_prefix("radial-gradient(").and_then(|r| r.strip_suffix(')')) {
+        (false, rest)
+    } else {
+        return None;
+    };
+
+    let args = split_gradient_args(inner);
+    if args.is_empty() { return None; }
+
+    if is_linear {
+        // First arg may be a direction keyword or angle.
+        let mut stop_start = 0;
+        let direction = {
+            let first = args[0].trim().to_lowercase();
+            if first.ends_with("deg") {
+                // e.g. "90deg"
+                let deg: f32 = first.trim_end_matches("deg").parse().unwrap_or(0.0);
+                stop_start = 1;
+                LinearDirection::Angle(deg.to_radians())
+            } else if first.starts_with("to ") {
+                let side = first[3..].trim();
+                let (dx, dy) = match side {
+                    "right"        => (1.0_f32, 0.0_f32),
+                    "left"         => (-1.0, 0.0),
+                    "bottom"       => (0.0, 1.0),
+                    "top"          => (0.0, -1.0),
+                    "right bottom" | "bottom right" => (1.0, 1.0),
+                    "right top"    | "top right"    => (1.0, -1.0),
+                    "left bottom"  | "bottom left"  => (-1.0, 1.0),
+                    "left top"     | "top left"     => (-1.0, -1.0),
+                    _              => (0.0, 1.0),
+                };
+                stop_start = 1;
+                LinearDirection::ToSide(dx, dy)
+            } else {
+                // No explicit direction — default is "to bottom" (top → bottom)
+                LinearDirection::ToSide(0.0, 1.0)
+            }
+        };
+
+        let stops: Vec<CssColorStop> = args[stop_start..]
+            .iter()
+            .filter_map(|s| parse_color_stop(s))
+            .collect();
+
+        if stops.len() < 2 { return None; }
+
+        // Auto-distribute stops that have no explicit position.
+        let stops = auto_distribute_stops(stops);
+        Some(GradientValue::Linear { direction, stops })
+    } else {
+        // radial-gradient: first arg may be shape keyword.
+        let mut stop_start = 0;
+        let first = args[0].trim().to_lowercase();
+        let circle = if first == "circle" || first.starts_with("circle ") {
+            stop_start = 1;
+            true
+        } else if first == "ellipse" || first.starts_with("ellipse ") || first.starts_with("closest") || first.starts_with("farthest") {
+            stop_start = 1;
+            false
+        } else {
+            false
+        };
+
+        let stops: Vec<CssColorStop> = args[stop_start..]
+            .iter()
+            .filter_map(|s| parse_color_stop(s))
+            .collect();
+
+        if stops.len() < 2 { return None; }
+
+        let stops = auto_distribute_stops(stops);
+        Some(GradientValue::Radial { circle, stops })
+    }
+}
+
+/// Assign evenly-spaced positions to any stops that don't have an explicit position.
+fn auto_distribute_stops(mut stops: Vec<CssColorStop>) -> Vec<CssColorStop> {
+    // If the first stop has no position, assign 0.0.
+    if stops[0].position.is_none() {
+        stops[0].position = Some(0.0);
+    }
+    // If the last stop has no position, assign 1.0.
+    let last = stops.len() - 1;
+    if stops[last].position.is_none() {
+        stops[last].position = Some(1.0);
+    }
+    // Fill in any remaining None positions by linear interpolation between
+    // the nearest positioned neighbors.
+    let n = stops.len();
+    let mut i = 0;
+    while i < n {
+        if stops[i].position.is_none() {
+            // Find the next stop that has a position.
+            let mut j = i + 1;
+            while j < n && stops[j].position.is_none() {
+                j += 1;
+            }
+            // Interpolate between stops[i-1] and stops[j].
+            let start_pos = stops[i - 1].position.unwrap_or(0.0);
+            let end_pos = stops[j].position.unwrap_or(1.0);
+            let count = (j - i + 1) as f32;
+            for k in i..j {
+                let t = (k - i + 1) as f32 / count;
+                stops[k].position = Some(start_pos + t * (end_pos - start_pos));
+            }
+            i = j + 1;
+        } else {
+            i += 1;
+        }
+    }
+    stops
+}
+
 pub fn parse_value(val: &str) -> Value {
     let val = val.trim();
     // Strip !important
@@ -580,6 +818,13 @@ pub fn parse_value(val: &str) -> Value {
         if name_str.starts_with("--") {
             let fallback = fallback_str.map(|fb| Box::new(parse_value(fb)));
             return Value::CssVar { name: intern(name_str), fallback };
+        }
+    }
+
+    // gradient: linear-gradient(...) or radial-gradient(...)
+    if val.starts_with("linear-gradient(") || val.starts_with("radial-gradient(") {
+        if let Some(g) = parse_gradient(val) {
+            return Value::Gradient(g);
         }
     }
 
@@ -817,6 +1062,74 @@ mod tests {
         let s = parse_selector("div .bar");
         // The rightmost selector part is .bar, so key should be Class("bar")
         assert_eq!(s.key_feature(), SelectorKey::Class("bar".to_string()));
+    }
+
+    #[test]
+    fn test_parse_linear_gradient_to_right() {
+        let v = parse_value("linear-gradient(to right, #ff0, #f00)");
+        match v {
+            Value::Gradient(GradientValue::Linear { direction, stops }) => {
+                assert!(matches!(direction, LinearDirection::ToSide(dx, _) if dx > 0.0));
+                assert_eq!(stops.len(), 2);
+                assert_eq!(stops[0].position, Some(0.0));
+                assert_eq!(stops[1].position, Some(1.0));
+            }
+            other => panic!("expected linear gradient, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_linear_gradient_angle() {
+        let v = parse_value("linear-gradient(90deg, #fff, #000)");
+        match v {
+            Value::Gradient(GradientValue::Linear { direction, stops }) => {
+                assert!(matches!(direction, LinearDirection::Angle(_)));
+                assert_eq!(stops.len(), 2);
+            }
+            other => panic!("expected linear gradient, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_radial_gradient_circle() {
+        let v = parse_value("radial-gradient(circle, #fff, #000)");
+        match v {
+            Value::Gradient(GradientValue::Radial { circle, stops }) => {
+                assert!(circle);
+                assert_eq!(stops.len(), 2);
+                assert_eq!(stops[0].position, Some(0.0));
+                assert_eq!(stops[1].position, Some(1.0));
+            }
+            other => panic!("expected radial gradient, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_gradient_color_stops_with_percentages() {
+        let v = parse_value("linear-gradient(to right, #ff0 0%, #f00 50%, #00f 100%)");
+        match v {
+            Value::Gradient(GradientValue::Linear { stops, .. }) => {
+                assert_eq!(stops.len(), 3);
+                assert!((stops[0].position.unwrap() - 0.0).abs() < 1e-5);
+                assert!((stops[1].position.unwrap() - 0.5).abs() < 1e-5);
+                assert!((stops[2].position.unwrap() - 1.0).abs() < 1e-5);
+            }
+            other => panic!("expected linear gradient, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_gradient_auto_distribute_middle_stops() {
+        // Three stops: first and last have positions, middle does not.
+        let v = parse_value("linear-gradient(to right, red 0%, green, blue 100%)");
+        match v {
+            Value::Gradient(GradientValue::Linear { stops, .. }) => {
+                assert_eq!(stops.len(), 3);
+                assert!((stops[1].position.unwrap() - 0.5).abs() < 1e-5,
+                    "middle stop should be auto-distributed to 0.5, got {:?}", stops[1].position);
+            }
+            other => panic!("expected linear gradient, got {:?}", other),
+        }
     }
 }
 

--- a/src/layer_tree.rs
+++ b/src/layer_tree.rs
@@ -1,5 +1,5 @@
 use crate::layout::{LayoutBox, DisplayType, PositionType, Rect as LayoutRect};
-use crate::css::{Value, Color, BoxShadow, TransformOp};
+use crate::css::{Value, Color, BoxShadow, TransformOp, GradientValue, CssColorStop, LinearDirection};
 use crate::matrix::{Matrix3x3, Matrix4x4};
 use markup5ever_rcdom::NodeData;
 
@@ -47,6 +47,19 @@ pub enum PaintCommand {
     },
     /// Outer box-shadow
     Shadow(LayoutRect, BoxShadow),
+    /// CSS `linear-gradient()` background fill.
+    LinearGradient {
+        rect: LayoutRect,
+        direction: LinearDirection,
+        stops: Vec<CssColorStop>,
+        radius: f32,
+    },
+    /// CSS `radial-gradient()` background fill.
+    RadialGradient {
+        rect: LayoutRect,
+        stops: Vec<CssColorStop>,
+        radius: f32,
+    },
     /// Push a clip region onto the clip stack.
     /// All subsequent commands are clipped to `rect` (optionally with rounded corners
     /// when `radius` > 0). Paired with `PopClip`.
@@ -475,10 +488,50 @@ impl LayerTreeBuilder {
         }
 
         // Background
-        let bg = sv.get(&crate::css::intern("background-color")).or_else(|| sv.get(&crate::css::intern("background")));
-        if let Some(Value::Color(c)) = bg {
-            if c.a > 0 {
+        let bg = sv.get(&crate::css::intern("background-color"))
+            .or_else(|| sv.get(&crate::css::intern("background")))
+            .or_else(|| sv.get(&crate::css::intern("background-image")));
+        match bg {
+            Some(Value::Color(c)) if c.a > 0 => {
                 commands.push(PaintCommand::Rect(d, c.clone(), radius));
+            }
+            Some(Value::Gradient(GradientValue::Linear { direction, stops })) => {
+                commands.push(PaintCommand::LinearGradient {
+                    rect: d,
+                    direction: direction.clone(),
+                    stops: stops.clone(),
+                    radius,
+                });
+            }
+            Some(Value::Gradient(GradientValue::Radial { stops, .. })) => {
+                commands.push(PaintCommand::RadialGradient {
+                    rect: d,
+                    stops: stops.clone(),
+                    radius,
+                });
+            }
+            _ => {}
+        }
+        // Also check background-image for gradients (separate from background-color)
+        if matches!(bg, Some(Value::Color(_)) | None) {
+            let bg_img = sv.get(&crate::css::intern("background-image"));
+            match bg_img {
+                Some(Value::Gradient(GradientValue::Linear { direction, stops })) => {
+                    commands.push(PaintCommand::LinearGradient {
+                        rect: d,
+                        direction: direction.clone(),
+                        stops: stops.clone(),
+                        radius,
+                    });
+                }
+                Some(Value::Gradient(GradientValue::Radial { stops, .. })) => {
+                    commands.push(PaintCommand::RadialGradient {
+                        rect: d,
+                        stops: stops.clone(),
+                        radius,
+                    });
+                }
+                _ => {}
             }
         }
 
@@ -565,6 +618,8 @@ impl LayerTreeBuilder {
                 PaintCommand::Image { rect, .. } => *rect,
                 PaintCommand::Text { rect, .. } => *rect,
                 PaintCommand::Shadow(r, ..) => *r,
+                PaintCommand::LinearGradient { rect, .. } => *rect,
+                PaintCommand::RadialGradient { rect, .. } => *rect,
                 PaintCommand::PushClip { rect, .. } => *rect,
                 PaintCommand::PopClip => continue,
             };

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,7 +1,8 @@
-use tiny_skia::{Pixmap, Paint, Transform, Stroke, PathBuilder, PixmapPaint, Mask, FillRule};
+use tiny_skia::{Pixmap, Paint, Transform, Stroke, PathBuilder, PixmapPaint, Mask, FillRule,
+    LinearGradient, RadialGradient, GradientStop, SpreadMode, Point as SkPoint};
 use ab_glyph::{Font, FontRef, PxScale, point};
 use crate::layout::{LayoutBox, Rect as LayoutRect};
-use crate::css::Color;
+use crate::css::{Color, CssColorStop, LinearDirection};
 use crate::layer_tree::{LayerTree, LayerTreeBuilder, PaintCommand, ObjectFit};
 use crate::matrix::Matrix4x4;
 use std::collections::HashMap;
@@ -259,6 +260,36 @@ fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile
                     pixmap.fill_rect(tr, &paint, transform, active_mask!());
                 }
             }
+            PaintCommand::LinearGradient { rect: r, direction, stops, radius } => {
+                if let Some(shader) = build_linear_gradient_shader(*r, direction, stops) {
+                    let mut paint = Paint::default();
+                    paint.shader = shader;
+                    paint.anti_alias = true;
+                    if *radius > 0.0 {
+                        if let Some(path) = create_rounded_rect_path(*r, *radius) {
+                            pixmap.fill_path(&path, &paint, FillRule::Winding, transform, active_mask!());
+                        }
+                    } else if let Some(tr) = tiny_skia::Rect::from_xywh(r.x, r.y, r.width, r.height) {
+                        pixmap.fill_rect(tr, &paint, transform, active_mask!());
+                    }
+                }
+            }
+
+            PaintCommand::RadialGradient { rect: r, stops, radius } => {
+                if let Some(shader) = build_radial_gradient_shader(*r, stops) {
+                    let mut paint = Paint::default();
+                    paint.shader = shader;
+                    paint.anti_alias = true;
+                    if *radius > 0.0 {
+                        if let Some(path) = create_rounded_rect_path(*r, *radius) {
+                            pixmap.fill_path(&path, &paint, FillRule::Winding, transform, active_mask!());
+                        }
+                    } else if let Some(tr) = tiny_skia::Rect::from_xywh(r.x, r.y, r.width, r.height) {
+                        pixmap.fill_rect(tr, &paint, transform, active_mask!());
+                    }
+                }
+            }
+
             PaintCommand::Border(r, w, c, radius) => {
                 let mut paint = Paint::default();
                 paint.set_color_rgba8(c.r, c.g, c.b, c.a);
@@ -568,6 +599,96 @@ fn render_text_raw(
             }
         }
     }
+}
+
+/// Convert a `CssColorStop` slice into `tiny_skia::GradientStop`s.
+fn css_stops_to_skia(stops: &[CssColorStop]) -> Vec<GradientStop> {
+    stops.iter().filter_map(|s| {
+        let pos = s.position.unwrap_or(0.0).clamp(0.0, 1.0);
+        let color = tiny_skia::Color::from_rgba8(s.color.r, s.color.g, s.color.b, s.color.a);
+        GradientStop::new(pos, color).into()
+    }).collect()
+}
+
+/// Build a tiny-skia `Shader` for a CSS `linear-gradient()`.
+fn build_linear_gradient_shader<'a>(
+    r: LayoutRect,
+    direction: &LinearDirection,
+    stops: &[CssColorStop],
+) -> Option<tiny_skia::Shader<'a>> {
+    let skia_stops = css_stops_to_skia(stops);
+    if skia_stops.len() < 2 { return None; }
+
+    // Compute start/end points from the direction and the rect bounds.
+    let cx = r.x + r.width / 2.0;
+    let cy = r.y + r.height / 2.0;
+
+    let (start, end) = match direction {
+        LinearDirection::Angle(rad) => {
+            // CSS angle: 0 = to top, 90deg = to right (clockwise from 12 o'clock).
+            // tiny-skia uses standard math coords (+y down).
+            // We want: direction vector = (sin(rad), -cos(rad)) for CSS convention.
+            let dx = rad.sin();
+            let dy = -rad.cos();
+            // Determine the distance from center to edge along that direction.
+            let half_w = r.width / 2.0;
+            let half_h = r.height / 2.0;
+            // Scale so the gradient covers the full box diagonal.
+            let scale = if dx.abs() < 1e-6 {
+                half_h / dy.abs().max(1e-6)
+            } else if dy.abs() < 1e-6 {
+                half_w / dx.abs().max(1e-6)
+            } else {
+                (half_w / dx.abs()).min(half_h / dy.abs())
+            };
+            (
+                SkPoint::from_xy(cx - dx * scale, cy - dy * scale),
+                SkPoint::from_xy(cx + dx * scale, cy + dy * scale),
+            )
+        }
+        LinearDirection::ToSide(dx, dy) => {
+            let mag = (dx * dx + dy * dy).sqrt().max(1e-6);
+            let ndx = dx / mag;
+            let ndy = dy / mag;
+            let half_w = r.width / 2.0;
+            let half_h = r.height / 2.0;
+            let scale = if ndx.abs() < 1e-6 {
+                half_h / ndy.abs().max(1e-6)
+            } else if ndy.abs() < 1e-6 {
+                half_w / ndx.abs().max(1e-6)
+            } else {
+                (half_w / ndx.abs()).min(half_h / ndy.abs())
+            };
+            (
+                SkPoint::from_xy(cx - ndx * scale, cy - ndy * scale),
+                SkPoint::from_xy(cx + ndx * scale, cy + ndy * scale),
+            )
+        }
+    };
+
+    LinearGradient::new(start, end, skia_stops, SpreadMode::Pad, Transform::identity())
+}
+
+/// Build a tiny-skia `Shader` for a CSS `radial-gradient()`.
+fn build_radial_gradient_shader<'a>(
+    r: LayoutRect,
+    stops: &[CssColorStop],
+) -> Option<tiny_skia::Shader<'a>> {
+    let skia_stops = css_stops_to_skia(stops);
+    if skia_stops.len() < 2 { return None; }
+
+    let center = SkPoint::from_xy(r.x + r.width / 2.0, r.y + r.height / 2.0);
+    let radius = (r.width.min(r.height) / 2.0).max(1.0);
+
+    RadialGradient::new(
+        center,
+        0.0,
+        center,
+        radius,
+        skia_stops,
+        SpreadMode::Pad,
+        Transform::identity(),
+    )
 }
 
 fn blend_glyph_pixel(pixmap: &mut Pixmap, x: u32, y: u32, coverage: f32, color: &Color) {

--- a/storage.json
+++ b/storage.json
@@ -1,1 +1,1 @@
-{"data":{"https://a.com":{"key":"valueA"},"https://b.com":{"key":"valueB"}}}
+{"data":{"https://b.com":{"key":"valueB"},"https://a.com":{"key":"valueA"}}}

--- a/tests/test_perf_large_css.rs
+++ b/tests/test_perf_large_css.rs
@@ -1,0 +1,85 @@
+/// Performance test: large Bootstrap-like CSS with many complex selectors.
+/// Must complete within a reasonable time (< 30s even in debug mode).
+
+use browser::engine::process_html_with_cache;
+use std::collections::HashMap;
+use url::Url;
+
+fn base_url() -> Url { Url::parse("https://test.com/").unwrap() }
+
+fn run(html: &str) -> browser::engine::PageResult {
+    let image_cache = HashMap::new();
+    let mut css_cache = HashMap::new();
+    let js_overrides = HashMap::new();
+    let (result, _) = process_html_with_cache(
+        html, &base_url(), &image_cache, &mut css_cache,
+        None, &js_overrides, None, None, None, 800.0,
+    ).expect("pipeline should not fail");
+    result
+}
+
+#[test]
+fn test_large_css_does_not_hang() {
+    use std::time::Instant;
+    
+    // 2700 rules — simulating Bootstrap-like CSS scale:
+    // 2000 simple class rules + 500 complex descendant rules + 200 tag rules
+    let mut css = String::new();
+    for i in 0..2000_usize {
+        css.push_str(&format!(".rule-{} {{ color: red; margin: {}px 0; }}\n", i, i % 20));
+    }
+    for i in 0..500_usize {
+        css.push_str(&format!(".parent-{} .child-{} {{ background: #fff; }}\n", i % 100, i % 100));
+    }
+    for i in 0..200_usize {
+        css.push_str(&format!("div.variant-{} {{ font-size: {}px; }}\n", i % 10, 14 + i % 10));
+    }
+    
+    // 500 elements with mixed classes
+    let elements: String = (0..500_usize).map(|i| {
+        format!("<div class=\"parent-{} rule-{} variant-{}\"><p class=\"child-{}\">Para {}</p></div>",
+                i % 100, i % 2000, i % 10, i % 100, i)
+    }).collect();
+    
+    let html = format!("<style>{}</style>{}", css, elements);
+    
+    let start = Instant::now();
+    let result = run(&html);
+    let elapsed = start.elapsed();
+    
+    println!("Large CSS pipeline: {:?}", elapsed);
+    assert!(result.height > 0);
+    // Should complete in under 30s even in debug mode
+    assert!(elapsed.as_secs() < 30, "Pipeline took too long: {:?}", elapsed);
+}
+
+#[test]
+fn test_render_time_scaling() {
+    use std::time::Instant;
+    
+    // Test with 50 elements
+    let elements_50: String = (0..50_usize).map(|i| {
+        format!("<div class=\"parent-{} rule-{} variant-{}\"><p class=\"child-{}\">Para {}</p></div>",
+                i % 100, i % 2000, i % 10, i % 100, i)
+    }).collect();
+    let html_50 = format!("<style>.parent-1 .child-1 {{ background: white; }}</style>{}", elements_50);
+    
+    let start = Instant::now();
+    let result_50 = run(&html_50);
+    let elapsed_50 = start.elapsed();
+    println!("50 elements: {:?}, height: {}", elapsed_50, result_50.height);
+    
+    // Test with 100 elements
+    let elements_100: String = (0..100_usize).map(|i| {
+        format!("<div><p>Para {}</p></div>", i)
+    }).collect();
+    let html_100 = elements_100;
+    
+    let start = Instant::now();
+    let result_100 = run(&html_100);
+    let elapsed_100 = start.elapsed();
+    println!("100 elements (no extra CSS): {:?}, height: {}", elapsed_100, result_100.height);
+    
+    assert!(result_50.height > 0);
+    assert!(result_100.height > 0);
+}

--- a/tests/test_pipeline.rs
+++ b/tests/test_pipeline.rs
@@ -1,0 +1,326 @@
+/// End-to-end rendering pipeline tests.
+///
+/// These tests run the full DOM → CSS matching → Layout → Render chain
+/// with representative HTML to catch hangs, panics, or regressions
+/// in any pipeline stage.
+
+use browser::engine::process_html_with_cache;
+use std::collections::HashMap;
+use url::Url;
+
+fn base_url() -> Url {
+    Url::parse("https://yunseong.dev/").unwrap()
+}
+
+fn run(html: &str, css: &str) -> browser::engine::PageResult {
+    let html_with_style = if css.is_empty() {
+        html.to_string()
+    } else {
+        format!("<style>{}</style>{}", css, html)
+    };
+    let image_cache = HashMap::new();
+    let mut css_cache = HashMap::new();
+    let js_overrides = HashMap::new();
+    let (result, _) = process_html_with_cache(
+        &html_with_style,
+        &base_url(),
+        &image_cache,
+        &mut css_cache,
+        None,
+        &js_overrides,
+        None,
+        None,
+        None,
+        800.0,
+    )
+    .expect("pipeline should not fail");
+    result
+}
+
+// ── Stage completion ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_completes_plain_paragraph() {
+    let result = run("<p>Hello, world!</p>", "");
+    assert!(result.width > 0);
+    assert!(result.height > 0);
+}
+
+#[test]
+fn test_pipeline_completes_with_css_classes() {
+    let css = r#"
+        .container { width: 760px; margin: 0 auto; padding: 20px; }
+        .title     { font-size: 32px; color: #111; margin-bottom: 16px; }
+        .subtitle  { font-size: 18px; color: #555; }
+    "#;
+    let html = r#"
+        <div class="container">
+            <h1 class="title">Yunseong Jeong</h1>
+            <p class="subtitle">Software Engineer</p>
+        </div>
+    "#;
+    let result = run(html, css);
+    assert!(result.width > 0);
+    assert!(result.height > 0);
+}
+
+// ── CSS matching correctness ──────────────────────────────────────────────────
+
+#[test]
+fn test_css_many_rules_does_not_hang() {
+    // 200 rules — stress-tests sig_cache HashMap dedup path.
+    let css: String = (0..200)
+        .map(|i| format!(".rule-{} {{ color: #000; margin: {}px; }}\n", i, i % 50))
+        .collect();
+    let html = r#"<div class="rule-0 rule-1 rule-5"><p class="rule-10">text</p></div>"#;
+    let result = run(html, &css);
+    assert!(result.height > 0);
+}
+
+#[test]
+fn test_css_specificity_order_preserved() {
+    // ID > class > tag — background-color of #box should be blue (highest spec).
+    let css = r#"
+        div            { background-color: red; }
+        .box           { background-color: green; }
+        #box           { background-color: blue; }
+    "#;
+    let html = r#"<div id="box" class="box" style="width:100px;height:100px;"></div>"#;
+    let result = run(html, css);
+    assert!(result.height > 0);
+}
+
+#[test]
+fn test_important_overrides_normal() {
+    let css = r#"
+        p { color: red !important; }
+        p { color: blue; }
+    "#;
+    let html = "<p>text</p>";
+    let result = run(html, css);
+    assert!(result.height > 0);
+}
+
+// ── Layout correctness ───────────────────────────────────────────────────────
+
+#[test]
+fn test_layout_produces_links() {
+    let html = r#"
+        <nav>
+            <a href="/about">About</a>
+            <a href="/posts">Posts</a>
+            <a href="https://github.com/dev-yunseong">GitHub</a>
+        </nav>
+    "#;
+    let result = run(html, "");
+    assert_eq!(result.links.len(), 3);
+    assert!(result.links.iter().any(|(_, href)| href.contains("about")));
+    assert!(result.links.iter().any(|(_, href)| href.contains("github")));
+}
+
+#[test]
+fn test_layout_margin_collapsing_does_not_hang() {
+    // Many adjacent block siblings — exercises margin collapsing loop.
+    let css = "p { margin: 16px 0; }";
+    let html: String = (0..50).map(|i| format!("<p>Paragraph {}</p>", i)).collect();
+    let result = run(&html, css);
+    assert!(result.height > 0);
+}
+
+#[test]
+fn test_layout_deeply_nested_blocks() {
+    let mut html = String::from("<div>");
+    for i in 0..50 {
+        html.push_str(&format!("<div style=\"padding:{}px;\">", i % 10));
+    }
+    html.push_str("<p>deep text</p>");
+    for _ in 0..51 { html.push_str("</div>"); }
+    let result = run(&html, "");
+    assert!(result.height > 0);
+}
+
+#[test]
+fn test_layout_produces_reasonable_height() {
+    // 10 paragraphs at ~20px each → height well above 0 and below 16384.
+    let css = "p { height: 30px; }";
+    let html: String = (0..10).map(|_| "<p>line</p>").collect();
+    let result = run(&html, css);
+    assert!(result.height >= 100);
+    assert!(result.height <= 16384);
+}
+
+// ── Blog-like page (representative of yunseong.dev) ──────────────────────────
+
+#[test]
+fn test_pipeline_blog_page_structure() {
+    let css = r#"
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-size: 16px; color: #222; background: #fff; }
+        header { background: #1a1a2e; padding: 20px; }
+        header a { color: #eee; text-decoration: none; }
+        nav ul { list-style: none; display: flex; gap: 16px; }
+        main { max-width: 800px; margin: 40px auto; padding: 0 20px; }
+        h1 { font-size: 2em; margin-bottom: 8px; }
+        h2 { font-size: 1.5em; margin: 32px 0 12px; }
+        p  { line-height: 1.7; margin-bottom: 16px; }
+        .tag { background: #eef; padding: 2px 8px; border-radius: 4px; }
+        footer { border-top: 1px solid #ddd; padding: 20px; text-align: center; }
+    "#;
+    let html = r#"
+        <header>
+            <a href="/">yunseong.dev</a>
+            <nav>
+                <ul>
+                    <li><a href="/about">About</a></li>
+                    <li><a href="/posts">Posts</a></li>
+                    <li><a href="/projects">Projects</a></li>
+                </ul>
+            </nav>
+        </header>
+        <main>
+            <h1>Building a Web Browser in Rust</h1>
+            <p class="tag">Rust</p>
+            <p>
+                This project is a from-scratch browser engine written in Rust.
+                It parses HTML and CSS, builds a layout tree, and renders to a texture.
+            </p>
+            <h2>Architecture</h2>
+            <p>
+                The pipeline runs: Network → DOM → Style → Layout → Render → GUI.
+                Each stage is separated into its own module.
+            </p>
+            <h2>CSS Matching</h2>
+            <p>
+                Selector matching uses a SelectorIndex to bucket selectors by tag,
+                class, or ID so only relevant selectors are tested per element.
+            </p>
+        </main>
+        <footer>
+            <p>© 2026 Yunseong Jeong</p>
+        </footer>
+    "#;
+    let result = run(html, css);
+    assert!(result.width > 0);
+    assert!(result.height > 200, "blog page should be taller than 200px");
+    // At least the nav links should be collected.
+    assert!(result.links.len() >= 3);
+}
+
+// ── Render output sanity ──────────────────────────────────────────────────────
+
+#[test]
+fn test_render_produces_non_blank_pixmap() {
+    // White background with a colored block — pixmap must not be all-white.
+    let css = "div { background-color: #ff0000; width: 200px; height: 200px; }";
+    let html = "<div></div>";
+    let result = run(html, css);
+    let pixels = &result.pixmap_bytes;
+    // At least one pixel should be non-white (background is red).
+    // tiny_skia pixmap is RGBA; red = high R, low G, low B.
+    let has_color = pixels.chunks(4).any(|px| px[0] > 200 && px[1] < 50 && px[2] < 50);
+    assert!(has_color, "red div should produce red pixels");
+}
+
+#[test]
+fn test_render_pixmap_dimensions_match_viewport() {
+    let result = run("<div style=\"height:500px;\"></div>", "");
+    assert_eq!(result.width, 800, "viewport width should be 800px");
+}
+
+// ── CSS Gradients (#81) ──────────────────────────────────────────────────────
+
+/// `linear-gradient(to right, #ff0, #f00)` must render without panic and
+/// produce at least one non-transparent pixel.
+#[test]
+fn test_pipeline_linear_gradient_to_right_renders() {
+    let css = r#"div { background: linear-gradient(to right, #ff0, #f00); width: 200px; height: 100px; }"#;
+    let html = r#"<div></div>"#;
+    let result = run(html, css);
+    assert!(result.width > 0);
+    assert!(result.height > 0);
+    // Expect at least one non-transparent pixel (gradient is fully opaque).
+    let has_opaque = result.pixmap_bytes.chunks(4).any(|px| px[3] > 0);
+    assert!(has_opaque, "linear-gradient should produce opaque pixels");
+}
+
+/// `linear-gradient(90deg, #fff, #000)` (angle-based) must complete and produce pixels.
+#[test]
+fn test_pipeline_linear_gradient_angle_renders() {
+    let css = r#"div { background: linear-gradient(90deg, #fff, #000); width: 200px; height: 100px; }"#;
+    let html = r#"<div></div>"#;
+    let result = run(html, css);
+    assert!(result.width > 0);
+    let has_opaque = result.pixmap_bytes.chunks(4).any(|px| px[3] > 0);
+    assert!(has_opaque, "90deg linear-gradient should produce opaque pixels");
+}
+
+/// `radial-gradient(circle, #fff, #000)` must complete and produce pixels.
+#[test]
+fn test_pipeline_radial_gradient_circle_renders() {
+    let css = r#"div { background: radial-gradient(circle, #fff, #000); width: 200px; height: 200px; }"#;
+    let html = r#"<div></div>"#;
+    let result = run(html, css);
+    assert!(result.width > 0);
+    let has_opaque = result.pixmap_bytes.chunks(4).any(|px| px[3] > 0);
+    assert!(has_opaque, "radial-gradient should produce opaque pixels");
+}
+
+/// Gradient with explicit percentage stops must parse and render correctly.
+#[test]
+fn test_pipeline_linear_gradient_percent_stops_renders() {
+    let css = r#"div { background: linear-gradient(to right, #ff0 0%, #f00 50%, #00f 100%); width: 300px; height: 100px; }"#;
+    let html = r#"<div></div>"#;
+    let result = run(html, css);
+    assert!(result.width > 0);
+    let has_opaque = result.pixmap_bytes.chunks(4).any(|px| px[3] > 0);
+    assert!(has_opaque, "gradient with percentage stops should produce opaque pixels");
+}
+
+/// Gradient on `background-image` property must render the same as `background`.
+#[test]
+fn test_pipeline_gradient_on_background_image_property() {
+    let css = r#"div { background-image: linear-gradient(to right, #0f0, #00f); width: 200px; height: 100px; }"#;
+    let html = r#"<div></div>"#;
+    let result = run(html, css);
+    assert!(result.width > 0);
+    let has_opaque = result.pixmap_bytes.chunks(4).any(|px| px[3] > 0);
+    assert!(has_opaque, "background-image gradient should produce opaque pixels");
+}
+
+// ── Overflow / z-index / positioned elements ─────────────────────────────────
+
+#[test]
+fn test_pipeline_overflow_hidden_clipped() {
+    let css = "div { overflow: hidden; width: 100px; height: 100px; }
+               p   { height: 300px; background: blue; }";
+    let html = "<div><p></p></div>";
+    let result = run(html, css);
+    assert!(result.height > 0);
+}
+
+#[test]
+fn test_pipeline_positioned_absolute() {
+    let css = r#"
+        .parent   { position: relative; width: 300px; height: 300px; }
+        .absolute { position: absolute; top: 10px; left: 10px; width: 50px; height: 50px; }
+    "#;
+    let html = r#"<div class="parent"><div class="absolute">abs</div></div>"#;
+    let result = run(html, css);
+    assert!(result.height > 0);
+}
+
+#[test]
+fn test_pipeline_z_index_stacking() {
+    let css = r#"
+        .back  { position: absolute; z-index: 1; top: 0; left: 0; width: 100px; height: 100px; background: red; }
+        .front { position: absolute; z-index: 2; top: 20px; left: 20px; width: 100px; height: 100px; background: blue; }
+    "#;
+    let html = r#"
+        <div style="position:relative; width:200px; height:200px;">
+            <div class="back"></div>
+            <div class="front"></div>
+        </div>
+    "#;
+    let result = run(html, css);
+    assert!(result.height > 0);
+}


### PR DESCRIPTION
## Summary
- Parse `linear-gradient()` and `radial-gradient()` in `src/css.rs` — new `GradientValue`, `CssColorStop`, `LinearDirection` types with `parse_gradient()` function
- Add `PaintCommand::LinearGradient` and `PaintCommand::RadialGradient` variants in `src/layer_tree.rs`; emit them from `collect_paint_commands()` when `background` or `background-image` is a gradient
- Render gradient fills in `src/render.rs` via `tiny_skia::LinearGradient` and `tiny_skia::RadialGradient` shaders; supports `to <side>` keywords, angle (`deg`), and `border-radius` clipping
- Color stops with percentages and auto-distribution of stops without explicit positions

## Test plan
- [x] `cargo test --lib` — all 101 unit tests pass (5 new CSS gradient parse tests)
- [x] `cargo test --test test_pipeline` — all 20 integration tests pass (5 new gradient pipeline render tests)
- [x] `browser-cli navigate https://google.com` — exit code 0, Title and links present (confirms no regression)
- [x] `background: linear-gradient(to right, #ff0, #f00)` renders a smooth left-to-right gradient
- [x] `background: linear-gradient(90deg, #fff, #000)` renders with angle support
- [x] `background: radial-gradient(circle, #fff, #000)` renders a radial fill
- [x] Color stops with percentages (`0%`, `50%`, `100%`) work correctly

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)