### PR TITLE
feat: complete DOM API — querySelector, classList, innerHTML, addEventListener (#84)

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -491,6 +491,386 @@ impl JsRuntime {
         });
         context.register_global_callable(js_string!("__aura_fetch"), 3, aura_fetch).unwrap();
 
+        // ── DOM Query APIs ────────────────────────────────────────────────────
+
+        // __aura_query_selector(root_nid_or_0, selector_str) → nid | null
+        let query_selector = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let root_nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let selector = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let found = DOM_ROOT.with(|root| {
+                if let Some(ref r) = *root.borrow() {
+                    let search_root = if root_nid == 0 {
+                        r.clone()
+                    } else {
+                        NODE_REGISTRY.with(|reg| reg.borrow().get(&root_nid).cloned()).unwrap_or_else(|| r.clone())
+                    };
+                    query_selector_first(&search_root, &selector, root_nid != 0)
+                } else { None }
+            });
+            Ok(found.map(|h| JsValue::from(register_node(h))).unwrap_or(JsValue::null()))
+        });
+        context.register_global_callable(js_string!("__aura_query_selector"), 2, query_selector).unwrap();
+
+        // __aura_query_selector_all(root_nid_or_0, selector_str) → JSON array of nids
+        let query_selector_all = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let root_nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let selector = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let nids = DOM_ROOT.with(|root| {
+                if let Some(ref r) = *root.borrow() {
+                    let search_root = if root_nid == 0 {
+                        r.clone()
+                    } else {
+                        NODE_REGISTRY.with(|reg| reg.borrow().get(&root_nid).cloned()).unwrap_or_else(|| r.clone())
+                    };
+                    query_selector_all_nodes(&search_root, &selector, root_nid != 0)
+                } else { vec![] }
+            });
+            let ids: Vec<u32> = nids.into_iter().map(register_node).collect();
+            let json = format!("[{}]", ids.iter().map(|n| n.to_string()).collect::<Vec<_>>().join(","));
+            Ok(JsValue::from(js_string!(json)))
+        });
+        context.register_global_callable(js_string!("__aura_query_selector_all"), 2, query_selector_all).unwrap();
+
+        // __aura_get_elements_by_class(root_nid_or_0, class_name) → JSON array of nids
+        let get_by_class = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let root_nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let cls = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let nids = DOM_ROOT.with(|root| {
+                if let Some(ref r) = *root.borrow() {
+                    let search_root = if root_nid == 0 {
+                        r.clone()
+                    } else {
+                        NODE_REGISTRY.with(|reg| reg.borrow().get(&root_nid).cloned()).unwrap_or_else(|| r.clone())
+                    };
+                    find_elements_by_class(&search_root, &cls, root_nid != 0)
+                } else { vec![] }
+            });
+            let ids: Vec<u32> = nids.into_iter().map(register_node).collect();
+            let json = format!("[{}]", ids.iter().map(|n| n.to_string()).collect::<Vec<_>>().join(","));
+            Ok(JsValue::from(js_string!(json)))
+        });
+        context.register_global_callable(js_string!("__aura_get_elements_by_class"), 2, get_by_class).unwrap();
+
+        // __aura_get_elements_by_tag(root_nid_or_0, tag_name) → JSON array of nids
+        let get_by_tag = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let root_nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let tag = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default().to_lowercase();
+            let nids = DOM_ROOT.with(|root| {
+                if let Some(ref r) = *root.borrow() {
+                    let search_root = if root_nid == 0 {
+                        r.clone()
+                    } else {
+                        NODE_REGISTRY.with(|reg| reg.borrow().get(&root_nid).cloned()).unwrap_or_else(|| r.clone())
+                    };
+                    find_elements_by_tag_name(&search_root, &tag, root_nid != 0)
+                } else { vec![] }
+            });
+            let ids: Vec<u32> = nids.into_iter().map(register_node).collect();
+            let json = format!("[{}]", ids.iter().map(|n| n.to_string()).collect::<Vec<_>>().join(","));
+            Ok(JsValue::from(js_string!(json)))
+        });
+        context.register_global_callable(js_string!("__aura_get_elements_by_tag"), 2, get_by_tag).unwrap();
+
+        // ── DOM Mutation APIs ─────────────────────────────────────────────────
+
+        // __aura_create_element(tag) → nid
+        let create_element = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let tag = args.get(0).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_else(|| "div".to_string()).to_lowercase();
+            let nid = DOM_ROOT.with(|root| {
+                use html5ever::{QualName, LocalName, ns};
+                use markup5ever_rcdom::{Node, NodeData};
+                let new_node = Node::new(NodeData::Element {
+                    name: QualName::new(None, ns!(html), LocalName::from(tag)),
+                    attrs: std::cell::RefCell::new(vec![]),
+                    template_contents: std::cell::RefCell::new(None),
+                    mathml_annotation_xml_integration_point: false,
+                });
+                // Store it even without a DOM parent so it can be used
+                let nid = register_node(new_node.clone());
+                // If there's a DOM root, we register it but don't attach yet
+                let _ = root; // suppress warning
+                nid
+            });
+            Ok(JsValue::from(nid))
+        });
+        context.register_global_callable(js_string!("__aura_create_element"), 1, create_element).unwrap();
+
+        // __aura_append_child(parent_nid, child_nid) → void
+        let append_child = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let parent_nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let child_nid = args.get(1).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let (Some(parent), Some(child)) = (reg.get(&parent_nid), reg.get(&child_nid)) {
+                    // Remove from existing parent if any
+                    let child_ptr = Rc::as_ptr(child) as usize;
+                    if let Some(old_parent_handle) = find_parent_by_ptr_in_dom(child_ptr) {
+                        old_parent_handle.children.borrow_mut().retain(|c| Rc::as_ptr(c) as usize != child_ptr);
+                    }
+                    // Set new parent relationship via Cell::set
+                    child.parent.set(Some(Rc::downgrade(parent)));
+                    parent.children.borrow_mut().push(child.clone());
+                }
+            });
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("__aura_append_child"), 2, append_child).unwrap();
+
+        // __aura_remove_child(parent_nid, child_nid) → void
+        let remove_child = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let parent_nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let child_nid = args.get(1).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let (Some(parent), Some(child)) = (reg.get(&parent_nid), reg.get(&child_nid)) {
+                    let child_ptr = Rc::as_ptr(child) as usize;
+                    parent.children.borrow_mut().retain(|c| Rc::as_ptr(c) as usize != child_ptr);
+                    child.parent.set(None);
+                }
+            });
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("__aura_remove_child"), 2, remove_child).unwrap();
+
+        // __aura_insert_before(parent_nid, new_child_nid, ref_nid_or_null) → void
+        let insert_before = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let parent_nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let new_nid = args.get(1).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let ref_nid = args.get(2).and_then(|v| if v.is_null() { None } else { v.as_number().map(|n| n as u32) });
+            NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let (Some(parent), Some(new_child)) = (reg.get(&parent_nid), reg.get(&new_nid)) {
+                    // Remove from existing parent
+                    let new_ptr = Rc::as_ptr(new_child) as usize;
+                    if let Some(old_parent) = find_parent_by_ptr_in_dom(new_ptr) {
+                        old_parent.children.borrow_mut().retain(|c| Rc::as_ptr(c) as usize != new_ptr);
+                    }
+                    new_child.parent.set(Some(Rc::downgrade(parent)));
+
+                    let mut children = parent.children.borrow_mut();
+                    if let Some(ref_nid_val) = ref_nid {
+                        if let Some(ref_node) = reg.get(&ref_nid_val) {
+                            let ref_ptr = Rc::as_ptr(ref_node) as usize;
+                            if let Some(pos) = children.iter().position(|c| Rc::as_ptr(c) as usize == ref_ptr) {
+                                children.insert(pos, new_child.clone());
+                                return;
+                            }
+                        }
+                    }
+                    children.push(new_child.clone());
+                }
+            });
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("__aura_insert_before"), 3, insert_before).unwrap();
+
+        // __aura_remove_self(nid) → void
+        let remove_self = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    let node_ptr = Rc::as_ptr(node) as usize;
+                    // Get parent via Cell::take/set pattern
+                    let parent_weak = node.parent.take();
+                    if let Some(ref pw) = parent_weak {
+                        if let Some(parent) = pw.upgrade() {
+                            parent.children.borrow_mut().retain(|c| Rc::as_ptr(c) as usize != node_ptr);
+                        }
+                    }
+                    // parent_weak was taken (None now), leave it as None
+                }
+            });
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("__aura_remove_self"), 1, remove_self).unwrap();
+
+        // __aura_get_inner_html(nid) → string
+        let get_inner_html = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let html = NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    serialize_inner_html(node)
+                } else {
+                    String::new()
+                }
+            });
+            Ok(JsValue::from(js_string!(html)))
+        });
+        context.register_global_callable(js_string!("__aura_get_inner_html"), 1, get_inner_html).unwrap();
+
+        // __aura_set_inner_html(nid, html_str) → void
+        let set_inner_html = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let html_str = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    // Determine context tag for fragment parsing
+                    let ctx_tag = if let NodeData::Element { ref name, .. } = node.data {
+                        name.local.to_string()
+                    } else { "div".to_string() };
+                    let fragment_nodes = parse_html_fragment(&html_str, &ctx_tag);
+                    // Replace children
+                    let mut children = node.children.borrow_mut();
+                    children.clear();
+                    for child in fragment_nodes {
+                        child.parent.set(Some(Rc::downgrade(node)));
+                        children.push(child);
+                    }
+                }
+            });
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("__aura_set_inner_html"), 2, set_inner_html).unwrap();
+
+        // __aura_get_text_content(nid) → string
+        let get_text_content = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let text = NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    collect_text_content(node)
+                } else {
+                    String::new()
+                }
+            });
+            Ok(JsValue::from(js_string!(text)))
+        });
+        context.register_global_callable(js_string!("__aura_get_text_content"), 1, get_text_content).unwrap();
+
+        // __aura_set_text_content(nid, text) → void
+        let set_text_content = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let text = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    use markup5ever_rcdom::Node;
+                    use html5ever::tendril::StrTendril;
+                    let text_node = Node::new(NodeData::Text {
+                        contents: std::cell::RefCell::new(StrTendril::from(text.as_str())),
+                    });
+                    text_node.parent.set(Some(Rc::downgrade(node)));
+                    let mut children = node.children.borrow_mut();
+                    children.clear();
+                    children.push(text_node);
+                }
+            });
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("__aura_set_text_content"), 2, set_text_content).unwrap();
+
+        // __aura_get_attribute(nid, name) → string | null
+        let get_attr = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let name = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let val = NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    if let NodeData::Element { ref attrs, .. } = node.data {
+                        for attr in attrs.borrow().iter() {
+                            if attr.name.local.to_string() == name {
+                                return Some(attr.value.to_string());
+                            }
+                        }
+                    }
+                }
+                None
+            });
+            Ok(val.map(|v| JsValue::from(js_string!(v))).unwrap_or(JsValue::null()))
+        });
+        context.register_global_callable(js_string!("__aura_get_attribute"), 2, get_attr).unwrap();
+
+        // __aura_remove_attribute(nid, name) → void
+        let remove_attr = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let name = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            NODE_REGISTRY.with(|reg| {
+                if let Some(node) = reg.borrow().get(&nid) {
+                    if let NodeData::Element { ref attrs, .. } = node.data {
+                        attrs.borrow_mut().retain(|a| a.name.local.to_string() != name);
+                    }
+                }
+            });
+            Ok(JsValue::undefined())
+        });
+        context.register_global_callable(js_string!("__aura_remove_attribute"), 2, remove_attr).unwrap();
+
+        // __aura_has_attribute(nid, name) → bool
+        let has_attr = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let name = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let found = NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    if let NodeData::Element { ref attrs, .. } = node.data {
+                        return attrs.borrow().iter().any(|a| a.name.local.to_string() == name);
+                    }
+                }
+                false
+            });
+            Ok(JsValue::from(found))
+        });
+        context.register_global_callable(js_string!("__aura_has_attribute"), 2, has_attr).unwrap();
+
+        // __aura_get_children_nids(nid) → JSON array of {nid, tag, string_id}
+        let get_children = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let result = NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    let mut items = Vec::new();
+                    for child in node.children.borrow().iter() {
+                        if let NodeData::Element { ref name, ref attrs, .. } = child.data {
+                            let tag = name.local.to_string();
+                            let id_attr = attrs.borrow().iter()
+                                .find(|a| a.name.local.to_string() == "id")
+                                .map(|a| a.value.to_string())
+                                .unwrap_or_default();
+                            let child_nid = register_node(child.clone());
+                            items.push(format!("{{\"nid\":{},\"tag\":\"{}\",\"id\":\"{}\"}}", child_nid, tag, id_attr));
+                        }
+                    }
+                    items.join(",")
+                } else {
+                    String::new()
+                }
+            });
+            Ok(JsValue::from(js_string!(format!("[{}]", result))))
+        });
+        context.register_global_callable(js_string!("__aura_get_children"), 1, get_children).unwrap();
+
+        // __aura_get_node_info(nid) → {tag, id, class} or null
+        let get_node_info = NativeFunction::from_copy_closure(|_this, args, context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let info = NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                if let Some(node) = reg.get(&nid) {
+                    if let NodeData::Element { ref name, ref attrs, .. } = node.data {
+                        let tag = name.local.to_string();
+                        let attrs_b = attrs.borrow();
+                        let id = attrs_b.iter().find(|a| a.name.local.to_string() == "id").map(|a| a.value.to_string()).unwrap_or_default();
+                        let class = attrs_b.iter().find(|a| a.name.local.to_string() == "class").map(|a| a.value.to_string()).unwrap_or_default();
+                        return Some((tag, id, class));
+                    }
+                }
+                None
+            });
+            if let Some((tag, id, class)) = info {
+                use boa_engine::object::ObjectInitializer;
+                let mut obj = ObjectInitializer::new(context);
+                obj.property(js_string!("tag"), JsValue::from(js_string!(tag)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("id"), JsValue::from(js_string!(id)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("class"), JsValue::from(js_string!(class)), boa_engine::property::Attribute::all());
+                Ok(obj.build().into())
+            } else {
+                Ok(JsValue::null())
+            }
+        });
+        context.register_global_callable(js_string!("__aura_get_node_info"), 1, get_node_info).unwrap();
+
         // Load bootstrap
         let bootstrap = include_str!("js_bootstrap.js");
         let _ = context.eval(Source::from_bytes(bootstrap.as_bytes()));
@@ -766,4 +1146,552 @@ fn register_node(handle: Handle) -> u32 {
     NODE_REGISTRY.with(|reg| reg.borrow_mut().insert(id, handle));
     REVERSE_NODE_REGISTRY.with(|reg| reg.borrow_mut().insert(ptr, id));
     id
+}
+
+// ── CSS Selector Matching ─────────────────────────────────────────────────────
+
+/// Simple CSS selector parser: supports tag, #id, .class, and combinations
+/// e.g. "div", "#foo", ".bar", "div.foo", "div#id", ".a.b"
+/// Also supports comma-separated selectors: "h1, h2, h3"
+fn selector_matches(node: &Handle, selector: &str) -> bool {
+    // Comma-separated: match any
+    if selector.contains(',') {
+        return selector.split(',').any(|s| selector_matches(node, s.trim()));
+    }
+
+    if let NodeData::Element { ref name, ref attrs, .. } = node.data {
+        let tag = name.local.to_string().to_lowercase();
+        let attrs_b = attrs.borrow();
+        let id_val = attrs_b.iter().find(|a| a.name.local.to_string() == "id").map(|a| a.value.to_string()).unwrap_or_default();
+        let class_val = attrs_b.iter().find(|a| a.name.local.to_string() == "class").map(|a| a.value.to_string()).unwrap_or_default();
+        let classes: Vec<&str> = class_val.split_whitespace().collect();
+
+        // Parse compound selector (no spaces — those would be descendant combinators)
+        // We handle simple compound selectors: tag.class#id combinations
+        let sel = selector.trim();
+
+        // Check for attribute selectors like [type="submit"] - simplified
+        if sel.contains('[') {
+            return selector_matches_with_attr(node, sel);
+        }
+
+        // Split into parts by '#' and '.'
+        // Strategy: extract optional tag prefix, then check all id/class parts
+        let mut remaining = sel;
+        let mut required_tag: Option<&str> = None;
+
+        // Extract tag prefix (before any '.' or '#')
+        let prefix_end = remaining.find(|c| c == '.' || c == '#').unwrap_or(remaining.len());
+        if prefix_end > 0 {
+            let prefix = &remaining[..prefix_end];
+            if prefix != "*" {
+                required_tag = Some(prefix);
+            }
+            remaining = &remaining[prefix_end..];
+        }
+
+        if let Some(t) = required_tag {
+            if tag != t.to_lowercase() {
+                return false;
+            }
+        }
+
+        // Check remaining .class and #id parts
+        while !remaining.is_empty() {
+            if remaining.starts_with('#') {
+                let end = remaining[1..].find(|c| c == '.' || c == '#').map(|p| p + 1).unwrap_or(remaining.len());
+                let required_id = &remaining[1..end];
+                if id_val != required_id {
+                    return false;
+                }
+                remaining = &remaining[end..];
+            } else if remaining.starts_with('.') {
+                let end = remaining[1..].find(|c| c == '.' || c == '#').map(|p| p + 1).unwrap_or(remaining.len());
+                let required_class = &remaining[1..end];
+                if !classes.contains(&required_class) {
+                    return false;
+                }
+                remaining = &remaining[end..];
+            } else {
+                break;
+            }
+        }
+        true
+    } else {
+        false
+    }
+}
+
+fn selector_matches_with_attr(node: &Handle, sel: &str) -> bool {
+    if let NodeData::Element { ref name, ref attrs, .. } = node.data {
+        let tag = name.local.to_string().to_lowercase();
+        let attrs_b = attrs.borrow();
+
+        // Extract tag part before '['
+        let bracket_pos = sel.find('[').unwrap_or(sel.len());
+        let tag_part = &sel[..bracket_pos];
+        if !tag_part.is_empty() && tag_part != "*" && tag != tag_part.to_lowercase() {
+            return false;
+        }
+
+        // Parse [attr=value] or [attr]
+        let bracket_content = &sel[bracket_pos..];
+        if let Some(inner) = bracket_content.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            if inner.contains('=') {
+                let mut parts = inner.splitn(2, '=');
+                let attr_name = parts.next().unwrap_or("").trim().trim_matches('"');
+                let attr_val = parts.next().unwrap_or("").trim().trim_matches('"');
+                return attrs_b.iter().any(|a| a.name.local.to_string() == attr_name && a.value.to_string() == attr_val);
+            } else {
+                let attr_name = inner.trim();
+                return attrs_b.iter().any(|a| a.name.local.to_string() == attr_name);
+            }
+        }
+        false
+    } else {
+        false
+    }
+}
+
+fn query_selector_first(root: &Handle, selector: &str, skip_root: bool) -> Option<Handle> {
+    // Handle descendant combinator: "ancestor descendant"
+    // We do a simple two-pass: find all ancestors, then find descendants
+    let sel = selector.trim();
+
+    // Check for descendant combinator (space not inside brackets)
+    if let Some((ancestor_sel, desc_sel)) = split_descendant_selector(sel) {
+        // Find all elements matching ancestor_sel, then search their subtrees
+        let ancestors = query_selector_all_nodes(root, ancestor_sel, skip_root);
+        for ancestor in ancestors {
+            if let Some(found) = query_selector_first(&ancestor, desc_sel, true) {
+                return Some(found);
+            }
+        }
+        return None;
+    }
+
+    if !skip_root && selector_matches(root, sel) {
+        return Some(root.clone());
+    }
+    for child in root.children.borrow().iter() {
+        if let Some(found) = query_selector_first(child, sel, false) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn query_selector_all_nodes(root: &Handle, selector: &str, skip_root: bool) -> Vec<Handle> {
+    let mut results = Vec::new();
+    let sel = selector.trim();
+
+    if let Some((ancestor_sel, desc_sel)) = split_descendant_selector(sel) {
+        let ancestors = query_selector_all_nodes(root, ancestor_sel, skip_root);
+        for ancestor in ancestors {
+            let mut desc = query_selector_all_nodes(&ancestor, desc_sel, true);
+            results.append(&mut desc);
+        }
+        return results;
+    }
+
+    if !skip_root && selector_matches(root, sel) {
+        results.push(root.clone());
+    }
+    for child in root.children.borrow().iter() {
+        let mut found = query_selector_all_nodes(child, sel, false);
+        results.append(&mut found);
+    }
+    results
+}
+
+/// Split "ancestor descendant" into (ancestor_sel, descendant_sel).
+/// Returns None if there's no descendant combinator (space outside brackets/parens).
+fn split_descendant_selector(sel: &str) -> Option<(&str, &str)> {
+    let mut depth = 0i32;
+    let bytes = sel.as_bytes();
+    let mut last_space: Option<usize> = None;
+
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'(' | b'[' => depth += 1,
+            b')' | b']' => depth -= 1,
+            b' ' if depth == 0 => {
+                last_space = Some(i);
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(pos) = last_space {
+        let ancestor = sel[..pos].trim_end();
+        let desc = sel[pos + 1..].trim_start();
+        if !ancestor.is_empty() && !desc.is_empty() {
+            return Some((ancestor, desc));
+        }
+    }
+    None
+}
+
+fn find_elements_by_class(root: &Handle, cls: &str, skip_root: bool) -> Vec<Handle> {
+    let mut results = Vec::new();
+    if !skip_root {
+        if let NodeData::Element { ref attrs, .. } = root.data {
+            let class_val = attrs.borrow().iter()
+                .find(|a| a.name.local.to_string() == "class")
+                .map(|a| a.value.to_string())
+                .unwrap_or_default();
+            if class_val.split_whitespace().any(|c| c == cls) {
+                results.push(root.clone());
+            }
+        }
+    }
+    for child in root.children.borrow().iter() {
+        let mut found = find_elements_by_class(child, cls, false);
+        results.append(&mut found);
+    }
+    results
+}
+
+fn find_elements_by_tag_name(root: &Handle, tag: &str, skip_root: bool) -> Vec<Handle> {
+    let mut results = Vec::new();
+    if !skip_root {
+        if let NodeData::Element { ref name, .. } = root.data {
+            if tag == "*" || name.local.to_string().to_lowercase() == tag {
+                results.push(root.clone());
+            }
+        }
+    }
+    for child in root.children.borrow().iter() {
+        let mut found = find_elements_by_tag_name(child, tag, false);
+        results.append(&mut found);
+    }
+    results
+}
+
+/// Find the parent of a node identified by its raw pointer, searching the DOM from root.
+fn find_parent_by_ptr_in_dom(child_ptr: usize) -> Option<Handle> {
+    DOM_ROOT.with(|root| {
+        if let Some(ref r) = *root.borrow() {
+            find_parent_by_ptr(r, child_ptr)
+        } else {
+            None
+        }
+    })
+}
+
+fn find_parent_by_ptr(node: &Handle, child_ptr: usize) -> Option<Handle> {
+    for child in node.children.borrow().iter() {
+        if Rc::as_ptr(child) as usize == child_ptr {
+            return Some(node.clone());
+        }
+        if let Some(found) = find_parent_by_ptr(child, child_ptr) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Serialize inner HTML of a node (children only, not the node itself).
+fn serialize_inner_html(node: &Handle) -> String {
+    let mut out = String::new();
+    for child in node.children.borrow().iter() {
+        serialize_node(child, &mut out);
+    }
+    out
+}
+
+fn serialize_node(node: &Handle, out: &mut String) {
+    match &node.data {
+        NodeData::Text { ref contents } => {
+            out.push_str(&html_escape(&contents.borrow().to_string()));
+        }
+        NodeData::Element { ref name, ref attrs, .. } => {
+            let tag = name.local.to_string();
+            out.push('<');
+            out.push_str(&tag);
+            for attr in attrs.borrow().iter() {
+                out.push(' ');
+                out.push_str(&attr.name.local.to_string());
+                out.push_str("=\"");
+                out.push_str(&html_escape(&attr.value.to_string()));
+                out.push('"');
+            }
+            out.push('>');
+            // Self-closing void elements
+            if !matches!(tag.as_str(), "area"|"base"|"br"|"col"|"embed"|"hr"|"img"|"input"|"link"|"meta"|"param"|"source"|"track"|"wbr") {
+                for child in node.children.borrow().iter() {
+                    serialize_node(child, out);
+                }
+                out.push_str("</");
+                out.push_str(&tag);
+                out.push('>');
+            }
+        }
+        NodeData::Comment { ref contents } => {
+            out.push_str("<!--");
+            out.push_str(contents);
+            out.push_str("-->");
+        }
+        _ => {}
+    }
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+     .replace('<', "&lt;")
+     .replace('>', "&gt;")
+     .replace('"', "&quot;")
+}
+
+/// Collect all text content (recursively) from a node.
+fn collect_text_content(node: &Handle) -> String {
+    let mut out = String::new();
+    match &node.data {
+        NodeData::Text { ref contents } => {
+            out.push_str(&contents.borrow().to_string());
+        }
+        NodeData::Element { .. } => {
+            for child in node.children.borrow().iter() {
+                out.push_str(&collect_text_content(child));
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Parse an HTML fragment string into a vec of Handle nodes.
+/// Uses html5ever's fragment parsing.
+fn parse_html_fragment(html: &str, _ctx_tag: &str) -> Vec<Handle> {
+    use html5ever::parse_fragment;
+    use html5ever::tendril::TendrilSink;
+    use html5ever::{QualName, LocalName, ns};
+
+    let ctx_name = QualName::new(None, ns!(html), LocalName::from(_ctx_tag));
+    let dom = parse_fragment(
+        markup5ever_rcdom::RcDom::default(),
+        Default::default(),
+        ctx_name,
+        vec![],
+        false,
+    )
+    .from_utf8()
+    .read_from(&mut html.as_bytes())
+    .unwrap();
+
+    // The fragment parser puts the content as children of the context element,
+    // which is the first child of the document.
+    // IMPORTANT: We must extract the nodes from the DOM tree BEFORE `dom` is
+    // dropped, because `Node::drop` calls `mem::take` on all descendants'
+    // children to avoid deep stack recursion. If we just clone the handles
+    // and let `dom` drop naturally, the extracted nodes would have their
+    // children cleared by the drop implementation.
+    // Solution: steal (take) the children out of the DOM tree before drop.
+    let nodes = steal_fragment_children(&dom.document);
+    // dom is dropped here but since we've already cleared the tree, the custom
+    // Drop impl won't find any children to clear (they're now owned by `nodes`).
+    nodes
+}
+
+/// Steal the fragment children from the DOM tree by removing them from their
+/// parent nodes. This prevents `Node::drop` from clearing their children.
+fn steal_fragment_children(doc: &Handle) -> Vec<Handle> {
+    // Structure: document → [context_element] → [fragment nodes]
+    // We need to take ownership of the fragment nodes out of context_element.
+    for child in doc.children.borrow().iter() {
+        if let NodeData::Element { .. } = child.data {
+            // This is the context element. Take its children.
+            let children: Vec<Handle> = child.children.borrow_mut().drain(..).collect();
+            // Clear the parent pointers so they don't point into the dying dom
+            for c in &children {
+                c.parent.set(None);
+            }
+            return children;
+        }
+    }
+    vec![]
+}
+
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dom;
+
+    fn make_runtime(html: &str) -> JsRuntime {
+        let dom = dom::parse_html(html);
+        JsRuntime::new(Some(dom.document), None, None)
+    }
+
+    fn eval(rt: &mut JsRuntime, code: &str) -> String {
+        if let Ok(val) = rt.context.eval(Source::from_bytes(code.as_bytes())) {
+            if let Ok(s) = val.to_string(&mut rt.context) {
+                return s.to_std_string_escaped();
+            }
+        }
+        String::new()
+    }
+
+    #[test]
+    fn test_query_selector_h1() {
+        let mut rt = make_runtime("<html><body><h1>Hello</h1></body></html>");
+        let result = eval(&mut rt, "document.querySelector('h1') !== null ? 'found' : 'null'");
+        assert_eq!(result, "found");
+    }
+
+    #[test]
+    fn test_query_selector_returns_null_for_missing() {
+        let mut rt = make_runtime("<html><body><p>text</p></body></html>");
+        let result = eval(&mut rt, "document.querySelector('h1') === null ? 'null' : 'found'");
+        assert_eq!(result, "null");
+    }
+
+    #[test]
+    fn test_text_content_getter() {
+        let mut rt = make_runtime("<html><body><h1>Hello World</h1></body></html>");
+        let result = eval(&mut rt, "document.querySelector('h1').textContent");
+        assert_eq!(result, "Hello World");
+    }
+
+    #[test]
+    fn test_get_element_by_id() {
+        let mut rt = make_runtime("<html><body><div id='main'>content</div></body></html>");
+        let result = eval(&mut rt, "document.getElementById('main') !== null ? 'found' : 'null'");
+        assert_eq!(result, "found");
+    }
+
+    #[test]
+    fn test_query_selector_all_count() {
+        let mut rt = make_runtime("<html><body><p>a</p><p>b</p><p>c</p></body></html>");
+        let result = eval(&mut rt, "document.querySelectorAll('p').length");
+        assert_eq!(result, "3");
+    }
+
+    #[test]
+    fn test_get_attribute() {
+        let mut rt = make_runtime("<html><body><a href='/path' id='link1'>link</a></body></html>");
+        let result = eval(&mut rt, "document.querySelector('a').getAttribute('href')");
+        assert_eq!(result, "/path");
+    }
+
+    #[test]
+    fn test_get_attribute_missing_returns_null() {
+        let mut rt = make_runtime("<html><body><a>link</a></body></html>");
+        let result = eval(&mut rt, "document.querySelector('a').getAttribute('href') === null ? 'null' : 'found'");
+        assert_eq!(result, "null");
+    }
+
+    #[test]
+    fn test_class_list_add_contains() {
+        let mut rt = make_runtime("<html><body><div id='el'>x</div></body></html>");
+        let result = eval(&mut rt,
+            "var el = document.getElementById('el'); el.classList.add('active'); el.classList.contains('active')");
+        assert_eq!(result, "true");
+    }
+
+    #[test]
+    fn test_class_list_remove() {
+        let mut rt = make_runtime("<html><body><div id='el' class='active foo'>x</div></body></html>");
+        let result = eval(&mut rt,
+            "var el = document.getElementById('el'); el.classList.remove('active'); el.classList.contains('active')");
+        assert_eq!(result, "false");
+    }
+
+    #[test]
+    fn test_class_list_toggle_adds() {
+        let mut rt = make_runtime("<html><body><div id='el'>x</div></body></html>");
+        let result = eval(&mut rt,
+            "var el = document.getElementById('el'); el.classList.toggle('visible'); el.classList.contains('visible')");
+        assert_eq!(result, "true");
+    }
+
+    #[test]
+    fn test_class_list_toggle_removes() {
+        let mut rt = make_runtime("<html><body><div id='el' class='visible'>x</div></body></html>");
+        let result = eval(&mut rt,
+            "var el = document.getElementById('el'); el.classList.toggle('visible'); el.classList.contains('visible')");
+        assert_eq!(result, "false");
+    }
+
+    #[test]
+    fn test_get_elements_by_class_name() {
+        let mut rt = make_runtime("<html><body><div class='card'>a</div><div class='card'>b</div><p>c</p></body></html>");
+        let result = eval(&mut rt, "document.getElementsByClassName('card').length");
+        assert_eq!(result, "2");
+    }
+
+    #[test]
+    fn test_get_elements_by_tag_name() {
+        let mut rt = make_runtime("<html><body><span>a</span><span>b</span></body></html>");
+        let result = eval(&mut rt, "document.getElementsByTagName('span').length");
+        assert_eq!(result, "2");
+    }
+
+    #[test]
+    fn test_add_event_listener_fires() {
+        let mut rt = make_runtime("<html><body><button id='btn'>click</button></body></html>");
+        eval(&mut rt, "var clicked = false; var btn = document.getElementById('btn'); btn.addEventListener('click', function() { clicked = true; });");
+        eval(&mut rt, "btn.dispatchEvent(new Event('click'))");
+        let result = eval(&mut rt, "clicked");
+        assert_eq!(result, "true");
+    }
+
+    #[test]
+    fn test_document_add_event_listener_domcontentloaded() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        // DOMContentLoaded fires synchronously when addEventListener is called
+        let result = eval(&mut rt,
+            "var fired = false; document.addEventListener('DOMContentLoaded', function() { fired = true; }); fired");
+        assert_eq!(result, "true");
+    }
+
+    #[test]
+    fn test_selector_matches_class() {
+        let mut rt = make_runtime("<html><body><div class='hero'>content</div></body></html>");
+        let result = eval(&mut rt, "document.querySelector('.hero') !== null ? 'found' : 'null'");
+        assert_eq!(result, "found");
+    }
+
+    #[test]
+    fn test_selector_matches_id() {
+        let mut rt = make_runtime("<html><body><section id='about'>text</section></body></html>");
+        let result = eval(&mut rt, "document.querySelector('#about') !== null ? 'found' : 'null'");
+        assert_eq!(result, "found");
+    }
+
+    #[test]
+    fn test_inner_html_getter() {
+        let mut rt = make_runtime("<html><body><div id='app'><p>hello</p></div></body></html>");
+        let result = eval(&mut rt, "document.getElementById('app').innerHTML");
+        assert!(result.contains("hello"), "Expected innerHTML to contain 'hello', got: {:?}", result);
+    }
+
+    #[test]
+    fn test_parse_html_fragment_text_content() {
+        // Test that parse_html_fragment preserves text content
+        let nodes = parse_html_fragment("<p>hello world</p>", "div");
+        assert_eq!(nodes.len(), 1, "Expected 1 fragment node");
+
+        if let NodeData::Element { ref name, .. } = nodes[0].data {
+            assert_eq!(name.local.to_string(), "p");
+        }
+
+        let text = collect_text_content(&nodes[0]);
+        assert_eq!(text, "hello world", "Text content should be preserved after fragment parse");
+    }
+
+    #[test]
+    fn test_inner_html_setter() {
+        let mut rt = make_runtime("<html><body><div id='app'></div></body></html>");
+        // Set innerHTML
+        eval(&mut rt, "document.getElementById('app').innerHTML = '<p>hello</p>';");
+        // Check via the getter that the p is now there
+        let result = eval(&mut rt, "document.getElementById('app').innerHTML");
+        assert!(result.contains("hello"), "Expected innerHTML to contain 'hello', got: {:?}", result);
+        // Also check querySelector works after mutation
+        let found = eval(&mut rt, "document.querySelector('#app p') !== null ? 'found' : 'null'");
+        assert_eq!(found, "found", "Expected querySelector('#app p') to find element after innerHTML set");
+    }
 }

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -31,6 +31,8 @@ class Event {
         this.defaultPrevented = false;
     }
     preventDefault() { this.defaultPrevented = true; }
+    stopPropagation() { this._stopped = true; }
+    stopImmediatePropagation() { this._stopped = true; this._immediateStopped = true; }
 }
 
 class MouseEvent extends Event {
@@ -58,16 +60,18 @@ class EventTarget {
         let current = this;
         // Simple bubbling (if supported by event)
         while (current) {
+            if (event._stopped) break;
             event.currentTarget = current;
-            
+
             // 1. Check addEventListener listeners
-            let list = current._listeners.get(event.type);
+            let list = current._listeners ? current._listeners.get(event.type) : null;
             if (list) {
                 for (let listener of list) {
+                    if (event._immediateStopped) break;
                     try { listener.call(current, event); } catch(e) { console.log("Event Error: " + e); }
                 }
             }
-            
+
             // 2. Check onEVENT property
             let onHandler = current['on' + event.type];
             if (typeof onHandler === 'function') {
@@ -81,6 +85,90 @@ class EventTarget {
     }
 }
 
+// -- ClassList ----------------------------------------------------------------
+class DOMTokenList {
+    constructor(nid) {
+        this._nid = nid;
+    }
+    _getClasses() {
+        let cls = __aura_get_attribute(this._nid, 'class') || '';
+        return cls.split(/\s+/).filter(c => c.length > 0);
+    }
+    _setClasses(arr) {
+        __aura_set_attribute(this._nid, 'class', arr.join(' '));
+    }
+    add(...tokens) {
+        let classes = this._getClasses();
+        for (let t of tokens) {
+            if (!classes.includes(t)) classes.push(t);
+        }
+        this._setClasses(classes);
+    }
+    remove(...tokens) {
+        let classes = this._getClasses();
+        for (let t of tokens) {
+            classes = classes.filter(c => c !== t);
+        }
+        this._setClasses(classes);
+    }
+    toggle(token, force) {
+        let classes = this._getClasses();
+        let has = classes.includes(token);
+        if (force === undefined) {
+            if (has) {
+                classes = classes.filter(c => c !== token);
+            } else {
+                classes.push(token);
+            }
+            this._setClasses(classes);
+            return !has;
+        } else {
+            if (force) {
+                if (!has) { classes.push(token); this._setClasses(classes); }
+            } else {
+                if (has) { classes = classes.filter(c => c !== token); this._setClasses(classes); }
+            }
+            return force;
+        }
+    }
+    contains(token) {
+        return this._getClasses().includes(token);
+    }
+    replace(oldToken, newToken) {
+        let classes = this._getClasses();
+        let idx = classes.indexOf(oldToken);
+        if (idx !== -1) {
+            classes[idx] = newToken;
+            this._setClasses(classes);
+            return true;
+        }
+        return false;
+    }
+    toString() {
+        return this._getClasses().join(' ');
+    }
+    get length() { return this._getClasses().length; }
+    item(index) { return this._getClasses()[index] || null; }
+}
+
+// -- NodeList / HTMLCollection ------------------------------------------------
+class NodeList {
+    constructor(nids, tag) {
+        this._nids = nids;
+        this._tag = tag;
+        for (let i = 0; i < nids.length; i++) {
+            this[i] = __get_or_create_node(nids[i], null, null);
+        }
+        this.length = nids.length;
+    }
+    item(i) { return this[i] || null; }
+    forEach(fn) { this._nids.forEach((nid, i) => fn(this[i], i, this)); }
+    [Symbol.iterator]() {
+        let i = 0, self = this;
+        return { next() { return i < self.length ? { value: self[i++], done: false } : { done: true }; } };
+    }
+}
+
 // -- Node & Element Classes ---------------------------------------------------
 class Node extends EventTarget {
     constructor(id) {
@@ -89,13 +177,74 @@ class Node extends EventTarget {
     }
     get parentNode() {
         let pid = __aura_get_parent_id(this._id);
-        return pid ? __get_or_create_node(pid) : null;
+        if (!pid) return null;
+        let info = __aura_get_node_info(pid);
+        return info ? __get_or_create_node(pid, info.tag, info.id) : __get_or_create_node(pid);
+    }
+    get childNodes() {
+        let arr = JSON.parse(__aura_get_children(this._id));
+        return new NodeList(arr.map(c => c.nid));
+    }
+    get firstChild() {
+        let arr = JSON.parse(__aura_get_children(this._id));
+        if (arr.length === 0) return null;
+        let c = arr[0];
+        return __get_or_create_node(c.nid, c.tag, c.id);
+    }
+    get lastChild() {
+        let arr = JSON.parse(__aura_get_children(this._id));
+        if (arr.length === 0) return null;
+        let c = arr[arr.length - 1];
+        return __get_or_create_node(c.nid, c.tag, c.id);
+    }
+    get textContent() {
+        return __aura_get_text_content(this._id);
+    }
+    set textContent(val) {
+        __aura_set_text_content(this._id, String(val));
     }
     appendChild(child) {
-        if (child instanceof Node) {
+        if (child && child._id) {
             __aura_append_child(this._id, child._id);
         }
         return child;
+    }
+    removeChild(child) {
+        if (child && child._id) {
+            __aura_remove_child(this._id, child._id);
+        }
+        return child;
+    }
+    insertBefore(newChild, refChild) {
+        if (newChild && newChild._id) {
+            __aura_insert_before(this._id, newChild._id, refChild ? refChild._id : null);
+        }
+        return newChild;
+    }
+    replaceChild(newChild, oldChild) {
+        if (newChild && newChild._id && oldChild && oldChild._id) {
+            __aura_insert_before(this._id, newChild._id, oldChild._id);
+            __aura_remove_child(this._id, oldChild._id);
+        }
+        return oldChild;
+    }
+    cloneNode(deep) {
+        // Shallow clone: create same-tag element, copy attributes
+        let info = __aura_get_node_info(this._id);
+        if (!info) return null;
+        let clone = document.createElement(info.tag);
+        // Copy all attributes via innerHTML trick is too complex; skip for now
+        return clone;
+    }
+    contains(other) {
+        if (!other || !other._id) return false;
+        if (other._id === this._id) return true;
+        let children = JSON.parse(__aura_get_children(this._id));
+        for (let c of children) {
+            let child_node = __get_or_create_node(c.nid, c.tag, c.id);
+            if (child_node.contains(other)) return true;
+        }
+        return false;
     }
 }
 
@@ -104,21 +253,137 @@ class Element extends Node {
         super(id);
         this.tagName = (tag || '').toUpperCase();
         this.id = string_id || '';
+        this._classList = null;
         this.style = new Proxy({ _id: id }, {
             set: (target, prop, value) => {
                 let kebab = prop.replace(/([A-Z])/g, "-$1").toLowerCase();
                 __aura_set_style(target._id, kebab, value);
                 target[prop] = value;
                 return true;
+            },
+            get: (target, prop) => {
+                return target[prop];
             }
         });
+    }
+    get classList() {
+        if (!this._classList) this._classList = new DOMTokenList(this._id);
+        return this._classList;
+    }
+    get className() {
+        return __aura_get_attribute(this._id, 'class') || '';
+    }
+    set className(val) {
+        __aura_set_attribute(this._id, 'class', String(val));
+    }
+    get innerHTML() {
+        return __aura_get_inner_html(this._id);
+    }
+    set innerHTML(val) {
+        __aura_set_inner_html(this._id, String(val));
+    }
+    get outerHTML() {
+        let info = __aura_get_node_info(this._id);
+        if (!info) return '';
+        let inner = __aura_get_inner_html(this._id);
+        let tag = info.tag.toLowerCase();
+        let cls = info.class ? ` class="${info.class}"` : '';
+        let id_attr = info.id ? ` id="${info.id}"` : '';
+        return `<${tag}${id_attr}${cls}>${inner}</${tag}>`;
+    }
+    get textContent() {
+        return __aura_get_text_content(this._id);
+    }
+    set textContent(val) {
+        __aura_set_text_content(this._id, String(val));
     }
     setAttribute(name, value) {
         __aura_set_attribute(this._id, name, String(value));
     }
+    getAttribute(name) {
+        return __aura_get_attribute(this._id, name);
+    }
+    removeAttribute(name) {
+        __aura_remove_attribute(this._id, name);
+    }
+    hasAttribute(name) {
+        return __aura_has_attribute(this._id, name);
+    }
+    remove() {
+        __aura_remove_self(this._id);
+    }
     focus() {
         __aura_set_focus(this.id);
     }
+    blur() {}
+    matches(selector) {
+        // Use querySelector from root to check if this element matches
+        // Simplified: just check tag/class/id
+        let nids_json = __aura_query_selector_all(0, selector);
+        let nids = JSON.parse(nids_json);
+        return nids.includes(this._id);
+    }
+    closest(selector) {
+        let node = this;
+        while (node) {
+            if (node.matches && node.matches(selector)) return node;
+            node = node.parentNode;
+        }
+        return null;
+    }
+    querySelector(selector) {
+        let nid = __aura_query_selector(this._id, selector);
+        if (!nid) return null;
+        let info = __aura_get_node_info(nid);
+        return info ? __get_or_create_node(nid, info.tag, info.id) : __get_or_create_node(nid);
+    }
+    querySelectorAll(selector) {
+        let nids_json = __aura_query_selector_all(this._id, selector);
+        let nids = JSON.parse(nids_json);
+        return new NodeList(nids.map(nid => {
+            let info = __aura_get_node_info(nid);
+            return __get_or_create_node(nid, info ? info.tag : null, info ? info.id : null);
+        }).map(el => el._id));
+    }
+    getElementsByClassName(cls) {
+        let nids_json = __aura_get_elements_by_class(this._id, cls);
+        let nids = JSON.parse(nids_json);
+        return new NodeList(nids);
+    }
+    getElementsByTagName(tag) {
+        let nids_json = __aura_get_elements_by_tag(this._id, tag.toLowerCase());
+        let nids = JSON.parse(nids_json);
+        return new NodeList(nids);
+    }
+    get children() {
+        let arr = JSON.parse(__aura_get_children(this._id));
+        return new NodeList(arr.map(c => {
+            __get_or_create_node(c.nid, c.tag, c.id);
+            return c.nid;
+        }));
+    }
+    get childElementCount() {
+        let arr = JSON.parse(__aura_get_children(this._id));
+        return arr.length;
+    }
+    get firstElementChild() {
+        let arr = JSON.parse(__aura_get_children(this._id));
+        if (arr.length === 0) return null;
+        let c = arr[0];
+        return __get_or_create_node(c.nid, c.tag, c.id);
+    }
+    get lastElementChild() {
+        let arr = JSON.parse(__aura_get_children(this._id));
+        if (arr.length === 0) return null;
+        let c = arr[arr.length - 1];
+        return __get_or_create_node(c.nid, c.tag, c.id);
+    }
+    // getBoundingClientRect stub — returns zeros (layout info not available in JS)
+    getBoundingClientRect() {
+        return { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
+    }
+    // scrollIntoView stub
+    scrollIntoView() {}
 }
 
 // -- Storage -----------------------------------------------------------------
@@ -138,7 +403,34 @@ var localStorage = {
 };
 
 // -- document -----------------------------------------------------------------
+var _document_listeners = new Map();
+
 var document = {
+    // Event listener support on document itself
+    _listeners: new Map(),
+    addEventListener: function(type, callback) {
+        if (!this._listeners.has(type)) this._listeners.set(type, []);
+        this._listeners.get(type).push(callback);
+        // DOMContentLoaded fires immediately (page already loaded)
+        if (type === 'DOMContentLoaded') {
+            try { callback(new Event('DOMContentLoaded')); } catch(e) {}
+        }
+    },
+    removeEventListener: function(type, callback) {
+        if (!this._listeners.has(type)) return;
+        this._listeners.set(type, this._listeners.get(type).filter(l => l !== callback));
+    },
+    dispatchEvent: function(event) {
+        event.target = this;
+        let list = this._listeners.get(event.type);
+        if (list) {
+            for (let l of list) {
+                try { l.call(this, event); } catch(e) { console.log("Event Error: " + e); }
+            }
+        }
+        return !event.defaultPrevented;
+    },
+
     getElementById: function(id) {
         let res = __aura_get_element_by_id(id);
         return res ? __get_or_create_node(res.nid, res.tag, id) : null;
@@ -147,15 +439,61 @@ var document = {
         let nativeId = __aura_create_element(tag);
         return __get_or_create_node(nativeId, tag);
     },
+    createTextNode: function(text) {
+        // Create a text node — for now return a minimal node-like object
+        return { _id: 0, _text: text, nodeType: 3, textContent: text };
+    },
+    createDocumentFragment: function() {
+        return document.createElement('div');
+    },
+
+    querySelector: function(selector) {
+        let nid = __aura_query_selector(0, selector);
+        if (!nid) return null;
+        let info = __aura_get_node_info(nid);
+        return info ? __get_or_create_node(nid, info.tag, info.id) : __get_or_create_node(nid);
+    },
+    querySelectorAll: function(selector) {
+        let nids_json = __aura_query_selector_all(0, selector);
+        let nids = JSON.parse(nids_json);
+        let nodes = nids.map(nid => {
+            let info = __aura_get_node_info(nid);
+            return __get_or_create_node(nid, info ? info.tag : null, info ? info.id : null);
+        });
+        return new NodeList(nodes.map(n => n._id));
+    },
+    getElementsByClassName: function(cls) {
+        let nids_json = __aura_get_elements_by_class(0, cls);
+        let nids = JSON.parse(nids_json);
+        return new NodeList(nids);
+    },
+    getElementsByTagName: function(tag) {
+        let nids_json = __aura_get_elements_by_tag(0, tag.toLowerCase());
+        let nids = JSON.parse(nids_json);
+        return new NodeList(nids);
+    },
+
     get body() {
         let nativeId = __aura_get_body();
         return nativeId ? __get_or_create_node(nativeId, 'body') : null;
+    },
+    get head() {
+        let nids_json = __aura_get_elements_by_tag(0, 'head');
+        let nids = JSON.parse(nids_json);
+        if (nids.length === 0) return null;
+        return __get_or_create_node(nids[0], 'head');
+    },
+    get documentElement() {
+        let nids_json = __aura_get_elements_by_tag(0, 'html');
+        let nids = JSON.parse(nids_json);
+        if (nids.length === 0) return null;
+        return __get_or_create_node(nids[0], 'html');
     },
     activeElement: null,
     location: { href: '', hostname: '', pathname: '/', search: '', hash: '' },
     title: '',
     readyState: 'complete',
-    
+
     // Internal bridge for Rust to trigger events
     __trigger_event: function(id, type, data) {
         let target = __get_or_create_node(id);
@@ -183,9 +521,51 @@ window.setTimeout = function(fn, delay) {
     return 1;
 };
 
+window.clearTimeout = function() {};
+window.setInterval = function(fn, delay) {
+    // Simplified: run once as macro task
+    if (typeof fn === 'function') {
+        __aura_queue_task(fn);
+    }
+    return 1;
+};
+window.clearInterval = function() {};
+
 // -- fetch() -----------------------------------------------------------------
 window.fetch = function(url) {
     return new Promise((resolve, reject) => {
         __aura_fetch(url, resolve, reject);
     });
 };
+
+// -- MutationObserver stub ---------------------------------------------------
+class MutationObserver {
+    constructor(callback) { this._callback = callback; }
+    observe(target, options) {}
+    disconnect() {}
+    takeRecords() { return []; }
+}
+
+// -- IntersectionObserver stub -----------------------------------------------
+class IntersectionObserver {
+    constructor(callback, options) { this._callback = callback; }
+    observe(target) {}
+    unobserve(target) {}
+    disconnect() {}
+}
+
+// -- ResizeObserver stub -----------------------------------------------------
+class ResizeObserver {
+    constructor(callback) { this._callback = callback; }
+    observe(target) {}
+    unobserve(target) {}
+    disconnect() {}
+}
+
+// -- CustomEvent -------------------------------------------------------------
+class CustomEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.detail = options.detail !== undefined ? options.detail : null;
+    }
+}


### PR DESCRIPTION
## Summary

- **Query APIs**: `document.querySelector`, `querySelectorAll`, `getElementsByClassName`, `getElementsByTagName`, plus element-scoped variants — backed by a Rust CSS selector engine supporting tag, `#id`, `.class`, compound selectors, descendant combinators (`ancestor desc`), and `[attr=val]` attribute selectors
- **Mutation APIs**: `createElement`, `appendChild`, `removeChild`, `insertBefore`, `remove`, `innerHTML` getter/setter, `textContent` getter/setter — DOM tree modified in-place on the rcdom handles so style/layout re-render sees the changes
- **Attribute APIs**: `getAttribute`, `setAttribute`, `removeAttribute`, `hasAttribute`
- **ClassList**: `DOMTokenList` with `add`, `remove`, `toggle`, `contains`, `replace`
- **Events**: `addEventListener`/`removeEventListener`/`dispatchEvent` added to both `Element` and `document`; `DOMContentLoaded` fires synchronously when registered (page already loaded)
- **Observer stubs**: `MutationObserver`, `IntersectionObserver`, `ResizeObserver`, `CustomEvent` — prevents crashes on sites that guard with feature detection
- **Key fix**: `parse_html_fragment` steals children from the parser DOM before it's dropped, preventing `Node::drop`'s iterative child-clearing from clobbering text nodes

## Test plan

- [x] 20 new unit tests in `js::tests` covering: querySelector, textContent, getElementById, querySelectorAll count, getAttribute, classList add/contains/remove/toggle, getElementsByClassName/TagName, addEventListener fires, DOMContentLoaded, selector by class/id, innerHTML getter/setter, fragment text content preservation
- [x] All 138 unit tests pass (`cargo test --lib`)
- [x] `cargo build --bins` succeeds with no errors
- [x] CLI reviewer: `browser-cli navigate https://yunseong.dev` — renders full page with nav, content, Korean text
- [x] CLI reviewer: `browser-cli navigate https://google.com` — renders search page with links, forms

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)