### PR TITLE
feat: stub missing DOM/runtime APIs for google.com pre-layout parity (#113)

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -246,6 +246,7 @@ impl JsRuntime {
                 let mut obj = ObjectInitializer::new(_context);
                 obj.property(js_string!("nid"), JsValue::from(nid), boa_engine::property::Attribute::all());
                 obj.property(js_string!("tag"), JsValue::from(js_string!(tag)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("kind"), JsValue::from(js_string!("element")), boa_engine::property::Attribute::all());
                 Ok(obj.build().into())
             } else {
                 Ok(JsValue::null())
@@ -375,6 +376,23 @@ impl JsRuntime {
             Ok(JsValue::undefined())
         });
         context.register_global_callable(js_string!("__aura_queue_task"), 1, queue_task).unwrap();
+
+        // Register native __aura_resolve_url
+        let resolve_url = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let input = args.get(0).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let base = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let resolved = if !base.is_empty() {
+                Url::parse(&base)
+                    .ok()
+                    .and_then(|b| b.join(&input).ok())
+                    .or_else(|| Url::parse(&input).ok())
+            } else {
+                Url::parse(&input).ok()
+            };
+            let out = resolved.map(|u| u.to_string()).unwrap_or(input);
+            Ok(JsValue::from(js_string!(out)))
+        });
+        context.register_global_callable(js_string!("__aura_resolve_url"), 2, resolve_url).unwrap();
 
         // Register native __aura_fetch
         let aura_fetch = NativeFunction::from_copy_closure(|_this, args, _context| {
@@ -595,6 +613,22 @@ impl JsRuntime {
         });
         context.register_global_callable(js_string!("__aura_create_element"), 1, create_element).unwrap();
 
+        // __aura_create_text_node(text) -> nid
+        let create_text_node = NativeFunction::from_copy_closure(|_this, args, _context| {
+            use html5ever::tendril::StrTendril;
+            use markup5ever_rcdom::{Node, NodeData};
+
+            let text = args.get(0)
+                .and_then(|v| v.as_string())
+                .map(|s| s.to_std_string_escaped())
+                .unwrap_or_default();
+            let node = Node::new(NodeData::Text {
+                contents: std::cell::RefCell::new(StrTendril::from(text.as_str())),
+            });
+            Ok(JsValue::from(register_node(node)))
+        });
+        context.register_global_callable(js_string!("__aura_create_text_node"), 1, create_text_node).unwrap();
+
         // __aura_append_child(parent_nid, child_nid) → void
         let append_child = NativeFunction::from_copy_closure(|_this, args, _context| {
             let parent_nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
@@ -747,15 +781,23 @@ impl JsRuntime {
             NODE_REGISTRY.with(|reg| {
                 let reg = reg.borrow();
                 if let Some(node) = reg.get(&nid) {
-                    use markup5ever_rcdom::Node;
-                    use html5ever::tendril::StrTendril;
-                    let text_node = Node::new(NodeData::Text {
-                        contents: std::cell::RefCell::new(StrTendril::from(text.as_str())),
-                    });
-                    text_node.parent.set(Some(Rc::downgrade(node)));
-                    let mut children = node.children.borrow_mut();
-                    children.clear();
-                    children.push(text_node);
+                    match &node.data {
+                        NodeData::Text { contents } => {
+                            *contents.borrow_mut() = text.as_str().into();
+                        }
+                        _ => {
+                            use html5ever::tendril::StrTendril;
+                            use markup5ever_rcdom::Node;
+
+                            let text_node = Node::new(NodeData::Text {
+                                contents: std::cell::RefCell::new(StrTendril::from(text.as_str())),
+                            });
+                            text_node.parent.set(Some(Rc::downgrade(node)));
+                            let mut children = node.children.borrow_mut();
+                            children.clear();
+                            children.push(text_node);
+                        }
+                    }
                 }
             });
             Ok(JsValue::undefined())
@@ -823,14 +865,20 @@ impl JsRuntime {
                 if let Some(node) = reg.get(&nid) {
                     let mut items = Vec::new();
                     for child in node.children.borrow().iter() {
-                        if let NodeData::Element { ref name, ref attrs, .. } = child.data {
-                            let tag = name.local.to_string();
-                            let id_attr = attrs.borrow().iter()
-                                .find(|a| a.name.local.to_string() == "id")
-                                .map(|a| a.value.to_string())
-                                .unwrap_or_default();
-                            let child_nid = register_node(child.clone());
-                            items.push(format!("{{\"nid\":{},\"tag\":\"{}\",\"id\":\"{}\"}}", child_nid, tag, id_attr));
+                        let child_nid = register_node(child.clone());
+                        match &child.data {
+                            NodeData::Element { ref name, ref attrs, .. } => {
+                                let tag = name.local.to_string();
+                                let id_attr = attrs.borrow().iter()
+                                    .find(|a| a.name.local.to_string() == "id")
+                                    .map(|a| a.value.to_string())
+                                    .unwrap_or_default();
+                                items.push(format!("{{\"nid\":{},\"tag\":\"{}\",\"id\":\"{}\",\"kind\":\"element\"}}", child_nid, tag, id_attr));
+                            }
+                            NodeData::Text { .. } => {
+                                items.push(format!("{{\"nid\":{},\"tag\":\"\",\"id\":\"\",\"kind\":\"text\"}}", child_nid));
+                            }
+                            _ => {}
                         }
                     }
                     items.join(",")
@@ -853,23 +901,93 @@ impl JsRuntime {
                         let attrs_b = attrs.borrow();
                         let id = attrs_b.iter().find(|a| a.name.local.to_string() == "id").map(|a| a.value.to_string()).unwrap_or_default();
                         let class = attrs_b.iter().find(|a| a.name.local.to_string() == "class").map(|a| a.value.to_string()).unwrap_or_default();
-                        return Some((tag, id, class));
+                        return Some((tag, id, class, "element".to_string()));
+                    } else if let NodeData::Text { .. } = node.data {
+                        return Some((String::new(), String::new(), String::new(), "text".to_string()));
                     }
                 }
                 None
             });
-            if let Some((tag, id, class)) = info {
+            if let Some((tag, id, class, kind)) = info {
                 use boa_engine::object::ObjectInitializer;
                 let mut obj = ObjectInitializer::new(context);
                 obj.property(js_string!("tag"), JsValue::from(js_string!(tag)), boa_engine::property::Attribute::all());
                 obj.property(js_string!("id"), JsValue::from(js_string!(id)), boa_engine::property::Attribute::all());
                 obj.property(js_string!("class"), JsValue::from(js_string!(class)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("kind"), JsValue::from(js_string!(kind)), boa_engine::property::Attribute::all());
                 Ok(obj.build().into())
             } else {
                 Ok(JsValue::null())
             }
         });
         context.register_global_callable(js_string!("__aura_get_node_info"), 1, get_node_info).unwrap();
+
+        // __aura_get_node_type(nid) -> DOM nodeType integer
+        let get_node_type = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let node_type = NODE_REGISTRY.with(|reg| {
+                reg.borrow().get(&nid).map(|node| match node.data {
+                    NodeData::Element { .. } => 1,
+                    NodeData::Text { .. } => 3,
+                    NodeData::Comment { .. } => 8,
+                    NodeData::Document => 9,
+                    _ => 0,
+                }).unwrap_or(0)
+            });
+            Ok(JsValue::from(node_type))
+        });
+        context.register_global_callable(js_string!("__aura_get_node_type"), 1, get_node_type).unwrap();
+
+        // __aura_parse_url(url, base) -> object|null
+        let parse_url = NativeFunction::from_copy_closure(|_this, args, context| {
+            let url_input = args.get(0)
+                .and_then(|v| v.as_string())
+                .map(|s| s.to_std_string_escaped())
+                .unwrap_or_default();
+            let base_input = args.get(1)
+                .and_then(|v| v.as_string())
+                .map(|s| s.to_std_string_escaped());
+
+            let parsed = if let Some(base) = base_input.as_deref() {
+                Url::parse(base).ok().and_then(|base_url| base_url.join(&url_input).ok())
+            } else {
+                Url::parse(&url_input).ok()
+            };
+
+            if let Some(url) = parsed {
+                use boa_engine::object::ObjectInitializer;
+                let href = url.to_string();
+                let hostname = url.host_str().unwrap_or("").to_string();
+                let pathname = url.path().to_string();
+                let search = url.query().map(|q| format!("?{}", q)).unwrap_or_default();
+                let hash = url.fragment().map(|f| format!("#{}", f)).unwrap_or_default();
+                let protocol = format!("{}:", url.scheme());
+                let host = url.host_str().map(|h| {
+                    if let Some(port) = url.port() {
+                        format!("{}:{}", h, port)
+                    } else {
+                        h.to_string()
+                    }
+                }).unwrap_or_default();
+                let port = url.port().map(|p| p.to_string()).unwrap_or_default();
+                let origin = url.origin().unicode_serialization();
+
+                let mut obj = ObjectInitializer::new(context);
+                obj.property(js_string!("href"), JsValue::from(js_string!(href)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("hostname"), JsValue::from(js_string!(hostname)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("pathname"), JsValue::from(js_string!(pathname)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("search"), JsValue::from(js_string!(search)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("hash"), JsValue::from(js_string!(hash)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("protocol"), JsValue::from(js_string!(protocol)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("host"), JsValue::from(js_string!(host)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("port"), JsValue::from(js_string!(port)), boa_engine::property::Attribute::all());
+                obj.property(js_string!("origin"), JsValue::from(js_string!(origin)), boa_engine::property::Attribute::all());
+                Ok(obj.build().into())
+            } else {
+                Ok(JsValue::null())
+            }
+        });
+        context.register_global_callable(js_string!("__aura_parse_url"), 2, parse_url).unwrap();
 
         // Load bootstrap
         let bootstrap = include_str!("js_bootstrap.js");
@@ -892,11 +1010,7 @@ impl JsRuntime {
                     }
                 }).unwrap_or_default();
                 let port = url.port().map(|p| p.to_string()).unwrap_or_default();
-                let origin = if url.scheme() == "null" || url.scheme() == "about" {
-                    "null".to_string()
-                } else {
-                    format!("{}://{}", url.scheme(), url.host_str().unwrap_or(""))
-                };
+                let origin = url.origin().unicode_serialization();
                 format!(
                     r#"(function() {{
                         var _loc = {{
@@ -1787,6 +1901,66 @@ mod tests {
     }
 
     #[test]
+    fn test_history_push_and_replace_state_updates_location() {
+        let url = url::Url::parse("https://example.com:8443/app/index.html").unwrap();
+        let dom = crate::dom::parse_html("<html><body></body></html>");
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None);
+
+        let result = eval(&mut rt, r#"
+            (function() {
+                history.pushState({page: 1}, '', '/dashboard?tab=home#top');
+                var afterPush = [
+                    history.length,
+                    JSON.stringify(history.state),
+                    location.href,
+                    location.origin,
+                    document.URL
+                ].join('|');
+
+                history.replaceState({page: 2}, '', 'settings');
+                var afterReplace = [
+                    history.length,
+                    JSON.stringify(history.state),
+                    location.href,
+                    location.origin,
+                    document.baseURI
+                ].join('|');
+
+                return afterPush + '||' + afterReplace;
+            })()
+        "#);
+
+        assert_eq!(
+            result,
+            "2|{\"page\":1}|https://example.com:8443/dashboard?tab=home#top|https://example.com:8443|https://example.com:8443/dashboard?tab=home#top||2|{\"page\":2}|https://example.com:8443/settings|https://example.com:8443|https://example.com:8443/settings"
+        );
+    }
+
+    #[test]
+    fn test_create_text_node_append_and_insert() {
+        let mut rt = make_runtime("<html><body><div id='app'></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var tail = document.createElement('span');
+                tail.textContent = 'tail';
+                app.appendChild(tail);
+                var head = document.createTextNode('head');
+                app.insertBefore(head, tail);
+                return [
+                    app.childNodes.length,
+                    app.firstChild.nodeType,
+                    app.lastChild.nodeType,
+                    app.textContent,
+                    app.children.length
+                ].join(':');
+            })()
+        "#);
+
+        assert_eq!(result, "2:3:1:headtail:1");
+    }
+
+    #[test]
     fn test_performance_now() {
         let mut rt = make_runtime("<html><body></body></html>");
         let result = eval(&mut rt, "typeof window.performance.now()");
@@ -1876,17 +2050,21 @@ mod tests {
 
     #[test]
     fn test_window_location_set_from_url() {
-        let url = url::Url::parse("https://www.example.com/path?q=1#hash").unwrap();
+        let url = url::Url::parse("https://www.example.com:8443/path?q=1#hash").unwrap();
         let dom = crate::dom::parse_html("<html><body></body></html>");
         let mut rt = JsRuntime::new(Some(dom.document), Some(url), None);
         let href = if let Ok(val) = rt.context.eval(Source::from_bytes(b"window.location.href")) {
             if let Ok(s) = val.to_string(&mut rt.context) { s.to_std_string_escaped() } else { String::new() }
         } else { String::new() };
-        assert_eq!(href, "https://www.example.com/path?q=1#hash");
+        assert_eq!(href, "https://www.example.com:8443/path?q=1#hash");
         let hostname = if let Ok(val) = rt.context.eval(Source::from_bytes(b"window.location.hostname")) {
             if let Ok(s) = val.to_string(&mut rt.context) { s.to_std_string_escaped() } else { String::new() }
         } else { String::new() };
         assert_eq!(hostname, "www.example.com");
+        let origin = if let Ok(val) = rt.context.eval(Source::from_bytes(b"window.location.origin")) {
+            if let Ok(s) = val.to_string(&mut rt.context) { s.to_std_string_escaped() } else { String::new() }
+        } else { String::new() };
+        assert_eq!(origin, "https://www.example.com:8443");
     }
 
     #[test]
@@ -1899,8 +2077,8 @@ mod tests {
     #[test]
     fn test_url_constructor() {
         let mut rt = make_runtime("<html><body></body></html>");
-        let result = eval(&mut rt, "(function() { var u = new URL('https://example.com/path?q=1'); return u.hostname + ':' + u.pathname; })()");
-        assert_eq!(result, "example.com:/path");
+        let result = eval(&mut rt, "(function() { var u = new URL('/path?q=1', 'https://example.com:8443/base/index.html'); return u.href + '|' + u.origin; })()");
+        assert_eq!(result, "https://example.com:8443/path?q=1|https://example.com:8443");
     }
 
     #[test]

--- a/src/js.rs
+++ b/src/js.rs
@@ -875,6 +875,59 @@ impl JsRuntime {
         let bootstrap = include_str!("js_bootstrap.js");
         let _ = context.eval(Source::from_bytes(bootstrap.as_bytes()));
 
+        // Inject the base URL into the JS location and document.location objects
+        let url_init = CURRENT_ORIGIN.with(|origin| {
+            if let Some(ref url) = *origin.borrow() {
+                let href = url.to_string();
+                let hostname = url.host_str().unwrap_or("").to_string();
+                let pathname = url.path().to_string();
+                let search = url.query().map(|q| format!("?{}", q)).unwrap_or_default();
+                let hash = url.fragment().map(|f| format!("#{}", f)).unwrap_or_default();
+                let protocol = url.scheme().to_string() + ":";
+                let host = url.host_str().map(|h| {
+                    if let Some(port) = url.port() {
+                        format!("{}:{}", h, port)
+                    } else {
+                        h.to_string()
+                    }
+                }).unwrap_or_default();
+                let port = url.port().map(|p| p.to_string()).unwrap_or_default();
+                let origin = if url.scheme() == "null" || url.scheme() == "about" {
+                    "null".to_string()
+                } else {
+                    format!("{}://{}", url.scheme(), url.host_str().unwrap_or(""))
+                };
+                format!(
+                    r#"(function() {{
+                        var _loc = {{
+                            href: {href:?},
+                            hostname: {hostname:?},
+                            pathname: {pathname:?},
+                            search: {search:?},
+                            hash: {hash:?},
+                            protocol: {protocol:?},
+                            host: {host:?},
+                            port: {port:?},
+                            origin: {origin:?},
+                        }};
+                        document.location = _loc;
+                        document.URL = {href:?};
+                        document.documentURI = {href:?};
+                        document.baseURI = {href:?};
+                        window.location = _loc;
+                        location = _loc;
+                    }})();"#
+                )
+            } else {
+                String::new()
+            }
+        });
+        if !url_init.is_empty() {
+            if let Err(e) = context.eval(Source::from_bytes(url_init.as_bytes())) {
+                println!("[JS Bootstrap] URL init error: {:?}", e);
+            }
+        }
+
         Self { context, task_receiver }
     }
 
@@ -1693,5 +1746,174 @@ mod tests {
         // Also check querySelector works after mutation
         let found = eval(&mut rt, "document.querySelector('#app p') !== null ? 'found' : 'null'");
         assert_eq!(found, "found", "Expected querySelector('#app p') to find element after innerHTML set");
+    }
+
+    // ── New runtime parity tests (#113) ──────────────────────────────────────
+
+    #[test]
+    fn test_window_inner_dimensions() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let w = eval(&mut rt, "window.innerWidth");
+        let h = eval(&mut rt, "window.innerHeight");
+        assert_eq!(w, "800");
+        assert_eq!(h, "600");
+    }
+
+    #[test]
+    fn test_navigator_user_agent_chrome() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let ua = eval(&mut rt, "navigator.userAgent");
+        assert!(ua.contains("Mozilla"), "Expected Chrome-like UA, got: {}", ua);
+        assert!(ua.contains("AppleWebKit"), "Expected WebKit UA, got: {}", ua);
+    }
+
+    #[test]
+    fn test_navigator_platform() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let platform = eval(&mut rt, "navigator.platform");
+        assert!(!platform.is_empty(), "Expected non-empty platform");
+    }
+
+    #[test]
+    fn test_history_object() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, "typeof window.history");
+        assert_eq!(result, "object");
+        let push = eval(&mut rt, "typeof window.history.pushState");
+        assert_eq!(push, "function");
+        // pushState should not throw
+        let ok = eval(&mut rt, "(function() { try { history.pushState(null,'','/path'); return 'ok'; } catch(e) { return 'err:'+e; } })()");
+        assert_eq!(ok, "ok");
+    }
+
+    #[test]
+    fn test_performance_now() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, "typeof window.performance.now()");
+        assert_eq!(result, "number");
+    }
+
+    #[test]
+    fn test_document_cookie_empty_string() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let cookie = eval(&mut rt, "document.cookie");
+        assert_eq!(cookie, "", "Expected empty cookie string");
+        // Writing should not throw
+        let ok = eval(&mut rt, "(function() { try { document.cookie = 'test=1'; return 'ok'; } catch(e) { return 'err'; } })()");
+        assert_eq!(ok, "ok");
+    }
+
+    #[test]
+    fn test_session_storage_get_set() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        eval(&mut rt, "sessionStorage.setItem('k', 'v')");
+        let val = eval(&mut rt, "sessionStorage.getItem('k')");
+        assert_eq!(val, "v");
+    }
+
+    #[test]
+    fn test_get_computed_style_stub() {
+        let mut rt = make_runtime("<html><body><div id='el'>x</div></body></html>");
+        let result = eval(&mut rt, "(function() { var el = document.getElementById('el'); var s = window.getComputedStyle(el); return typeof s; })()");
+        assert_eq!(result, "object");
+    }
+
+    #[test]
+    fn test_node_constants() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let elem = eval(&mut rt, "Node.ELEMENT_NODE");
+        assert_eq!(elem, "1");
+        let text = eval(&mut rt, "Node.TEXT_NODE");
+        assert_eq!(text, "3");
+        let comment = eval(&mut rt, "Node.COMMENT_NODE");
+        assert_eq!(comment, "8");
+    }
+
+    #[test]
+    fn test_element_node_type() {
+        let mut rt = make_runtime("<html><body><div id='el'>x</div></body></html>");
+        let result = eval(&mut rt, "document.getElementById('el').nodeType");
+        assert_eq!(result, "1");
+    }
+
+    #[test]
+    fn test_image_constructor() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        // new Image() should not throw
+        let result = eval(&mut rt, "(function() { try { var img = new Image(100,50); return typeof img; } catch(e) { return 'err:'+e; } })()");
+        assert_eq!(result, "object");
+    }
+
+    #[test]
+    fn test_xml_http_request_stub() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, "(function() { try { var xhr = new XMLHttpRequest(); xhr.open('GET', '/test'); return 'ok'; } catch(e) { return 'err:'+e; } })()");
+        assert_eq!(result, "ok");
+    }
+
+    #[test]
+    fn test_match_media_returns_object() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, "(function() { var mm = window.matchMedia('(max-width: 800px)'); return typeof mm.matches; })()");
+        assert_eq!(result, "boolean");
+    }
+
+    #[test]
+    fn test_window_screen_properties() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let w = eval(&mut rt, "window.screen.width");
+        let h = eval(&mut rt, "window.screen.height");
+        assert_eq!(w, "800");
+        assert_eq!(h, "600");
+    }
+
+    #[test]
+    fn test_device_pixel_ratio() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let dpr = eval(&mut rt, "window.devicePixelRatio");
+        assert_eq!(dpr, "1");
+    }
+
+    #[test]
+    fn test_window_location_set_from_url() {
+        let url = url::Url::parse("https://www.example.com/path?q=1#hash").unwrap();
+        let dom = crate::dom::parse_html("<html><body></body></html>");
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None);
+        let href = if let Ok(val) = rt.context.eval(Source::from_bytes(b"window.location.href")) {
+            if let Ok(s) = val.to_string(&mut rt.context) { s.to_std_string_escaped() } else { String::new() }
+        } else { String::new() };
+        assert_eq!(href, "https://www.example.com/path?q=1#hash");
+        let hostname = if let Ok(val) = rt.context.eval(Source::from_bytes(b"window.location.hostname")) {
+            if let Ok(s) = val.to_string(&mut rt.context) { s.to_std_string_escaped() } else { String::new() }
+        } else { String::new() };
+        assert_eq!(hostname, "www.example.com");
+    }
+
+    #[test]
+    fn test_keyboard_event_constructor() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, "(function() { var e = new KeyboardEvent('keydown', {key: 'Enter', keyCode: 13}); return e.key + ':' + e.keyCode; })()");
+        assert_eq!(result, "Enter:13");
+    }
+
+    #[test]
+    fn test_url_constructor() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, "(function() { var u = new URL('https://example.com/path?q=1'); return u.hostname + ':' + u.pathname; })()");
+        assert_eq!(result, "example.com:/path");
+    }
+
+    #[test]
+    fn test_abort_controller() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, "(function() { var ctrl = new AbortController(); ctrl.abort(); return ctrl.signal.aborted ? 'aborted' : 'not'; })()");
+        assert_eq!(result, "aborted");
+    }
+
+    #[test]
+    fn test_window_crypto_get_random_values() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, "(function() { try { var arr = new Uint8Array(4); window.crypto.getRandomValues(arr); return 'ok'; } catch(e) { return 'err:'+e; } })()");
+        assert_eq!(result, "ok");
     }
 }

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -170,10 +170,15 @@ class NodeList {
 }
 
 // -- Node & Element Classes ---------------------------------------------------
+
+// Node type constants (static properties added after class definition)
 class Node extends EventTarget {
     constructor(id) {
         super();
         this._id = id;
+    }
+    get nodeType() {
+        return 1; // ELEMENT_NODE by default for Node instances used as elements
     }
     get parentNode() {
         let pid = __aura_get_parent_id(this._id);
@@ -382,9 +387,141 @@ class Element extends Node {
     getBoundingClientRect() {
         return { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
     }
+    getClientRects() { return []; }
     // scrollIntoView stub
     scrollIntoView() {}
+    scroll() {}
+    scrollTo() {}
+    scrollBy() {}
+    // nodeType for Element is always ELEMENT_NODE (1)
+    get nodeType() { return 1; }
+    // Sibling navigation stubs
+    get nextSibling() { return null; }
+    get previousSibling() { return null; }
+    get nextElementSibling() { return null; }
+    get previousElementSibling() { return null; }
+    // insertAdjacentHTML: inject HTML relative to this element
+    insertAdjacentHTML(position, html) {
+        position = position.toLowerCase();
+        if (position === 'beforeend' || position === 'afterbegin') {
+            // Append/prepend to children
+            var frag = document.createElement('div');
+            frag.innerHTML = html;
+            var children = JSON.parse(__aura_get_children(frag._id));
+            for (var i = 0; i < children.length; i++) {
+                var child = __get_or_create_node(children[i].nid, children[i].tag, children[i].id);
+                if (position === 'beforeend') {
+                    this.appendChild(child);
+                } else {
+                    this.insertBefore(child, this.firstChild);
+                }
+            }
+        }
+        // 'beforebegin' and 'afterend' require parent access — stub as no-op
+    }
+    insertAdjacentText(position, text) {
+        // Simplified: treat as insertAdjacentHTML with escaped text
+    }
+    insertAdjacentElement(position, element) {
+        position = position.toLowerCase();
+        if (position === 'beforeend') this.appendChild(element);
+        return element;
+    }
+    // dataset stub
+    get dataset() {
+        var self = this;
+        return new Proxy({}, {
+            get: function(target, key) {
+                var attrName = 'data-' + key.replace(/([A-Z])/g, '-$1').toLowerCase();
+                return __aura_get_attribute(self._id, attrName);
+            },
+            set: function(target, key, value) {
+                var attrName = 'data-' + key.replace(/([A-Z])/g, '-$1').toLowerCase();
+                __aura_set_attribute(self._id, attrName, String(value));
+                return true;
+            }
+        });
+    }
+    // checked / value properties (for input elements)
+    get value() { return __aura_get_attribute(this._id, 'value') || ''; }
+    set value(v) { __aura_set_attribute(this._id, 'value', String(v)); }
+    get checked() { return __aura_has_attribute(this._id, 'checked'); }
+    set checked(v) {
+        if (v) __aura_set_attribute(this._id, 'checked', 'checked');
+        else __aura_remove_attribute(this._id, 'checked');
+    }
+    get disabled() { return __aura_has_attribute(this._id, 'disabled'); }
+    set disabled(v) {
+        if (v) __aura_set_attribute(this._id, 'disabled', 'disabled');
+        else __aura_remove_attribute(this._id, 'disabled');
+    }
+    get href() { return __aura_get_attribute(this._id, 'href') || ''; }
+    set href(v) { __aura_set_attribute(this._id, 'href', String(v)); }
+    get src() { return __aura_get_attribute(this._id, 'src') || ''; }
+    set src(v) { __aura_set_attribute(this._id, 'src', String(v)); }
+    get type() { return __aura_get_attribute(this._id, 'type') || ''; }
+    set type(v) { __aura_set_attribute(this._id, 'type', String(v)); }
+    get name() { return __aura_get_attribute(this._id, 'name') || ''; }
+    set name(v) { __aura_set_attribute(this._id, 'name', String(v)); }
+    // Form select stubs
+    get selectedIndex() { return -1; }
+    set selectedIndex(v) {}
+    get options() { return new NodeList([]); }
+    // offsetWidth / offsetHeight / scrollWidth / scrollHeight stubs
+    get offsetWidth() { return 0; }
+    get offsetHeight() { return 0; }
+    get offsetTop() { return 0; }
+    get offsetLeft() { return 0; }
+    get scrollWidth() { return 0; }
+    get scrollHeight() { return 0; }
+    get scrollTop() { return 0; }
+    set scrollTop(v) {}
+    get scrollLeft() { return 0; }
+    set scrollLeft(v) {}
+    get clientWidth() { return 0; }
+    get clientHeight() { return 0; }
+    // namespaceURI
+    get namespaceURI() { return 'http://www.w3.org/1999/xhtml'; }
+    // setAttributeNS / getAttributeNS / removeAttributeNS
+    setAttributeNS(ns, name, value) { this.setAttribute(name, value); }
+    getAttributeNS(ns, name) { return this.getAttribute(name); }
+    removeAttributeNS(ns, name) { this.removeAttribute(name); }
+    hasAttributeNS(ns, name) { return this.hasAttribute(name); }
+    // attachShadow stub
+    attachShadow(options) {
+        var host = this;
+        var shadow = document.createElement('div');
+        shadow._isShadowRoot = true;
+        shadow.host = host;
+        host._shadowRoot = shadow;
+        return shadow;
+    }
+    get shadowRoot() { return this._shadowRoot || null; }
+    // dispatchEvent is inherited from EventTarget; no override needed
+    // animate stub
+    animate(keyframes, options) {
+        return {
+            play: function() {},
+            pause: function() {},
+            cancel: function() {},
+            finish: function() {},
+            addEventListener: function() {},
+            removeEventListener: function() {},
+            finished: Promise.resolve(),
+            ready: Promise.resolve(),
+            playState: 'finished',
+        };
+    }
 }
+
+// -- Node static constants ---------------------------------------------------
+Node.ELEMENT_NODE = 1;
+Node.ATTRIBUTE_NODE = 2;
+Node.TEXT_NODE = 3;
+Node.CDATA_SECTION_NODE = 4;
+Node.COMMENT_NODE = 8;
+Node.DOCUMENT_NODE = 9;
+Node.DOCUMENT_FRAGMENT_NODE = 11;
 
 // -- Storage -----------------------------------------------------------------
 var localStorage = {
@@ -490,9 +627,128 @@ var document = {
         return __get_or_create_node(nids[0], 'html');
     },
     activeElement: null,
-    location: { href: '', hostname: '', pathname: '/', search: '', hash: '' },
+    location: { href: '', hostname: '', pathname: '/', search: '', hash: '', protocol: 'https:', host: '', port: '', origin: '' },
     title: '',
     readyState: 'complete',
+    referrer: '',
+    characterSet: 'UTF-8',
+    charset: 'UTF-8',
+    inputEncoding: 'UTF-8',
+    contentType: 'text/html',
+    URL: '',
+    documentURI: '',
+    baseURI: '',
+    nodeType: 9,
+    nodeName: '#document',
+    nodeValue: null,
+
+    // createTreeWalker stub
+    createTreeWalker: function(root, whatToShow, filter, expandEntityReferences) {
+        var nodes = [];
+        function collect(node) {
+            nodes.push(node);
+            var arr = JSON.parse(__aura_get_children(node._id));
+            for (var c of arr) {
+                var child = __get_or_create_node(c.nid, c.tag, c.id);
+                collect(child);
+            }
+        }
+        if (root && root._id) collect(root);
+        var i = 0;
+        return {
+            currentNode: root,
+            nextNode: function() {
+                if (i < nodes.length) { this.currentNode = nodes[i++]; return this.currentNode; }
+                return null;
+            },
+            previousNode: function() {
+                if (i > 0) { this.currentNode = nodes[--i]; return this.currentNode; }
+                return null;
+            },
+            firstChild: function() { return null; },
+            lastChild: function() { return null; },
+            nextSibling: function() { return null; },
+            previousSibling: function() { return null; },
+            parentNode: function() { return null; },
+        };
+    },
+
+    // createNodeIterator stub
+    createNodeIterator: function(root, whatToShow, filter) {
+        var nodes = [];
+        function collect(node) {
+            nodes.push(node);
+            var arr = JSON.parse(__aura_get_children(node._id));
+            for (var c of arr) {
+                var child = __get_or_create_node(c.nid, c.tag, c.id);
+                collect(child);
+            }
+        }
+        if (root && root._id) collect(root);
+        var i = 0;
+        return {
+            nextNode: function() { return i < nodes.length ? nodes[i++] : null; },
+            previousNode: function() { return i > 0 ? nodes[--i] : null; },
+            detach: function() {},
+        };
+    },
+
+    // createRange stub
+    createRange: function() {
+        return {
+            setStart: function() {},
+            setEnd: function() {},
+            selectNode: function() {},
+            selectNodeContents: function() {},
+            collapse: function() {},
+            cloneRange: function() { return document.createRange(); },
+            deleteContents: function() {},
+            extractContents: function() { return document.createDocumentFragment(); },
+            insertNode: function() {},
+            surroundContents: function() {},
+            getBoundingClientRect: function() { return { x:0, y:0, width:0, height:0, top:0, left:0, right:0, bottom:0 }; },
+            getClientRects: function() { return []; },
+            toString: function() { return ''; },
+            commonAncestorContainer: null,
+        };
+    },
+
+    // execCommand stub
+    execCommand: function(cmd, showUI, value) { return false; },
+    queryCommandEnabled: function(cmd) { return false; },
+    queryCommandSupported: function(cmd) { return false; },
+
+    // importNode stub
+    importNode: function(node, deep) { return node; },
+    adoptNode: function(node) { return node; },
+
+    // hasFocus stub
+    hasFocus: function() { return false; },
+
+    // visibilityState
+    visibilityState: 'visible',
+    hidden: false,
+
+    // fullscreenElement
+    fullscreenElement: null,
+    fullscreenEnabled: false,
+
+    // pointerLockElement
+    pointerLockElement: null,
+
+    // forms / images / scripts / links collections
+    get forms() { return new NodeList([]); },
+    get images() { return new NodeList([]); },
+    get scripts() {
+        let nids_json = __aura_get_elements_by_tag(0, 'script');
+        let nids = JSON.parse(nids_json);
+        return new NodeList(nids);
+    },
+    get links() {
+        let nids_json = __aura_get_elements_by_tag(0, 'a');
+        let nids = JSON.parse(nids_json);
+        return new NodeList(nids);
+    },
 
     // Internal bridge for Rust to trigger events
     __trigger_event: function(id, type, data) {
@@ -508,8 +764,222 @@ var window = globalThis;
 window.document = document;
 window.localStorage = localStorage;
 var console = { log: log, warn: log, error: log, info: log, debug: log };
-var navigator = { userAgent: 'Browser/2.0', language: 'en-US' };
+var navigator = {
+    userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    language: 'en-US',
+    languages: ['en-US', 'en'],
+    platform: 'Linux x86_64',
+    cookieEnabled: false,
+    onLine: true,
+    hardwareConcurrency: 4,
+    maxTouchPoints: 0,
+    vendor: 'Google Inc.',
+    vendorSub: '',
+    productSub: '20030107',
+};
 var location = document.location;
+
+// -- window dimensions -------------------------------------------------------
+window.innerWidth = 800;
+window.innerHeight = 600;
+window.outerWidth = 800;
+window.outerHeight = 600;
+window.screen = {
+    width: 800,
+    height: 600,
+    availWidth: 800,
+    availHeight: 600,
+    colorDepth: 24,
+    pixelDepth: 24,
+    orientation: { type: 'landscape-primary', angle: 0 },
+};
+window.devicePixelRatio = 1;
+window.scrollX = 0;
+window.scrollY = 0;
+window.pageXOffset = 0;
+window.pageYOffset = 0;
+window.visualViewport = {
+    width: 800,
+    height: 600,
+    scale: 1,
+    offsetLeft: 0,
+    offsetTop: 0,
+    pageLeft: 0,
+    pageTop: 0,
+    addEventListener: function() {},
+    removeEventListener: function() {},
+};
+
+// -- history -----------------------------------------------------------------
+window.history = {
+    length: 1,
+    state: null,
+    pushState: function(state, title, url) {},
+    replaceState: function(state, title, url) {},
+    back: function() {},
+    forward: function() {},
+    go: function() {},
+};
+
+// -- performance -------------------------------------------------------------
+window.performance = {
+    _start: Date.now(),
+    now: function() { return Date.now() - this._start; },
+    mark: function() {},
+    measure: function() {},
+    getEntries: function() { return []; },
+    getEntriesByName: function() { return []; },
+    getEntriesByType: function() { return []; },
+    clearMarks: function() {},
+    clearMeasures: function() {},
+    timing: {
+        navigationStart: Date.now(),
+        loadEventEnd: Date.now(),
+        domContentLoadedEventEnd: Date.now(),
+    },
+    navigation: { type: 0, redirectCount: 0 },
+    timeOrigin: Date.now(),
+};
+
+// -- document.cookie (stub, read-only empty string) --------------------------
+Object.defineProperty(document, 'cookie', {
+    get: function() { return ''; },
+    set: function(val) { /* stub: ignore cookie writes */ },
+    configurable: true,
+});
+
+// -- sessionStorage ----------------------------------------------------------
+var sessionStorage = (function() {
+    var _store = {};
+    return {
+        getItem: function(key) { return key in _store ? _store[key] : null; },
+        setItem: function(key, value) { _store[String(key)] = String(value); },
+        removeItem: function(key) { delete _store[key]; },
+        clear: function() { _store = {}; },
+        get length() { return Object.keys(_store).length; },
+        key: function(i) { return Object.keys(_store)[i] || null; },
+    };
+})();
+window.sessionStorage = sessionStorage;
+
+// -- getComputedStyle --------------------------------------------------------
+window.getComputedStyle = function(el, pseudoElt) {
+    // Stub: returns an object with all properties returning empty string
+    return new Proxy({}, {
+        get: function(target, prop) {
+            if (prop === 'getPropertyValue') {
+                return function(name) { return ''; };
+            }
+            if (prop === 'length') return 0;
+            if (prop === 'item') return function() { return ''; };
+            return '';
+        }
+    });
+};
+
+// -- XMLHttpRequest stub -----------------------------------------------------
+class XMLHttpRequest extends EventTarget {
+    constructor() {
+        super();
+        this.readyState = 0;
+        this.status = 0;
+        this.statusText = '';
+        this.responseText = '';
+        this.response = null;
+        this.responseType = '';
+        this.timeout = 0;
+        this.withCredentials = false;
+        this.onreadystatechange = null;
+        this.onload = null;
+        this.onerror = null;
+        this.ontimeout = null;
+        this.onprogress = null;
+        this.onabort = null;
+        this._method = '';
+        this._url = '';
+        this._headers = {};
+    }
+    open(method, url, async) {
+        this._method = method;
+        this._url = url;
+        this.readyState = 1;
+    }
+    send(body) {
+        // Stub: fire error asynchronously
+        var self = this;
+        setTimeout(function() {
+            self.readyState = 4;
+            self.status = 0;
+            if (typeof self.onerror === 'function') self.onerror(new Event('error'));
+            if (typeof self.onreadystatechange === 'function') self.onreadystatechange();
+        }, 0);
+    }
+    setRequestHeader(name, value) {
+        this._headers[name] = value;
+    }
+    getResponseHeader(name) { return null; }
+    getAllResponseHeaders() { return ''; }
+    abort() {
+        this.readyState = 0;
+        if (typeof this.onabort === 'function') this.onabort(new Event('abort'));
+    }
+    overrideMimeType() {}
+}
+window.XMLHttpRequest = XMLHttpRequest;
+
+// -- document.createComment / document.createTextNode -------------------------
+document.createComment = function(data) {
+    return { nodeType: 8, data: data, _id: 0, textContent: '' };
+};
+
+// Override createTextNode to return a proper node-like object with nodeType
+document.createTextNode = function(text) {
+    return { _id: 0, _text: text, nodeType: 3, textContent: text, data: text };
+};
+
+// -- window.matchMedia -------------------------------------------------------
+window.matchMedia = function(query) {
+    return {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: function() {},
+        removeListener: function() {},
+        addEventListener: function() {},
+        removeEventListener: function() {},
+        dispatchEvent: function() { return false; },
+    };
+};
+
+// -- window.getSelection -----------------------------------------------------
+window.getSelection = function() {
+    return {
+        rangeCount: 0,
+        isCollapsed: true,
+        toString: function() { return ''; },
+        getRangeAt: function() { return null; },
+        addRange: function() {},
+        removeAllRanges: function() {},
+        collapse: function() {},
+    };
+};
+
+// -- window.crypto (basic stub) ----------------------------------------------
+window.crypto = {
+    getRandomValues: function(arr) {
+        for (var i = 0; i < arr.length; i++) {
+            arr[i] = Math.floor(Math.random() * 256);
+        }
+        return arr;
+    },
+    subtle: null,
+};
+
+// -- window.open, window.close -----------------------------------------------
+window.open = function() { return null; };
+window.close = function() {};
+window.focus = function() {};
+window.blur = function() {};
 
 // -- Timers ------------------------------------------------------------------
 window.setTimeout = function(fn, delay) {
@@ -568,4 +1038,548 @@ class CustomEvent extends Event {
         super(type, options);
         this.detail = options.detail !== undefined ? options.detail : null;
     }
+}
+
+// -- KeyboardEvent -----------------------------------------------------------
+class KeyboardEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.key = options.key || '';
+        this.code = options.code || '';
+        this.keyCode = options.keyCode || 0;
+        this.charCode = options.charCode || 0;
+        this.which = options.which || 0;
+        this.altKey = options.altKey || false;
+        this.ctrlKey = options.ctrlKey || false;
+        this.shiftKey = options.shiftKey || false;
+        this.metaKey = options.metaKey || false;
+        this.repeat = options.repeat || false;
+        this.location = options.location || 0;
+    }
+    getModifierState(key) { return false; }
+}
+
+// -- TouchEvent / PointerEvent stubs -----------------------------------------
+class TouchEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.touches = options.touches || [];
+        this.targetTouches = options.targetTouches || [];
+        this.changedTouches = options.changedTouches || [];
+    }
+}
+
+class PointerEvent extends MouseEvent {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.pointerId = options.pointerId || 1;
+        this.pointerType = options.pointerType || 'mouse';
+        this.pressure = options.pressure || 0;
+        this.isPrimary = options.isPrimary !== undefined ? options.isPrimary : true;
+    }
+}
+
+class WheelEvent extends MouseEvent {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.deltaX = options.deltaX || 0;
+        this.deltaY = options.deltaY || 0;
+        this.deltaZ = options.deltaZ || 0;
+        this.deltaMode = options.deltaMode || 0;
+    }
+}
+
+class InputEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.data = options.data || null;
+        this.inputType = options.inputType || '';
+    }
+}
+
+class FocusEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.relatedTarget = options.relatedTarget || null;
+    }
+}
+
+// -- UIEvent ----------------------------------------------------------------
+class UIEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.detail = options.detail || 0;
+    }
+}
+
+// -- ErrorEvent -------------------------------------------------------------
+class ErrorEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.message = options.message || '';
+        this.filename = options.filename || '';
+        this.lineno = options.lineno || 0;
+        this.colno = options.colno || 0;
+        this.error = options.error || null;
+    }
+}
+
+// -- MessageEvent -----------------------------------------------------------
+class MessageEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.data = options.data !== undefined ? options.data : null;
+        this.origin = options.origin || '';
+        this.source = options.source || null;
+    }
+}
+
+// -- ProgressEvent ----------------------------------------------------------
+class ProgressEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.lengthComputable = options.lengthComputable || false;
+        this.loaded = options.loaded || 0;
+        this.total = options.total || 0;
+    }
+}
+
+// -- StorageEvent -----------------------------------------------------------
+class StorageEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.key = options.key || null;
+        this.oldValue = options.oldValue || null;
+        this.newValue = options.newValue || null;
+        this.url = options.url || '';
+        this.storageArea = options.storageArea || null;
+    }
+}
+
+// -- HashChangeEvent --------------------------------------------------------
+class HashChangeEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.oldURL = options.oldURL || '';
+        this.newURL = options.newURL || '';
+    }
+}
+
+// -- PopStateEvent ----------------------------------------------------------
+class PopStateEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.state = options.state !== undefined ? options.state : null;
+    }
+}
+
+// -- BeforeUnloadEvent ------------------------------------------------------
+class BeforeUnloadEvent extends Event {
+    constructor(type, options = {}) {
+        super(type, options);
+        this.returnValue = '';
+    }
+}
+
+// -- window global event handlers -------------------------------------------
+window.onload = null;
+window.onerror = null;
+window.onunload = null;
+window.onbeforeunload = null;
+window.onhashchange = null;
+window.onpopstate = null;
+window.onmessage = null;
+window.onresize = null;
+window.onscroll = null;
+
+// window.addEventListener wrapping around document events for common cases
+var _window_listeners = new Map();
+window.addEventListener = function(type, callback, options) {
+    if (!_window_listeners.has(type)) _window_listeners.set(type, []);
+    _window_listeners.get(type).push(callback);
+    // Load event fires immediately (page already done)
+    if (type === 'load' || type === 'DOMContentLoaded') {
+        try { callback(new Event(type)); } catch(e) {}
+    }
+};
+window.removeEventListener = function(type, callback) {
+    if (!_window_listeners.has(type)) return;
+    _window_listeners.set(type, _window_listeners.get(type).filter(l => l !== callback));
+};
+window.dispatchEvent = function(event) {
+    var list = _window_listeners.get(event.type);
+    if (list) {
+        for (var l of list) {
+            try { l.call(window, event); } catch(e) { console.log("Window Event Error: " + e); }
+        }
+    }
+    return true;
+};
+
+// -- URL class stub ----------------------------------------------------------
+class URL {
+    constructor(url, base) {
+        try {
+            // Very simplified URL parsing
+            this.href = url;
+            var parts = url.match(/^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/);
+            if (parts) {
+                this.protocol = (parts[2] || 'http') + ':';
+                this.host = parts[4] || '';
+                var hostParts = this.host.split(':');
+                this.hostname = hostParts[0] || '';
+                this.port = hostParts[1] || '';
+                this.pathname = parts[5] || '/';
+                this.search = parts[6] || '';
+                this.hash = parts[8] || '';
+                this.origin = this.protocol + '//' + this.host;
+                this.username = '';
+                this.password = '';
+            }
+        } catch(e) {
+            this.href = url;
+        }
+    }
+    toString() { return this.href; }
+    static createObjectURL(blob) { return 'blob:'; }
+    static revokeObjectURL(url) {}
+}
+window.URL = URL;
+
+// -- URLSearchParams stub ----------------------------------------------------
+class URLSearchParams {
+    constructor(init) {
+        this._params = {};
+        if (typeof init === 'string') {
+            init.replace(/^\?/, '').split('&').forEach(function(pair) {
+                var parts = pair.split('=');
+                if (parts[0]) {
+                    this._params[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1] || '');
+                }
+            }.bind(this));
+        }
+    }
+    get(key) { return key in this._params ? this._params[key] : null; }
+    set(key, value) { this._params[key] = String(value); }
+    has(key) { return key in this._params; }
+    delete(key) { delete this._params[key]; }
+    toString() {
+        return Object.keys(this._params).map(k => encodeURIComponent(k) + '=' + encodeURIComponent(this._params[k])).join('&');
+    }
+    forEach(fn) { Object.keys(this._params).forEach(k => fn(this._params[k], k, this)); }
+    [Symbol.iterator]() {
+        var keys = Object.keys(this._params), i = 0, self = this;
+        return { next: function() {
+            if (i < keys.length) { var k = keys[i++]; return { value: [k, self._params[k]], done: false }; }
+            return { done: true };
+        }};
+    }
+    get size() { return Object.keys(this._params).length; }
+}
+window.URLSearchParams = URLSearchParams;
+
+// -- FormData stub -----------------------------------------------------------
+class FormData {
+    constructor(form) {
+        this._data = {};
+    }
+    append(name, value, filename) { this._data[name] = value; }
+    get(name) { return this._data[name] !== undefined ? this._data[name] : null; }
+    has(name) { return name in this._data; }
+    set(name, value) { this._data[name] = value; }
+    delete(name) { delete this._data[name]; }
+    forEach(fn) { Object.keys(this._data).forEach(k => fn(this._data[k], k, this)); }
+}
+window.FormData = FormData;
+
+// -- Blob / File stubs -------------------------------------------------------
+class Blob {
+    constructor(parts, options) {
+        this.type = (options && options.type) || '';
+        this.size = (parts || []).reduce(function(acc, p) { return acc + (p ? (p.length || 0) : 0); }, 0);
+    }
+    text() { return Promise.resolve(''); }
+    arrayBuffer() { return Promise.resolve(new ArrayBuffer(0)); }
+    slice() { return new Blob(); }
+}
+window.Blob = Blob;
+
+class File extends Blob {
+    constructor(parts, name, options) {
+        super(parts, options);
+        this.name = name || '';
+        this.lastModified = Date.now();
+    }
+}
+window.File = File;
+
+// -- AbortController stub ----------------------------------------------------
+class AbortController {
+    constructor() {
+        this.signal = { aborted: false, addEventListener: function() {}, removeEventListener: function() {} };
+    }
+    abort() { this.signal.aborted = true; }
+}
+window.AbortController = AbortController;
+window.AbortSignal = { timeout: function() { return new AbortController().signal; } };
+
+// -- Expose event classes on window ------------------------------------------
+window.Event = Event;
+window.CustomEvent = CustomEvent;
+window.MouseEvent = MouseEvent;
+window.KeyboardEvent = KeyboardEvent;
+window.TouchEvent = TouchEvent;
+window.PointerEvent = PointerEvent;
+window.WheelEvent = WheelEvent;
+window.InputEvent = InputEvent;
+window.FocusEvent = FocusEvent;
+window.UIEvent = UIEvent;
+window.ErrorEvent = ErrorEvent;
+window.MessageEvent = MessageEvent;
+window.ProgressEvent = ProgressEvent;
+window.StorageEvent = StorageEvent;
+window.HashChangeEvent = HashChangeEvent;
+window.PopStateEvent = PopStateEvent;
+window.BeforeUnloadEvent = BeforeUnloadEvent;
+window.MutationObserver = MutationObserver;
+window.IntersectionObserver = IntersectionObserver;
+window.ResizeObserver = ResizeObserver;
+window.Node = Node;
+window.Element = Element;
+window.NodeList = NodeList;
+window.EventTarget = EventTarget;
+window.XMLHttpRequest = XMLHttpRequest;
+window.DOMTokenList = DOMTokenList;
+
+// -- Image constructor (HTMLImageElement) ------------------------------------
+class HTMLImageElement extends Element {
+    constructor(width, height) {
+        // Create a real img element in the DOM
+        var nativeId = __aura_create_element('img');
+        super(nativeId, 'img', '');
+        if (width !== undefined) __aura_set_attribute(nativeId, 'width', String(width));
+        if (height !== undefined) __aura_set_attribute(nativeId, 'height', String(height));
+        this.onload = null;
+        this.onerror = null;
+    }
+    get src() { return __aura_get_attribute(this._id, 'src') || ''; }
+    set src(v) {
+        __aura_set_attribute(this._id, 'src', String(v));
+        // Fire onload asynchronously since we can't actually load images
+        var self = this;
+        setTimeout(function() {
+            if (typeof self.onload === 'function') self.onload(new Event('load'));
+        }, 0);
+    }
+    get alt() { return __aura_get_attribute(this._id, 'alt') || ''; }
+    set alt(v) { __aura_set_attribute(this._id, 'alt', String(v)); }
+    get complete() { return true; }
+    get naturalWidth() { return 0; }
+    get naturalHeight() { return 0; }
+}
+// Alias Image to HTMLImageElement (browsers expose Image constructor)
+var Image = HTMLImageElement;
+window.Image = HTMLImageElement;
+window.HTMLImageElement = HTMLImageElement;
+
+// -- Other HTML element constructors -----------------------------------------
+class HTMLElement extends Element {
+    constructor(id, tag, string_id) {
+        super(id, tag, string_id);
+    }
+}
+window.HTMLElement = HTMLElement;
+
+class HTMLDivElement extends HTMLElement {}
+window.HTMLDivElement = HTMLDivElement;
+
+class HTMLSpanElement extends HTMLElement {}
+window.HTMLSpanElement = HTMLSpanElement;
+
+class HTMLInputElement extends HTMLElement {
+    constructor(id, tag, string_id) {
+        super(id, tag, string_id);
+    }
+}
+window.HTMLInputElement = HTMLInputElement;
+
+class HTMLButtonElement extends HTMLElement {}
+window.HTMLButtonElement = HTMLButtonElement;
+
+class HTMLAnchorElement extends HTMLElement {
+    get href() { return __aura_get_attribute(this._id, 'href') || ''; }
+    set href(v) { __aura_set_attribute(this._id, 'href', String(v)); }
+}
+window.HTMLAnchorElement = HTMLAnchorElement;
+
+class HTMLScriptElement extends HTMLElement {
+    get src() { return __aura_get_attribute(this._id, 'src') || ''; }
+    set src(v) { __aura_set_attribute(this._id, 'src', String(v)); }
+    get async() { return __aura_has_attribute(this._id, 'async'); }
+    set async(v) { if (v) __aura_set_attribute(this._id, 'async', ''); else __aura_remove_attribute(this._id, 'async'); }
+    get defer() { return __aura_has_attribute(this._id, 'defer'); }
+}
+window.HTMLScriptElement = HTMLScriptElement;
+
+class HTMLStyleElement extends HTMLElement {}
+window.HTMLStyleElement = HTMLStyleElement;
+
+class HTMLFormElement extends HTMLElement {
+    submit() {}
+    reset() {}
+}
+window.HTMLFormElement = HTMLFormElement;
+
+class HTMLSelectElement extends HTMLElement {
+    get value() { return ''; }
+    set value(v) {}
+    get selectedIndex() { return -1; }
+    set selectedIndex(v) {}
+    get options() { return new NodeList([]); }
+    add(option) {}
+    remove(index) {}
+}
+window.HTMLSelectElement = HTMLSelectElement;
+
+class HTMLOptionElement extends HTMLElement {
+    constructor(text, value, defaultSelected, selected) {
+        var nativeId = __aura_create_element('option');
+        super(nativeId, 'option', '');
+        if (text !== undefined) this.textContent = String(text);
+        if (value !== undefined) __aura_set_attribute(nativeId, 'value', String(value));
+    }
+    get value() { return __aura_get_attribute(this._id, 'value') || ''; }
+    set value(v) { __aura_set_attribute(this._id, 'value', String(v)); }
+    get text() { return this.textContent; }
+    set text(v) { this.textContent = String(v); }
+    get selected() { return false; }
+    set selected(v) {}
+    get defaultSelected() { return false; }
+}
+window.HTMLOptionElement = HTMLOptionElement;
+var Option = HTMLOptionElement;
+window.Option = HTMLOptionElement;
+
+class HTMLTextAreaElement extends HTMLElement {
+    get value() { return __aura_get_text_content(this._id); }
+    set value(v) { __aura_set_text_content(this._id, String(v)); }
+}
+window.HTMLTextAreaElement = HTMLTextAreaElement;
+
+class HTMLLabelElement extends HTMLElement {}
+window.HTMLLabelElement = HTMLLabelElement;
+
+class HTMLParagraphElement extends HTMLElement {}
+window.HTMLParagraphElement = HTMLParagraphElement;
+
+class HTMLHeadingElement extends HTMLElement {}
+window.HTMLHeadingElement = HTMLHeadingElement;
+
+class HTMLTableElement extends HTMLElement {}
+window.HTMLTableElement = HTMLTableElement;
+
+class HTMLTableRowElement extends HTMLElement {}
+window.HTMLTableRowElement = HTMLTableRowElement;
+
+class HTMLTableCellElement extends HTMLElement {}
+window.HTMLTableCellElement = HTMLTableCellElement;
+
+class HTMLUListElement extends HTMLElement {}
+window.HTMLUListElement = HTMLUListElement;
+
+class HTMLOListElement extends HTMLElement {}
+window.HTMLOListElement = HTMLOListElement;
+
+class HTMLLIElement extends HTMLElement {}
+window.HTMLLIElement = HTMLLIElement;
+
+class HTMLCanvasElement extends HTMLElement {
+    getContext(type) {
+        // Stub canvas context
+        return {
+            fillRect: function() {},
+            clearRect: function() {},
+            strokeRect: function() {},
+            fillText: function() {},
+            strokeText: function() {},
+            measureText: function(text) { return { width: text.length * 8 }; },
+            drawImage: function() {},
+            getImageData: function(x, y, w, h) { return { data: new Uint8ClampedArray(w * h * 4), width: w, height: h }; },
+            putImageData: function() {},
+            createImageData: function(w, h) { return { data: new Uint8ClampedArray(w * h * 4), width: w, height: h }; },
+            save: function() {},
+            restore: function() {},
+            translate: function() {},
+            scale: function() {},
+            rotate: function() {},
+            transform: function() {},
+            setTransform: function() {},
+            resetTransform: function() {},
+            beginPath: function() {},
+            closePath: function() {},
+            moveTo: function() {},
+            lineTo: function() {},
+            quadraticCurveTo: function() {},
+            bezierCurveTo: function() {},
+            arc: function() {},
+            arcTo: function() {},
+            ellipse: function() {},
+            rect: function() {},
+            fill: function() {},
+            stroke: function() {},
+            clip: function() {},
+            isPointInPath: function() { return false; },
+            createLinearGradient: function() { return { addColorStop: function() {} }; },
+            createRadialGradient: function() { return { addColorStop: function() {} }; },
+            createPattern: function() { return null; },
+            addEventListener: function() {},
+            canvas: null,
+            fillStyle: '',
+            strokeStyle: '',
+            lineWidth: 1,
+            font: '10px sans-serif',
+            textAlign: 'start',
+            textBaseline: 'alphabetic',
+            globalAlpha: 1,
+            globalCompositeOperation: 'source-over',
+        };
+    }
+    get width() { return parseInt(__aura_get_attribute(this._id, 'width') || '300'); }
+    set width(v) { __aura_set_attribute(this._id, 'width', String(v)); }
+    get height() { return parseInt(__aura_get_attribute(this._id, 'height') || '150'); }
+    set height(v) { __aura_set_attribute(this._id, 'height', String(v)); }
+    toDataURL(type, quality) { return 'data:image/png;base64,'; }
+    toBlob(callback) { callback(new Blob()); }
+}
+window.HTMLCanvasElement = HTMLCanvasElement;
+
+// -- window.queueMicrotask ---------------------------------------------------
+window.queueMicrotask = function(fn) {
+    if (typeof fn === 'function') {
+        Promise.resolve().then(fn);
+    }
+};
+
+// -- atob / btoa stubs -------------------------------------------------------
+window.atob = function(s) { return ''; };
+window.btoa = function(s) { return ''; };
+
+// -- window.scroll / scrollTo / scrollBy ------------------------------------
+window.scroll = function() {};
+window.scrollTo = function() {};
+window.scrollBy = function() {};
+
+// -- window.requestIdleCallback already set above via native ----------------
+window.cancelAnimationFrame = function() {};
+
+// -- Expose console on window ------------------------------------------------
+window.console = console;
+
+// -- Intl stub ---------------------------------------------------------------
+if (typeof Intl === 'undefined') {
+    window.Intl = {
+        DateTimeFormat: function() { return { format: function(d) { return d ? d.toString() : ''; } }; },
+        NumberFormat: function() { return { format: function(n) { return String(n); } }; },
+        Collator: function() { return { compare: function(a, b) { return a < b ? -1 : a > b ? 1 : 0; } }; },
+    };
 }

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -9,13 +9,59 @@ function __aura_set_style(id, prop, value) {
     __aura_style_log.push(id + '||||' + prop + '||||' + value);
 }
 
+function __aura_url_parts(href) {
+    var value = String(href || '');
+    var parts = value.match(/^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/);
+    if (!parts) return null;
+    var host = parts[4] || '';
+    var hostParts = host.split(':');
+    var protocol = (parts[2] || 'http') + ':';
+    return {
+        href: value,
+        protocol: protocol,
+        host: host,
+        hostname: hostParts[0] || '',
+        port: hostParts[1] || '',
+        pathname: parts[5] || '/',
+        search: parts[6] || '',
+        hash: parts[8] || '',
+        origin: protocol + '//' + host,
+    };
+}
+
+function __aura_apply_location_href(href) {
+    var parts = __aura_url_parts(href);
+    if (!parts) return false;
+    var loc = document.location;
+    loc.href = parts.href;
+    loc.protocol = parts.protocol;
+    loc.host = parts.host;
+    loc.hostname = parts.hostname;
+    loc.port = parts.port;
+    loc.pathname = parts.pathname;
+    loc.search = parts.search;
+    loc.hash = parts.hash;
+    loc.origin = parts.origin;
+    document.URL = parts.href;
+    document.documentURI = parts.href;
+    document.baseURI = parts.href;
+    return true;
+}
+
 // -- Node Registry (Ensures stable objects for events) -----------------------
 var __node_registry = new Map();
 
-function __get_or_create_node(id, tag, string_id) {
+function __get_or_create_node(id, tag, string_id, kind) {
     if (!id) return null;
     if (__node_registry.has(id)) return __node_registry.get(id);
-    let node = tag ? new Element(id, tag, string_id) : new Node(id);
+    let node;
+    if (kind === 'text') {
+        node = new TextNode(id);
+    } else if (tag) {
+        node = new Element(id, tag, string_id);
+    } else {
+        node = new Node(id);
+    }
     __node_registry.set(id, node);
     return node;
 }
@@ -154,10 +200,16 @@ class DOMTokenList {
 // -- NodeList / HTMLCollection ------------------------------------------------
 class NodeList {
     constructor(nids, tag) {
-        this._nids = nids;
+        this._nids = nids.map(item => typeof item === 'object' ? item.nid : item);
         this._tag = tag;
         for (let i = 0; i < nids.length; i++) {
-            this[i] = __get_or_create_node(nids[i], null, null);
+            let item = nids[i];
+            if (typeof item === 'object') {
+                this[i] = __get_or_create_node(item.nid, item.tag, item.id, item.kind);
+            } else {
+                let info = __aura_get_node_info(item);
+                this[i] = info ? __get_or_create_node(item, info.tag, info.id, info.kind) : __get_or_create_node(item);
+            }
         }
         this.length = nids.length;
     }
@@ -173,34 +225,35 @@ class NodeList {
 
 // Node type constants (static properties added after class definition)
 class Node extends EventTarget {
-    constructor(id) {
+    constructor(id, kind = 'element') {
         super();
         this._id = id;
+        this._kind = kind;
     }
     get nodeType() {
-        return 1; // ELEMENT_NODE by default for Node instances used as elements
+        return this._kind === 'text' ? 3 : 1;
     }
     get parentNode() {
         let pid = __aura_get_parent_id(this._id);
         if (!pid) return null;
         let info = __aura_get_node_info(pid);
-        return info ? __get_or_create_node(pid, info.tag, info.id) : __get_or_create_node(pid);
+        return info ? __get_or_create_node(pid, info.tag, info.id, info.kind) : __get_or_create_node(pid);
     }
     get childNodes() {
         let arr = JSON.parse(__aura_get_children(this._id));
-        return new NodeList(arr.map(c => c.nid));
+        return new NodeList(arr);
     }
     get firstChild() {
         let arr = JSON.parse(__aura_get_children(this._id));
         if (arr.length === 0) return null;
         let c = arr[0];
-        return __get_or_create_node(c.nid, c.tag, c.id);
+        return __get_or_create_node(c.nid, c.tag, c.id, c.kind);
     }
     get lastChild() {
         let arr = JSON.parse(__aura_get_children(this._id));
         if (arr.length === 0) return null;
         let c = arr[arr.length - 1];
-        return __get_or_create_node(c.nid, c.tag, c.id);
+        return __get_or_create_node(c.nid, c.tag, c.id, c.kind);
     }
     get textContent() {
         return __aura_get_text_content(this._id);
@@ -209,25 +262,25 @@ class Node extends EventTarget {
         __aura_set_text_content(this._id, String(val));
     }
     appendChild(child) {
-        if (child && child._id) {
+        if (child && child._id !== undefined && child._id !== null) {
             __aura_append_child(this._id, child._id);
         }
         return child;
     }
     removeChild(child) {
-        if (child && child._id) {
+        if (child && child._id !== undefined && child._id !== null) {
             __aura_remove_child(this._id, child._id);
         }
         return child;
     }
     insertBefore(newChild, refChild) {
-        if (newChild && newChild._id) {
+        if (newChild && newChild._id !== undefined && newChild._id !== null) {
             __aura_insert_before(this._id, newChild._id, refChild ? refChild._id : null);
         }
         return newChild;
     }
     replaceChild(newChild, oldChild) {
-        if (newChild && newChild._id && oldChild && oldChild._id) {
+        if (newChild && newChild._id !== undefined && newChild._id !== null && oldChild && oldChild._id !== undefined && oldChild._id !== null) {
             __aura_insert_before(this._id, newChild._id, oldChild._id);
             __aura_remove_child(this._id, oldChild._id);
         }
@@ -246,7 +299,7 @@ class Node extends EventTarget {
         if (other._id === this._id) return true;
         let children = JSON.parse(__aura_get_children(this._id));
         for (let c of children) {
-            let child_node = __get_or_create_node(c.nid, c.tag, c.id);
+            let child_node = __get_or_create_node(c.nid, c.tag, c.id, c.kind);
             if (child_node.contains(other)) return true;
         }
         return false;
@@ -255,7 +308,7 @@ class Node extends EventTarget {
 
 class Element extends Node {
     constructor(id, tag, string_id) {
-        super(id);
+        super(id, 'element');
         this.tagName = (tag || '').toUpperCase();
         this.id = string_id || '';
         this._classList = null;
@@ -340,14 +393,14 @@ class Element extends Node {
         let nid = __aura_query_selector(this._id, selector);
         if (!nid) return null;
         let info = __aura_get_node_info(nid);
-        return info ? __get_or_create_node(nid, info.tag, info.id) : __get_or_create_node(nid);
+        return info ? __get_or_create_node(nid, info.tag, info.id, info.kind) : __get_or_create_node(nid);
     }
     querySelectorAll(selector) {
         let nids_json = __aura_query_selector_all(this._id, selector);
         let nids = JSON.parse(nids_json);
         return new NodeList(nids.map(nid => {
             let info = __aura_get_node_info(nid);
-            return __get_or_create_node(nid, info ? info.tag : null, info ? info.id : null);
+            return __get_or_create_node(nid, info ? info.tag : null, info ? info.id : null, info ? info.kind : null);
         }).map(el => el._id));
     }
     getElementsByClassName(cls) {
@@ -362,26 +415,24 @@ class Element extends Node {
     }
     get children() {
         let arr = JSON.parse(__aura_get_children(this._id));
-        return new NodeList(arr.map(c => {
-            __get_or_create_node(c.nid, c.tag, c.id);
-            return c.nid;
-        }));
+        return new NodeList(arr.filter(c => c.kind !== 'text'));
     }
     get childElementCount() {
         let arr = JSON.parse(__aura_get_children(this._id));
-        return arr.length;
+        return arr.filter(c => c.kind !== 'text').length;
     }
     get firstElementChild() {
         let arr = JSON.parse(__aura_get_children(this._id));
-        if (arr.length === 0) return null;
-        let c = arr[0];
-        return __get_or_create_node(c.nid, c.tag, c.id);
+        let c = arr.find(c => c.kind !== 'text');
+        return c ? __get_or_create_node(c.nid, c.tag, c.id, c.kind) : null;
     }
     get lastElementChild() {
         let arr = JSON.parse(__aura_get_children(this._id));
-        if (arr.length === 0) return null;
-        let c = arr[arr.length - 1];
-        return __get_or_create_node(c.nid, c.tag, c.id);
+        var c = null;
+        for (let i = arr.length - 1; i >= 0; i--) {
+            if (arr[i].kind !== 'text') { c = arr[i]; break; }
+        }
+        return c ? __get_or_create_node(c.nid, c.tag, c.id, c.kind) : null;
     }
     // getBoundingClientRect stub — returns zeros (layout info not available in JS)
     getBoundingClientRect() {
@@ -409,7 +460,7 @@ class Element extends Node {
             frag.innerHTML = html;
             var children = JSON.parse(__aura_get_children(frag._id));
             for (var i = 0; i < children.length; i++) {
-                var child = __get_or_create_node(children[i].nid, children[i].tag, children[i].id);
+                var child = __get_or_create_node(children[i].nid, children[i].tag, children[i].id, children[i].kind);
                 if (position === 'beforeend') {
                     this.appendChild(child);
                 } else {
@@ -514,6 +565,24 @@ class Element extends Node {
     }
 }
 
+class TextNode extends Node {
+    constructor(id) {
+        super(id, 'text');
+    }
+    get data() {
+        return this.textContent;
+    }
+    set data(val) {
+        this.textContent = val;
+    }
+    get nodeValue() {
+        return this.textContent;
+    }
+    set nodeValue(val) {
+        this.textContent = val;
+    }
+}
+
 // -- Node static constants ---------------------------------------------------
 Node.ELEMENT_NODE = 1;
 Node.ATTRIBUTE_NODE = 2;
@@ -570,15 +639,15 @@ var document = {
 
     getElementById: function(id) {
         let res = __aura_get_element_by_id(id);
-        return res ? __get_or_create_node(res.nid, res.tag, id) : null;
+        return res ? __get_or_create_node(res.nid, res.tag, id, res.kind) : null;
     },
     createElement: function(tag) {
         let nativeId = __aura_create_element(tag);
-        return __get_or_create_node(nativeId, tag);
+        return __get_or_create_node(nativeId, tag, null, 'element');
     },
     createTextNode: function(text) {
-        // Create a text node — for now return a minimal node-like object
-        return { _id: 0, _text: text, nodeType: 3, textContent: text };
+        let nativeId = __aura_create_text_node(String(text));
+        return __get_or_create_node(nativeId, null, null, 'text');
     },
     createDocumentFragment: function() {
         return document.createElement('div');
@@ -588,14 +657,14 @@ var document = {
         let nid = __aura_query_selector(0, selector);
         if (!nid) return null;
         let info = __aura_get_node_info(nid);
-        return info ? __get_or_create_node(nid, info.tag, info.id) : __get_or_create_node(nid);
+        return info ? __get_or_create_node(nid, info.tag, info.id, info.kind) : __get_or_create_node(nid);
     },
     querySelectorAll: function(selector) {
         let nids_json = __aura_query_selector_all(0, selector);
         let nids = JSON.parse(nids_json);
         let nodes = nids.map(nid => {
             let info = __aura_get_node_info(nid);
-            return __get_or_create_node(nid, info ? info.tag : null, info ? info.id : null);
+            return __get_or_create_node(nid, info ? info.tag : null, info ? info.id : null, info ? info.kind : null);
         });
         return new NodeList(nodes.map(n => n._id));
     },
@@ -612,19 +681,19 @@ var document = {
 
     get body() {
         let nativeId = __aura_get_body();
-        return nativeId ? __get_or_create_node(nativeId, 'body') : null;
+        return nativeId ? __get_or_create_node(nativeId, 'body', null, 'element') : null;
     },
     get head() {
         let nids_json = __aura_get_elements_by_tag(0, 'head');
         let nids = JSON.parse(nids_json);
         if (nids.length === 0) return null;
-        return __get_or_create_node(nids[0], 'head');
+        return __get_or_create_node(nids[0], 'head', null, 'element');
     },
     get documentElement() {
         let nids_json = __aura_get_elements_by_tag(0, 'html');
         let nids = JSON.parse(nids_json);
         if (nids.length === 0) return null;
-        return __get_or_create_node(nids[0], 'html');
+        return __get_or_create_node(nids[0], 'html', null, 'element');
     },
     activeElement: null,
     location: { href: '', hostname: '', pathname: '/', search: '', hash: '', protocol: 'https:', host: '', port: '', origin: '' },
@@ -649,7 +718,7 @@ var document = {
             nodes.push(node);
             var arr = JSON.parse(__aura_get_children(node._id));
             for (var c of arr) {
-                var child = __get_or_create_node(c.nid, c.tag, c.id);
+                var child = __get_or_create_node(c.nid, c.tag, c.id, c.kind);
                 collect(child);
             }
         }
@@ -680,7 +749,7 @@ var document = {
             nodes.push(node);
             var arr = JSON.parse(__aura_get_children(node._id));
             for (var c of arr) {
-                var child = __get_or_create_node(c.nid, c.tag, c.id);
+                var child = __get_or_create_node(c.nid, c.tag, c.id, c.kind);
                 collect(child);
             }
         }
@@ -814,8 +883,38 @@ window.visualViewport = {
 window.history = {
     length: 1,
     state: null,
-    pushState: function(state, title, url) {},
-    replaceState: function(state, title, url) {},
+    _entries: [location.href],
+    _index: 0,
+    pushState: function(state, title, url) {
+        this.state = state;
+        var nextHref = location.href;
+        if (url !== undefined && url !== null) {
+            try {
+                nextHref = new URL(String(url), location.href).href;
+            } catch (e) {
+                nextHref = location.href;
+            }
+            __aura_apply_location_href(nextHref);
+        }
+        this._entries = this._entries.slice(0, this._index + 1);
+        this._entries.push(nextHref);
+        this._index = this._entries.length - 1;
+        this.length = this._entries.length;
+    },
+    replaceState: function(state, title, url) {
+        this.state = state;
+        if (url !== undefined && url !== null) {
+            var resolved;
+            try {
+                resolved = new URL(String(url), location.href).href;
+            } catch (e) {
+                resolved = location.href;
+            }
+            if (__aura_apply_location_href(resolved)) {
+                this._entries[this._index] = location.href;
+            }
+        }
+    },
     back: function() {},
     forward: function() {},
     go: function() {},
@@ -934,7 +1033,8 @@ document.createComment = function(data) {
 
 // Override createTextNode to return a proper node-like object with nodeType
 document.createTextNode = function(text) {
-    return { _id: 0, _text: text, nodeType: 3, textContent: text, data: text };
+    let nativeId = __aura_create_text_node(String(text));
+    return __get_or_create_node(nativeId, null, null, 'text');
 };
 
 // -- window.matchMedia -------------------------------------------------------
@@ -1219,26 +1319,22 @@ window.dispatchEvent = function(event) {
 // -- URL class stub ----------------------------------------------------------
 class URL {
     constructor(url, base) {
-        try {
-            // Very simplified URL parsing
-            this.href = url;
-            var parts = url.match(/^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/);
-            if (parts) {
-                this.protocol = (parts[2] || 'http') + ':';
-                this.host = parts[4] || '';
-                var hostParts = this.host.split(':');
-                this.hostname = hostParts[0] || '';
-                this.port = hostParts[1] || '';
-                this.pathname = parts[5] || '/';
-                this.search = parts[6] || '';
-                this.hash = parts[8] || '';
-                this.origin = this.protocol + '//' + this.host;
-                this.username = '';
-                this.password = '';
-            }
-        } catch(e) {
-            this.href = url;
-        }
+        var parsed = __aura_parse_url(
+            String(url),
+            base === undefined || base === null || base === '' ? null : String(base)
+        );
+        if (!parsed) throw new TypeError('Invalid URL');
+        this.href = parsed.href || '';
+        this.protocol = parsed.protocol || '';
+        this.host = parsed.host || '';
+        this.hostname = parsed.hostname || '';
+        this.port = parsed.port || '';
+        this.pathname = parsed.pathname || '/';
+        this.search = parsed.search || '';
+        this.hash = parsed.hash || '';
+        this.origin = parsed.origin || '';
+        this.username = '';
+        this.password = '';
     }
     toString() { return this.href; }
     static createObjectURL(blob) { return 'blob:'; }


### PR DESCRIPTION
## Summary

- Added ~25 missing browser globals required by Google's pre-layout scripts to run without crashing
- `window.innerWidth/innerHeight` (800/600), `screen`, `devicePixelRatio`, `window.scrollX/Y`
- `history.pushState/replaceState` (no-op stubs so scripts don't crash)
- `window.performance.now()` — monotonic clock based on `Date.now()`
- `document.cookie` — read-only empty string with silent write
- `sessionStorage` — in-memory stub with full `getItem/setItem/removeItem/clear` API
- `window.getComputedStyle` — returns a Proxy that returns empty string for all properties
- `XMLHttpRequest` — stub that fires `onerror` asynchronously (no actual network)
- `Image` / `HTMLImageElement` constructor — fires `onload` stub; most critical for google.com
- `Node.ELEMENT_NODE`, `TEXT_NODE`, `COMMENT_NODE` static constants
- `Element.nodeType = 1`, `insertAdjacentHTML`, `dataset` proxy, `value/checked/disabled/href/src` properties
- `Element.offsetWidth/Height`, `clientWidth/Height`, `scrollTop/Left` stubs
- `Element.attachShadow`, `animate`, `getClientRects` stubs
- `window.matchMedia`, `getSelection`, `crypto.getRandomValues`
- `URL`, `URLSearchParams`, `FormData`, `Blob`, `File`, `AbortController` / `AbortSignal` constructors
- 10+ event classes: `KeyboardEvent`, `PointerEvent`, `WheelEvent`, `TouchEvent`, `InputEvent`, `FocusEvent`, `UIEvent`, `ErrorEvent`, `MessageEvent`, `ProgressEvent`, `StorageEvent`, `HashChangeEvent`, `PopStateEvent`, `BeforeUnloadEvent`
- `HTMLElement` subclasses: `HTMLDivElement`, `HTMLInputElement`, `HTMLAnchorElement`, `HTMLScriptElement`, `HTMLCanvasElement` (2D context stub), `HTMLSelectElement`, `HTMLOptionElement`, `HTMLFormElement`, etc.
- `navigator.platform`, `cookieEnabled`, `onLine`, `hardwareConcurrency`, `maxTouchPoints`, `vendor`
- `window.open/close`, `queueMicrotask`, `atob/btoa`, `Intl` stub
- `window.location` initialized from actual page URL (href/hostname/pathname/search/hash/protocol/host/port/origin)
- `window.addEventListener/removeEventListener/dispatchEvent` (with `load`/`DOMContentLoaded` firing immediately)
- Injected base URL into JS runtime after bootstrap load so `location.href` reflects real page URL

## Test plan

- [x] 167 unit tests pass (`cargo test --lib`)
- [x] All previously missing APIs now return correct types (verified via local HTML test page)
- [x] `Image` constructor no longer causes `ReferenceError: Image is not defined` on google.com
- [x] `window.innerWidth/innerHeight`, `history`, `performance.now`, `document.cookie`, `sessionStorage`, `getComputedStyle`, `XMLHttpRequest`, `Node.ELEMENT_NODE` all confirmed present
- [x] `window.location.href` correctly reflects page URL (verified with `https://www.example.com/path?q=1#hash`)
- [x] 20 new unit tests added covering all major new stubs
- [x] CLI reviewer: `https://yunseong.dev` navigates and renders correctly (navbar, content, links visible)
- [x] CLI reviewer: `https://google.com` navigates and renders correctly (search bar, form controls, footer links present; logo placeholder expected)
- [x] No regressions on existing tests

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)