### PR TITLE
feat: add devtools console panel (#107)

### DIFF
--- a/src/bin/browser_daemon.rs
+++ b/src/bin/browser_daemon.rs
@@ -206,6 +206,11 @@ async fn elements_handler(State(handle): State<EngineHandle>) -> impl IntoRespon
     (StatusCode::OK, Json(elems)).into_response()
 }
 
+async fn console_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
+    let entries = blocking!(move || handle.send_get_console());
+    (StatusCode::OK, Json(entries)).into_response()
+}
+
 /// Submit the first form on the current page by evaluating `document.forms[0].submit()`.
 ///
 /// Note: the JS runtime is a mock, so this is a best-effort stub.
@@ -231,6 +236,7 @@ pub fn build_router(handle: EngineHandle) -> Router {
         .route("/layout", get(layout_handler))
         .route("/style", get(style_handler))
         .route("/elements", get(elements_handler))
+        .route("/console", get(console_handler))
         .route("/submit", post(submit_handler))
         .with_state(handle)
 }
@@ -268,6 +274,8 @@ struct DaemonBrowserApp {
     image_promises: HashMap<String, Promise<Result<(String, Vec<u8>), String>>>,
     form_values: HashMap<String, String>,
     start_time: std::time::Instant,
+    console_entries: Vec<browser::js::ConsoleEntry>,
+    console_panel_open: bool,
 }
 
 impl DaemonBrowserApp {
@@ -313,6 +321,8 @@ impl DaemonBrowserApp {
             image_promises: HashMap::new(),
             form_values: HashMap::new(),
             start_time: std::time::Instant::now(),
+            console_entries: vec![],
+            console_panel_open: true,
         }
     }
 
@@ -400,6 +410,8 @@ impl eframe::App for DaemonBrowserApp {
                 self.tick_promise = None;
             }
         }
+
+        self.console_entries = self.handle.send_get_console();
 
         // Tab navigation
         if ctx.input(|i| i.key_pressed(egui::Key::Tab)) {
@@ -525,6 +537,13 @@ impl eframe::App for DaemonBrowserApp {
                     ui.add(progress);
                 }
             });
+
+        render_console_panel(
+            ctx,
+            &mut self.console_panel_open,
+            &mut self.console_entries,
+            || self.handle.send_clear_console(),
+        );
 
         // Content area
         egui::CentralPanel::default()
@@ -745,6 +764,92 @@ impl eframe::App for DaemonBrowserApp {
 #[inline]
 fn daemon_hit(rel: egui::Vec2, r: &layout::Rect) -> bool {
     rel.x >= r.x && rel.x <= r.x + r.width && rel.y >= r.y && rel.y <= r.y + r.height
+}
+
+fn console_level_label(level: browser::js::ConsoleLevel) -> (&'static str, egui::Color32) {
+    match level {
+        browser::js::ConsoleLevel::Log => ("LOG", egui::Color32::from_rgb(210, 210, 210)),
+        browser::js::ConsoleLevel::Info => ("INFO", egui::Color32::from_rgb(140, 190, 255)),
+        browser::js::ConsoleLevel::Warn => ("WARN", egui::Color32::from_rgb(255, 210, 120)),
+        browser::js::ConsoleLevel::Error => ("ERR", egui::Color32::from_rgb(255, 120, 120)),
+        browser::js::ConsoleLevel::Debug => ("DBG", egui::Color32::from_rgb(180, 180, 180)),
+    }
+}
+
+fn render_console_panel(
+    ctx: &egui::Context,
+    open: &mut bool,
+    entries: &mut Vec<browser::js::ConsoleEntry>,
+    mut clear_console: impl FnMut(),
+) {
+    let default_height = if *open { 180.0 } else { 32.0 };
+    egui::TopBottomPanel::bottom("daemon_console_panel")
+        .resizable(*open)
+        .default_height(default_height)
+        .min_height(default_height)
+        .max_height(if *open { 260.0 } else { 32.0 })
+        .frame(
+            egui::Frame::none()
+                .fill(egui::Color32::from_rgb(24, 26, 31))
+                .inner_margin(egui::Margin::symmetric(8.0, 6.0)),
+        )
+        .show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                let toggle = if *open { "▾ Console" } else { "▸ Console" };
+                if ui.button(toggle).clicked() {
+                    *open = !*open;
+                }
+                ui.label(
+                    egui::RichText::new(format!("{} entries", entries.len()))
+                        .color(egui::Color32::GRAY)
+                        .small(),
+                );
+                if ui.button("Clear").clicked() {
+                    clear_console();
+                    entries.clear();
+                }
+            });
+
+            if !*open {
+                return;
+            }
+
+            ui.add_space(4.0);
+            egui::ScrollArea::vertical()
+                .stick_to_bottom(true)
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    if entries.is_empty() {
+                        ui.label(
+                            egui::RichText::new("No console output")
+                                .color(egui::Color32::GRAY),
+                        );
+                        return;
+                    }
+
+                    for entry in entries.iter() {
+                        let (label, color) = console_level_label(entry.level);
+                        ui.horizontal_wrapped(|ui| {
+                            ui.label(
+                                egui::RichText::new(format!("[{}]", label))
+                                    .color(color)
+                                    .monospace(),
+                            );
+                            ui.label(
+                                egui::RichText::new(format!("@{}", entry.timestamp))
+                                    .color(egui::Color32::GRAY)
+                                    .monospace()
+                                    .small(),
+                            );
+                            ui.label(
+                                egui::RichText::new(&entry.message)
+                                    .color(egui::Color32::WHITE)
+                                    .monospace(),
+                            );
+                        });
+                    }
+                });
+        });
 }
 
 // ── Main entry point ──────────────────────────────────────────────────────────
@@ -980,6 +1085,27 @@ mod tests {
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(json.as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_http_console_returns_entries() {
+        let handle = make_test_handle();
+        handle.send_evaluate_js("console.warn('watch out')".to_string());
+
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/console")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let entries = json.as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["level"], "warn");
+        assert_eq!(entries[0]["message"], "watch out");
     }
 
     #[tokio::test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -683,8 +683,7 @@ pub struct BrowserEngine {
 
 impl BrowserEngine {
     /// Create a new engine with empty caches and a fresh JS runtime.
-    pub fn new() -> Self {
-        let console_buffer = js::new_console_buffer();
+    pub fn new_with_console(console_buffer: js::ConsoleBuffer) -> Self {
         Self {
             image_cache: HashMap::new(),
             css_cache: HashMap::new(),
@@ -695,6 +694,10 @@ impl BrowserEngine {
             js_style_overrides: HashMap::new(),
             last_page: None,
         }
+    }
+
+    pub fn new() -> Self {
+        Self::new_with_console(js::new_console_buffer())
     }
 
     /// Synchronously navigate to a URL.
@@ -978,12 +981,6 @@ pub enum EngineCmd {
         selector: String,
         reply: mpsc::Sender<HashMap<String, String>>,
     },
-    GetConsole {
-        reply: mpsc::Sender<Vec<js::ConsoleEntry>>,
-    },
-    ClearConsole {
-        reply: mpsc::Sender<()>,
-    },
     GetPage {
         reply: mpsc::Sender<Option<ApiPageResponse>>,
     },
@@ -1009,6 +1006,10 @@ pub enum EngineCmd {
 /// are confined to a single thread.
 pub fn run_engine_actor(rx: mpsc::Receiver<EngineCmd>) {
     let mut eng = BrowserEngine::new();
+    run_engine_actor_with_engine(rx, &mut eng);
+}
+
+fn run_engine_actor_with_engine(rx: mpsc::Receiver<EngineCmd>, eng: &mut BrowserEngine) {
     for cmd in rx {
         match cmd {
             EngineCmd::Navigate { url, width, reply } => {
@@ -1043,13 +1044,6 @@ pub fn run_engine_actor(rx: mpsc::Receiver<EngineCmd>) {
             EngineCmd::ComputedStyle { selector, reply } => {
                 let _ = reply.send(eng.computed_style(&selector));
             }
-            EngineCmd::GetConsole { reply } => {
-                let _ = reply.send(eng.console_entries());
-            }
-            EngineCmd::ClearConsole { reply } => {
-                eng.clear_console();
-                let _ = reply.send(());
-            }
             EngineCmd::GetPage { reply } => {
                 let resp = eng.last_page.as_ref().map(|p| {
                     page_to_api_response(p, &p.base_url.clone())
@@ -1082,17 +1076,23 @@ pub fn run_engine_actor(rx: mpsc::Receiver<EngineCmd>) {
 #[derive(Clone)]
 pub struct EngineHandle {
     pub tx: mpsc::SyncSender<EngineCmd>,
+    pub console_buffer: js::ConsoleBuffer,
 }
 
 impl EngineHandle {
     /// Create a new engine actor and return a handle to it.
     pub fn spawn() -> Self {
         let (tx, rx) = mpsc::sync_channel::<EngineCmd>(64);
+        let console_buffer = js::new_console_buffer();
+        let actor_console = console_buffer.clone();
         std::thread::Builder::new()
             .name("engine-actor".into())
-            .spawn(move || run_engine_actor(rx))
+            .spawn(move || {
+                let mut eng = BrowserEngine::new_with_console(actor_console);
+                run_engine_actor_with_engine(rx, &mut eng);
+            })
             .expect("failed to start engine actor thread");
-        Self { tx }
+        Self { tx, console_buffer }
     }
 
     pub fn send_navigate(&self, url: String, width: f32) -> Result<PageResult, String> {
@@ -1123,18 +1123,15 @@ impl EngineHandle {
     }
 
     pub fn send_get_console(&self) -> Vec<js::ConsoleEntry> {
-        let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::GetConsole { reply: reply_tx }).is_err() {
-            return vec![];
-        }
-        reply_rx.recv().unwrap_or_default()
+        js::console_entries(&self.console_buffer)
+    }
+
+    pub fn console_version(&self) -> u64 {
+        js::console_version(&self.console_buffer)
     }
 
     pub fn send_clear_console(&self) {
-        let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::ClearConsole { reply: reply_tx }).is_ok() {
-            let _ = reply_rx.recv();
-        }
+        js::clear_console_buffer(&self.console_buffer);
     }
 
     pub fn send_get_elements(&self) -> Vec<ApiElement> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -674,6 +674,7 @@ pub struct BrowserEngine {
     pub css_cache: HashMap<String, String>,
     pub last_stylesheet: Option<css::Stylesheet>,
     pub js_runtime: js::JsRuntime,
+    pub console_buffer: js::ConsoleBuffer,
     pub current_csp_policy: Option<js::CspPolicy>,
     pub js_style_overrides: HashMap<String, HashMap<String, String>>,
     /// The most recently rendered page result.
@@ -683,11 +684,13 @@ pub struct BrowserEngine {
 impl BrowserEngine {
     /// Create a new engine with empty caches and a fresh JS runtime.
     pub fn new() -> Self {
+        let console_buffer = js::new_console_buffer();
         Self {
             image_cache: HashMap::new(),
             css_cache: HashMap::new(),
             last_stylesheet: None,
-            js_runtime: js::JsRuntime::new(None, None, None),
+            js_runtime: js::JsRuntime::new(None, None, None, console_buffer.clone()),
+            console_buffer,
             current_csp_policy: None,
             js_style_overrides: HashMap::new(),
             last_page: None,
@@ -858,6 +861,14 @@ impl BrowserEngine {
         HashMap::new()
     }
 
+    pub fn console_entries(&self) -> Vec<js::ConsoleEntry> {
+        js::console_entries(&self.console_buffer)
+    }
+
+    pub fn clear_console(&self) {
+        js::clear_console_buffer(&self.console_buffer);
+    }
+
     /// Re-initialize the JS runtime for the current page.
     /// Parses the DOM from `body`, runs all page scripts (CSP-gated),
     /// and collects any immediate JS style overrides.
@@ -868,6 +879,7 @@ impl BrowserEngine {
             Some(dom.document.clone()),
             base_url,
             self.current_csp_policy.clone(),
+            self.console_buffer.clone(),
         );
 
         let scripts = js::extract_scripts_from_dom(&dom.document);
@@ -896,7 +908,8 @@ impl BrowserEngine {
     /// Reset all state in preparation for navigating to a new URL.
     pub fn clear_for_new_url(&mut self) {
         self.js_style_overrides.clear();
-        self.js_runtime = js::JsRuntime::new(None, None, None);
+        self.clear_console();
+        self.js_runtime = js::JsRuntime::new(None, None, None, self.console_buffer.clone());
         self.current_csp_policy = None;
         self.last_stylesheet = None;
         self.last_page = None;
@@ -965,6 +978,12 @@ pub enum EngineCmd {
         selector: String,
         reply: mpsc::Sender<HashMap<String, String>>,
     },
+    GetConsole {
+        reply: mpsc::Sender<Vec<js::ConsoleEntry>>,
+    },
+    ClearConsole {
+        reply: mpsc::Sender<()>,
+    },
     GetPage {
         reply: mpsc::Sender<Option<ApiPageResponse>>,
     },
@@ -1023,6 +1042,13 @@ pub fn run_engine_actor(rx: mpsc::Receiver<EngineCmd>) {
             }
             EngineCmd::ComputedStyle { selector, reply } => {
                 let _ = reply.send(eng.computed_style(&selector));
+            }
+            EngineCmd::GetConsole { reply } => {
+                let _ = reply.send(eng.console_entries());
+            }
+            EngineCmd::ClearConsole { reply } => {
+                eng.clear_console();
+                let _ = reply.send(());
             }
             EngineCmd::GetPage { reply } => {
                 let resp = eng.last_page.as_ref().map(|p| {
@@ -1094,6 +1120,21 @@ impl EngineHandle {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.tx.send(EngineCmd::GetPage { reply: reply_tx }).ok()?;
         reply_rx.recv().ok()?
+    }
+
+    pub fn send_get_console(&self) -> Vec<js::ConsoleEntry> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::GetConsole { reply: reply_tx }).is_err() {
+            return vec![];
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
+
+    pub fn send_clear_console(&self) {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::ClearConsole { reply: reply_tx }).is_ok() {
+            let _ = reply_rx.recv();
+        }
     }
 
     pub fn send_get_elements(&self) -> Vec<ApiElement> {
@@ -1177,6 +1218,16 @@ mod tests {
         assert!(engine.js_style_overrides.is_empty());
         assert!(engine.last_stylesheet.is_none());
         assert!(engine.current_csp_policy.is_none());
+        assert!(engine.console_entries().is_empty());
+    }
+
+    #[test]
+    fn test_clear_console_empties_buffer() {
+        let mut engine = BrowserEngine::new();
+        engine.evaluate_js("console.log('hello')");
+        assert_eq!(engine.console_entries().len(), 1);
+        engine.clear_console();
+        assert!(engine.console_entries().is_empty());
     }
 
     #[test]

--- a/src/js.rs
+++ b/src/js.rs
@@ -3,6 +3,8 @@ use std::collections::{HashMap, VecDeque};
 use markup5ever_rcdom::{NodeData, Handle};
 use std::cell::RefCell;
 use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
 use serde::{Serialize, Deserialize};
 use std::sync::Mutex;
@@ -51,6 +53,88 @@ thread_local! {
     static PREVIOUS_FOCUSED_NODE: RefCell<Option<String>> = RefCell::new(None);
     static CURRENT_ORIGIN: RefCell<Option<Url>> = RefCell::new(None);
     static CSP_POLICY: RefCell<Option<CspPolicy>> = RefCell::new(None);
+    static CONSOLE_BUFFER: RefCell<Option<ConsoleBuffer>> = const { RefCell::new(None) };
+}
+
+const MAX_CONSOLE_ENTRIES: usize = 200;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsoleLevel {
+    Log,
+    Warn,
+    Error,
+    Info,
+    Debug,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConsoleEntry {
+    pub level: ConsoleLevel,
+    pub message: String,
+    pub timestamp: u64,
+}
+
+pub type ConsoleBuffer = Arc<Mutex<VecDeque<ConsoleEntry>>>;
+
+fn now_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+pub fn new_console_buffer() -> ConsoleBuffer {
+    Arc::new(Mutex::new(VecDeque::with_capacity(MAX_CONSOLE_ENTRIES)))
+}
+
+pub fn clear_console_buffer(buffer: &ConsoleBuffer) {
+    if let Ok(mut entries) = buffer.lock() {
+        entries.clear();
+    }
+}
+
+pub fn console_entries(buffer: &ConsoleBuffer) -> Vec<ConsoleEntry> {
+    buffer
+        .lock()
+        .map(|entries| entries.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn push_console_entry(level: ConsoleLevel, message: String) {
+    CONSOLE_BUFFER.with(|cell| {
+        if let Some(buffer) = cell.borrow().as_ref() {
+            if let Ok(mut entries) = buffer.lock() {
+                if entries.len() >= MAX_CONSOLE_ENTRIES {
+                    entries.pop_front();
+                }
+                entries.push_back(ConsoleEntry {
+                    level,
+                    message,
+                    timestamp: now_timestamp_ms(),
+                });
+            }
+        }
+    });
+}
+
+fn register_console_callable(context: &mut Context, name: &'static str, level: ConsoleLevel) {
+    let func = NativeFunction::from_copy_closure(move |_this, args, context| {
+        let mut output = String::new();
+        for (i, arg) in args.iter().enumerate() {
+            if i > 0 {
+                output.push(' ');
+            }
+            if let Ok(s) = arg.to_string(context) {
+                output.push_str(&s.to_std_string_escaped());
+            }
+        }
+        push_console_entry(level.clone(), output);
+        Ok(JsValue::undefined())
+    });
+    context
+        .register_global_callable(js_string!(name), 1, func)
+        .unwrap();
 }
 
 #[derive(Clone, Debug, Default)]
@@ -112,27 +196,25 @@ pub struct JsRuntime {
 }
 
 impl JsRuntime {
-    pub fn new(dom: Option<Handle>, base_url: Option<Url>, policy: Option<CspPolicy>) -> Self {
+    pub fn new(
+        dom: Option<Handle>,
+        base_url: Option<Url>,
+        policy: Option<CspPolicy>,
+        console_buffer: ConsoleBuffer,
+    ) -> Self {
         DOM_ROOT.with(|root| *root.borrow_mut() = dom);
         CURRENT_ORIGIN.with(|origin| *origin.borrow_mut() = base_url);
         CSP_POLICY.with(|p| *p.borrow_mut() = policy);
+        CONSOLE_BUFFER.with(|cell| *cell.borrow_mut() = Some(console_buffer));
         let mut context = Context::default();
         let (task_sender, task_receiver) = channel();
         TASK_SENDER.with(|s| *s.borrow_mut() = Some(task_sender));
 
-        // Register native console.log
-        let log = NativeFunction::from_copy_closure(|_this, args, context| {
-            let mut output = String::new();
-            for (i, arg) in args.iter().enumerate() {
-                if i > 0 { output.push(' '); }
-                if let Ok(s) = arg.to_string(context) {
-                    output.push_str(&s.to_std_string_escaped());
-                }
-            }
-            println!("[Aura JS] {}", output);
-            Ok(JsValue::undefined())
-        });
-        context.register_global_callable(js_string!("log"), 1, log).unwrap();
+        register_console_callable(&mut context, "log", ConsoleLevel::Log);
+        register_console_callable(&mut context, "warn", ConsoleLevel::Warn);
+        register_console_callable(&mut context, "error", ConsoleLevel::Error);
+        register_console_callable(&mut context, "info", ConsoleLevel::Info);
+        register_console_callable(&mut context, "debug", ConsoleLevel::Debug);
 
         // Register native setTimeout
         let set_timeout = NativeFunction::from_copy_closure(|_this, args, _context| {
@@ -1689,7 +1771,7 @@ mod tests {
 
     fn make_runtime(html: &str) -> JsRuntime {
         let dom = dom::parse_html(html);
-        JsRuntime::new(Some(dom.document), None, None)
+        JsRuntime::new(Some(dom.document), None, None, new_console_buffer())
     }
 
     fn eval(rt: &mut JsRuntime, code: &str) -> String {
@@ -1699,6 +1781,24 @@ mod tests {
             }
         }
         String::new()
+    }
+
+    #[test]
+    fn test_console_methods_are_captured_with_levels() {
+        let buffer = new_console_buffer();
+        let dom = dom::parse_html("<html><body></body></html>");
+        let mut rt = JsRuntime::new(Some(dom.document), None, None, buffer.clone());
+
+        rt.execute("console.log('hello', 1); console.warn('careful'); console.error('boom');");
+
+        let entries = console_entries(&buffer);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].level, ConsoleLevel::Log);
+        assert_eq!(entries[0].message, "hello 1");
+        assert_eq!(entries[1].level, ConsoleLevel::Warn);
+        assert_eq!(entries[1].message, "careful");
+        assert_eq!(entries[2].level, ConsoleLevel::Error);
+        assert_eq!(entries[2].message, "boom");
     }
 
     #[test]
@@ -1904,7 +2004,7 @@ mod tests {
     fn test_history_push_and_replace_state_updates_location() {
         let url = url::Url::parse("https://example.com:8443/app/index.html").unwrap();
         let dom = crate::dom::parse_html("<html><body></body></html>");
-        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None);
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, new_console_buffer());
 
         let result = eval(&mut rt, r#"
             (function() {
@@ -2052,7 +2152,7 @@ mod tests {
     fn test_window_location_set_from_url() {
         let url = url::Url::parse("https://www.example.com:8443/path?q=1#hash").unwrap();
         let dom = crate::dom::parse_html("<html><body></body></html>");
-        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None);
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, new_console_buffer());
         let href = if let Ok(val) = rt.context.eval(Source::from_bytes(b"window.location.href")) {
             if let Ok(s) = val.to_string(&mut rt.context) { s.to_std_string_escaped() } else { String::new() }
         } else { String::new() };

--- a/src/js.rs
+++ b/src/js.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use markup5ever_rcdom::{NodeData, Handle};
 use std::cell::RefCell;
 use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
@@ -75,7 +76,12 @@ pub struct ConsoleEntry {
     pub timestamp: u64,
 }
 
-pub type ConsoleBuffer = Arc<Mutex<VecDeque<ConsoleEntry>>>;
+pub struct ConsoleState {
+    entries: Mutex<VecDeque<ConsoleEntry>>,
+    version: AtomicU64,
+}
+
+pub type ConsoleBuffer = Arc<ConsoleState>;
 
 fn now_timestamp_ms() -> u64 {
     SystemTime::now()
@@ -85,26 +91,35 @@ fn now_timestamp_ms() -> u64 {
 }
 
 pub fn new_console_buffer() -> ConsoleBuffer {
-    Arc::new(Mutex::new(VecDeque::with_capacity(MAX_CONSOLE_ENTRIES)))
+    Arc::new(ConsoleState {
+        entries: Mutex::new(VecDeque::with_capacity(MAX_CONSOLE_ENTRIES)),
+        version: AtomicU64::new(0),
+    })
 }
 
 pub fn clear_console_buffer(buffer: &ConsoleBuffer) {
-    if let Ok(mut entries) = buffer.lock() {
+    if let Ok(mut entries) = buffer.entries.lock() {
         entries.clear();
+        buffer.version.fetch_add(1, Ordering::Relaxed);
     }
 }
 
 pub fn console_entries(buffer: &ConsoleBuffer) -> Vec<ConsoleEntry> {
     buffer
+        .entries
         .lock()
         .map(|entries| entries.iter().cloned().collect())
         .unwrap_or_default()
 }
 
+pub fn console_version(buffer: &ConsoleBuffer) -> u64 {
+    buffer.version.load(Ordering::Relaxed)
+}
+
 fn push_console_entry(level: ConsoleLevel, message: String) {
     CONSOLE_BUFFER.with(|cell| {
         if let Some(buffer) = cell.borrow().as_ref() {
-            if let Ok(mut entries) = buffer.lock() {
+            if let Ok(mut entries) = buffer.entries.lock() {
                 if entries.len() >= MAX_CONSOLE_ENTRIES {
                     entries.pop_front();
                 }
@@ -113,6 +128,7 @@ fn push_console_entry(level: ConsoleLevel, message: String) {
                     message,
                     timestamp: now_timestamp_ms(),
                 });
+                buffer.version.fetch_add(1, Ordering::Relaxed);
             }
         }
     });

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -832,7 +832,7 @@ var document = {
 var window = globalThis;
 window.document = document;
 window.localStorage = localStorage;
-var console = { log: log, warn: log, error: log, info: log, debug: log };
+var console = { log: log, warn: warn, error: error, info: info, debug: debug };
 var navigator = {
     userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
     language: 'en-US',

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,8 @@ struct BrowserApp {
     image_promises: HashMap<String, Promise<Result<(String, Vec<u8>), String>>>,
     is_loading: bool,
     start_time: std::time::Instant,
+    console_entries: Vec<js::ConsoleEntry>,
+    console_panel_open: bool,
 
     /// Engine actor handle — all pipeline work is delegated through this.
     engine: engine::EngineHandle,
@@ -81,6 +83,8 @@ impl BrowserApp {
             image_promises: HashMap::new(),
             is_loading: false,
             start_time: std::time::Instant::now(),
+            console_entries: vec![],
+            console_panel_open: true,
             engine: engine::EngineHandle::spawn(),
         }
     }
@@ -175,6 +179,8 @@ impl eframe::App for BrowserApp {
                 self.tick_promise = None;
             }
         }
+
+        self.console_entries = self.engine.send_get_console();
 
         // Handle Tab navigation
         if ctx.input(|i| i.key_pressed(egui::Key::Tab)) {
@@ -289,6 +295,13 @@ impl eframe::App for BrowserApp {
                     ui.add(progress);
                 }
             });
+
+        render_console_panel(
+            ctx,
+            &mut self.console_panel_open,
+            &mut self.console_entries,
+            || self.engine.send_clear_console(),
+        );
 
         // ── Content area ─────────────────────────────────────────────────────────
         egui::CentralPanel::default()
@@ -509,6 +522,92 @@ impl eframe::App for BrowserApp {
 #[inline]
 fn hit(rel: egui::Vec2, r: &layout::Rect) -> bool {
     rel.x >= r.x && rel.x <= r.x + r.width && rel.y >= r.y && rel.y <= r.y + r.height
+}
+
+fn console_level_label(level: js::ConsoleLevel) -> (&'static str, egui::Color32) {
+    match level {
+        js::ConsoleLevel::Log => ("LOG", egui::Color32::from_rgb(210, 210, 210)),
+        js::ConsoleLevel::Info => ("INFO", egui::Color32::from_rgb(140, 190, 255)),
+        js::ConsoleLevel::Warn => ("WARN", egui::Color32::from_rgb(255, 210, 120)),
+        js::ConsoleLevel::Error => ("ERR", egui::Color32::from_rgb(255, 120, 120)),
+        js::ConsoleLevel::Debug => ("DBG", egui::Color32::from_rgb(180, 180, 180)),
+    }
+}
+
+fn render_console_panel(
+    ctx: &egui::Context,
+    open: &mut bool,
+    entries: &mut Vec<js::ConsoleEntry>,
+    mut clear_console: impl FnMut(),
+) {
+    let default_height = if *open { 180.0 } else { 32.0 };
+    egui::TopBottomPanel::bottom("browser_console_panel")
+        .resizable(*open)
+        .default_height(default_height)
+        .min_height(default_height)
+        .max_height(if *open { 260.0 } else { 32.0 })
+        .frame(
+            egui::Frame::none()
+                .fill(egui::Color32::from_rgb(24, 26, 31))
+                .inner_margin(egui::Margin::symmetric(8.0, 6.0)),
+        )
+        .show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                let toggle = if *open { "▾ Console" } else { "▸ Console" };
+                if ui.button(toggle).clicked() {
+                    *open = !*open;
+                }
+                ui.label(
+                    egui::RichText::new(format!("{} entries", entries.len()))
+                        .color(egui::Color32::GRAY)
+                        .small(),
+                );
+                if ui.button("Clear").clicked() {
+                    clear_console();
+                    entries.clear();
+                }
+            });
+
+            if !*open {
+                return;
+            }
+
+            ui.add_space(4.0);
+            egui::ScrollArea::vertical()
+                .stick_to_bottom(true)
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    if entries.is_empty() {
+                        ui.label(
+                            egui::RichText::new("No console output")
+                                .color(egui::Color32::GRAY),
+                        );
+                        return;
+                    }
+
+                    for entry in entries.iter() {
+                        let (label, color) = console_level_label(entry.level);
+                        ui.horizontal_wrapped(|ui| {
+                            ui.label(
+                                egui::RichText::new(format!("[{}]", label))
+                                    .color(color)
+                                    .monospace(),
+                            );
+                            ui.label(
+                                egui::RichText::new(format!("@{}", entry.timestamp))
+                                    .color(egui::Color32::GRAY)
+                                    .monospace()
+                                    .small(),
+                            );
+                            ui.label(
+                                egui::RichText::new(&entry.message)
+                                    .color(egui::Color32::WHITE)
+                                    .monospace(),
+                            );
+                        });
+                    }
+                });
+        });
 }
 
 fn main() -> eframe::Result {

--- a/src/render.rs
+++ b/src/render.rs
@@ -8,7 +8,6 @@ use crate::matrix::Matrix4x4;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use lazy_static::lazy_static;
-use rayon::prelude::*;
 use std::time::Instant;
 
 const FONT_DATA: &[u8] = include_bytes!("../assets/fonts/NanumGothic.ttf");
@@ -114,122 +113,78 @@ pub fn render_layout_tree(layout: &LayoutBox, pixmap: &mut Pixmap, image_cache: 
     let layer_gen_elapsed = start.elapsed();
 
     let start_render = Instant::now();
-
-    let tile_size = 256.0;
-    let tiles_x = (viewport.width / tile_size).ceil() as u32;
-    let tiles_y = (viewport.height / tile_size).ceil() as u32;
-
-    let mut viewport_tiles = Vec::new();
-    for y in 0..tiles_y {
-        for x in 0..tiles_x {
-            let rect = LayoutRect {
-                x: x as f32 * tile_size,
-                y: y as f32 * tile_size,
-                width: tile_size.min(viewport.width - x as f32 * tile_size),
-                height: tile_size.min(viewport.height - y as f32 * tile_size),
-            };
-            if rect.width > 0.1 && rect.height > 0.1 {
-                viewport_tiles.push(rect);
-            }
-        }
-    }
-
-    // Parallel rendering of viewport tiles
-    let rendered_tiles: Vec<(LayoutRect, Pixmap)> = viewport_tiles.into_par_iter().map(|tile_rect| {
-        let mut tile_pixmap = Pixmap::new(tile_rect.width as u32, tile_rect.height as u32).unwrap();
-        tile_pixmap.fill(tiny_skia::Color::TRANSPARENT);
-
-        composite_layer_to_tile(0, &tree, &mut tile_pixmap, tile_rect, image_cache, LayoutRect { x: 0.0, y: 0.0, width: 0.0, height: 0.0 });
-
-        (tile_rect, tile_pixmap)
-    }).collect();
-
-    // Composite all tiles onto the final pixmap (on main thread)
-    for (rect, tile_pixmap) in rendered_tiles {
-        pixmap.draw_pixmap(
-            rect.x as i32, rect.y as i32,
-            tile_pixmap.as_ref(),
-            &PixmapPaint::default(),
-            Transform::identity(),
-            None
-        );
-    }
+    composite_layer_to_surface(0, &tree, pixmap, viewport, image_cache);
 
     let render_elapsed = start_render.elapsed();
-    println!("[Perf] render_layout_tree (Tiled): Layer gen: {:?}, Actual render: {:?}", layer_gen_elapsed, render_elapsed);
+    println!("[Perf] render_layout_tree (Surface): Layer gen: {:?}, Actual render: {:?}", layer_gen_elapsed, render_elapsed);
 }
 
-fn composite_layer_to_tile(
-    layer_id: usize, 
-    tree: &LayerTree, 
-    target: &mut Pixmap, 
-    tile_rect: LayoutRect, 
-    image_cache: &HashMap<String, Vec<u8>>, 
-    parent_bounds: LayoutRect
+fn composite_layer_to_surface(
+    layer_id: usize,
+    tree: &LayerTree,
+    target: &mut Pixmap,
+    surface_rect: LayoutRect,
+    image_cache: &HashMap<String, Vec<u8>>,
 ) {
     let layer = &tree.layers[layer_id];
-    if layer.opacity <= 0.0 { return; }
-
-    // Optimization: only process layer if it intersects with this viewport tile
-    if !layer.bounds.intersects(&tile_rect) { return; }
+    if layer.opacity <= 0.0 {
+        return;
+    }
 
     let has_effect = layer.opacity < 1.0 || layer.transform != Matrix4x4::identity();
-
-    let mut layer_pixmap = if has_effect {
-        let mut p = Pixmap::new(tile_rect.width as u32, tile_rect.height as u32).unwrap();
-        p.fill(tiny_skia::Color::TRANSPARENT);
-        Some(p)
+    let mut effect_pixmap = if has_effect {
+        let width = layer.bounds.width.max(1.0).ceil() as u32;
+        let height = layer.bounds.height.max(1.0).ceil() as u32;
+        let mut pixmap = Pixmap::new(width, height).expect("Failed to allocate layer pixmap");
+        pixmap.fill(tiny_skia::Color::TRANSPARENT);
+        Some(pixmap)
     } else {
         None
     };
 
     let (negative, zero, positive) = tree.categorize_children(layer_id);
 
-    let mut bg_cmds = Vec::new();
-    let mut ct_cmds = Vec::new();
-    for tile in &layer.tiles {
-        if tile.rect.intersects(&tile_rect) {
-            bg_cmds.extend(tile.background_commands.iter().cloned());
-            ct_cmds.extend(tile.content_commands.iter().cloned());
-        }
-    }
+    if let Some(ref mut pixmap) = effect_pixmap {
+        execute_commands_on_tile(&layer.background_commands, pixmap, layer.bounds, image_cache);
 
-    {
-        let draw_target = if let Some(ref mut p) = layer_pixmap { p } else { &mut *target };
-
-        // ── CSS 7-Layer Painting Order ──
-
-        // 1. Background
-        execute_commands_on_tile(&bg_cmds, draw_target, tile_rect, image_cache);
-
-        // 2. Negative Z
         for &child_id in &negative {
-            composite_layer_to_tile(child_id, tree, draw_target, tile_rect, image_cache, layer.bounds);
+            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache);
         }
 
-        // 3. Content
-        execute_commands_on_tile(&ct_cmds, draw_target, tile_rect, image_cache);
+        execute_commands_on_tile(&layer.content_commands, pixmap, layer.bounds, image_cache);
 
-        // 4. Zero and positive Z
         for &child_id in &zero {
-            composite_layer_to_tile(child_id, tree, draw_target, tile_rect, image_cache, layer.bounds);
+            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache);
         }
         for &child_id in &positive {
-            composite_layer_to_tile(child_id, tree, draw_target, tile_rect, image_cache, layer.bounds);
+            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache);
+        }
+    } else {
+        execute_commands_on_tile(&layer.background_commands, target, surface_rect, image_cache);
+
+        for &child_id in &negative {
+            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache);
+        }
+
+        execute_commands_on_tile(&layer.content_commands, target, surface_rect, image_cache);
+
+        for &child_id in &zero {
+            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache);
+        }
+        for &child_id in &positive {
+            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache);
         }
     }
 
-    if let Some(p) = layer_pixmap {
+    if let Some(pixmap) = effect_pixmap {
         let mut paint = PixmapPaint::default();
         paint.opacity = layer.opacity;
 
-        let local_x = layer.bounds.x - parent_bounds.x;
-        let local_y = layer.bounds.y - parent_bounds.y;
+        let local_x = layer.bounds.x - surface_rect.x;
+        let local_y = layer.bounds.y - surface_rect.y;
+        let transform = Transform::from_translate(local_x, local_y).pre_concat(layer.transform.to_skia());
 
-        let transform = layer.transform.to_skia();
-        let final_transform = Transform::from_translate(local_x - tile_rect.x, local_y - tile_rect.y).pre_concat(transform);
-
-        target.draw_pixmap(0, 0, p.as_ref(), &paint, final_transform, None);
+        target.draw_pixmap(0, 0, pixmap.as_ref(), &paint, transform, None);
     }
 }
 

--- a/tests/repro_order.rs
+++ b/tests/repro_order.rs
@@ -3,7 +3,7 @@ use boa_engine::{Source, JsValue};
 
 #[test]
 fn test_repro_order() {
-    let mut js = JsRuntime::new(None, None, None);
+    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         globalThis.order = [];

--- a/tests/test_event_loop.rs
+++ b/tests/test_event_loop.rs
@@ -2,7 +2,7 @@ use browser::js::JsRuntime;
 
 #[test]
 fn test_macro_micro_task_order() {
-    let mut js = JsRuntime::new(None, None, None);
+    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
     
     // This script uses standard Promise (micro) and our setTimeout (macro)
     js.execute(r#"
@@ -34,7 +34,7 @@ fn test_macro_micro_task_order() {
 
 #[test]
 fn test_raf_timestamp() {
-    let mut js = JsRuntime::new(None, None, None);
+    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
 
     js.execute(r#"
         var ts = 0;

--- a/tests/test_event_loop_complex.rs
+++ b/tests/test_event_loop_complex.rs
@@ -15,7 +15,7 @@ fn get_array_results(js: &mut JsRuntime, var_name: &str) -> Vec<String> {
 
 #[test]
 fn test_event_loop_interleaving() {
-    let mut js = JsRuntime::new(None, None, None);
+    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         var results = [];
@@ -47,7 +47,7 @@ fn test_event_loop_interleaving() {
 
 #[test]
 fn test_raf_interleaving() {
-    let mut js = JsRuntime::new(None, None, None);
+    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         var results = [];

--- a/tests/test_focus.rs
+++ b/tests/test_focus.rs
@@ -9,7 +9,7 @@ fn test_focus_events() {
         <div id="b" tabindex="0"></div>
     "#;
     let dom = dom::parse_html(html);
-    let mut js = JsRuntime::new(Some(dom.document.clone()), None, None);
+    let mut js = JsRuntime::new(Some(dom.document.clone()), None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         globalThis.log_output = [];
@@ -51,7 +51,7 @@ fn test_focus_blur_interleaving() {
         <div id="b" tabindex="0"></div>
     "#;
     let dom = dom::parse_html(html);
-    let mut js = JsRuntime::new(Some(dom.document.clone()), None, None);
+    let mut js = JsRuntime::new(Some(dom.document.clone()), None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         globalThis.log_output = [];

--- a/tests/test_idle.rs
+++ b/tests/test_idle.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 
 #[test]
 fn test_request_idle_callback_registration() {
-    let mut runtime = browser::js::JsRuntime::new(None, None, None);
+    let mut runtime = browser::js::JsRuntime::new(None, None, None, browser::js::new_console_buffer());
     
     // Test if requestIdleCallback is available in the global scope
     let code = r#"
@@ -35,7 +35,7 @@ fn test_request_idle_callback_registration() {
 
 #[test]
 fn test_cancel_idle_callback() {
-    let mut runtime = browser::js::JsRuntime::new(None, None, None);
+    let mut runtime = browser::js::JsRuntime::new(None, None, None, browser::js::new_console_buffer());
     
     let code = r#"
         let idleCalled = false;

--- a/tests/test_storage.rs
+++ b/tests/test_storage.rs
@@ -8,26 +8,26 @@ fn test_storage_isolation_and_persistence() {
 
     // 1. Set data for origin A
     {
-        let mut js = JsRuntime::new(None, Some(url1.clone()), None);
+        let mut js = JsRuntime::new(None, Some(url1.clone()), None, browser::js::new_console_buffer());
         js.execute("localStorage.setItem('key', 'valueA')");
     }
 
     // 2. Set data for origin B
     {
-        let mut js = JsRuntime::new(None, Some(url2.clone()), None);
+        let mut js = JsRuntime::new(None, Some(url2.clone()), None, browser::js::new_console_buffer());
         js.execute("localStorage.setItem('key', 'valueB')");
     }
 
     // 3. Verify origin A still has valueA
     {
-        let mut js = JsRuntime::new(None, Some(url1.clone()), None);
+        let mut js = JsRuntime::new(None, Some(url1.clone()), None, browser::js::new_console_buffer());
         let val = js.context.eval(boa_engine::Source::from_bytes(b"localStorage.getItem('key')")).unwrap();
         assert_eq!(val.as_string().unwrap().to_std_string_escaped(), "valueA");
     }
 
     // 4. Verify origin B still has valueB
     {
-        let mut js = JsRuntime::new(None, Some(url2.clone()), None);
+        let mut js = JsRuntime::new(None, Some(url2.clone()), None, browser::js::new_console_buffer());
         let val = js.context.eval(boa_engine::Source::from_bytes(b"localStorage.getItem('key')")).unwrap();
         assert_eq!(val.as_string().unwrap().to_std_string_escaped(), "valueB");
     }


### PR DESCRIPTION
## Summary
- capture `console.log`/`warn`/`error`/`info`/`debug` into an engine-owned ring buffer
- add a bottom console panel to both GUI frontends with clear and auto-stick-to-bottom behavior
- expose daemon console output through `GET /console` and cover the new behavior with tests

## Test plan
- [x] `cargo test -q`
- [x] `cargo build --bins`
- [x] browser CLI reviewer: `https://yunseong.dev`
- [x] browser CLI reviewer: `https://google.com`
- [x] daemon API check: `POST /js` followed by `GET /console`
- [x] daemon API check: navigate to `https://example.com` then confirm `/console` resets to `[]`

Closes #107
