### PR TITLE
feat: add DevTools console REPL

### DIFF
--- a/src/bin/browser_cli.rs
+++ b/src/bin/browser_cli.rs
@@ -219,6 +219,24 @@ impl DaemonClient {
         Ok(v["result"].as_str().unwrap_or("").to_string())
     }
 
+    /// POST /console/eval — evaluate JS in the DevTools console REPL.
+    /// The result/error is echoed into the daemon console buffer (visible via GET /console).
+    /// Returns `(result, error)` where exactly one is `Some`.
+    fn console_eval(&self, code: &str) -> Result<(Option<String>, Option<String>), CliError> {
+        let resp = self
+            .client
+            .post(format!("{}/console/eval", self.base_url))
+            .json(&serde_json::json!({ "code": code }))
+            .send()
+            .map_err(Self::check_error)?;
+        let v: serde_json::Value = resp
+            .json()
+            .map_err(|e| CliError::Parse(e.to_string()))?;
+        let result = v["result"].as_str().map(|s| s.to_string());
+        let error = v["error"].as_str().map(|s| s.to_string());
+        Ok((result, error))
+    }
+
     /// GET /style?selector=<sel> — returns computed CSS styles as pretty-printed JSON.
     fn get_style(&self, selector: Option<&str>) -> Result<String, CliError> {
         let url = if let Some(sel) = selector {
@@ -494,6 +512,8 @@ enum Command {
     Forward,
     Screenshot(Option<String>),
     Js(String),
+    /// Evaluate JS via the DevTools console REPL — result/error is echoed into the console buffer.
+    Console(String),
     Style { selector: Option<String> },
     Layout,
     Help,
@@ -578,6 +598,13 @@ fn parse_command(line: &str) -> Command {
                 Command::Js(rest.to_string())
             }
         }
+        "console" | "repl" => {
+            if rest.is_empty() {
+                Command::Unknown("console requires a JS expression".to_string())
+            } else {
+                Command::Console(rest.to_string())
+            }
+        }
         "style" => Command::Style {
             selector: if rest.is_empty() {
                 None
@@ -605,6 +632,7 @@ fn print_help() {
     println!("  forward                 Go forward in history");
     println!("  screenshot [<file>]     Save a PNG screenshot (default: screenshot.png)");
     println!("  js <script>             Evaluate JavaScript and print the result");
+    println!("  console <expr>          Evaluate JS via DevTools console REPL (echoes in console buffer)");
     println!("  style [<selector>]      Print computed CSS styles (optionally filtered by selector)");
     println!("  layout                  Print the current layout tree");
     println!("  help                    Show this help");
@@ -673,6 +701,14 @@ fn dispatch_command(cmd: Command, state: &mut CliState) -> bool {
         Command::Js(script) => {
             match state.client.evaluate_js(&script) {
                 Ok(result) => println!("js result: {}", result),
+                Err(e) => eprintln!("Error: {}", e),
+            }
+        }
+        Command::Console(code) => {
+            match state.client.console_eval(&code) {
+                Ok((Some(result), _)) => println!("< {}", result),
+                Ok((_, Some(error))) => eprintln!("< [error] {}", error),
+                Ok((None, None)) => {}
                 Err(e) => eprintln!("Error: {}", e),
             }
         }
@@ -996,6 +1032,24 @@ mod tests {
     #[test]
     fn test_parse_command_js_no_script() {
         let cmd = parse_command("js");
+        assert!(matches!(cmd, Command::Unknown(_)));
+    }
+
+    #[test]
+    fn test_parse_command_console() {
+        let cmd = parse_command("console 1 + 1");
+        assert_eq!(cmd, Command::Console("1 + 1".to_string()));
+    }
+
+    #[test]
+    fn test_parse_command_console_alias() {
+        let cmd = parse_command("repl document.title");
+        assert_eq!(cmd, Command::Console("document.title".to_string()));
+    }
+
+    #[test]
+    fn test_parse_command_console_no_expr() {
+        let cmd = parse_command("console");
         assert!(matches!(cmd, Command::Unknown(_)));
     }
 

--- a/src/bin/browser_daemon.rs
+++ b/src/bin/browser_daemon.rs
@@ -79,6 +79,11 @@ struct JsRequest {
 }
 
 #[derive(serde::Deserialize)]
+struct ConsoleEvalRequest {
+    code: String,
+}
+
+#[derive(serde::Deserialize)]
 struct StyleQuery {
     selector: Option<String>,
 }
@@ -92,6 +97,12 @@ struct StatusResponse {
 #[derive(serde::Serialize)]
 struct JsResponse {
     result: String,
+}
+
+#[derive(serde::Serialize)]
+struct ConsoleEvalResponse {
+    result: Option<String>,
+    error: Option<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -169,6 +180,21 @@ async fn js_handler(
     (StatusCode::OK, Json(JsResponse { result })).into_response()
 }
 
+async fn console_eval_handler(
+    State(handle): State<EngineHandle>,
+    Json(req): Json<ConsoleEvalRequest>,
+) -> impl IntoResponse {
+    let outcome = blocking!(move || handle.send_console_eval_result(req.code));
+    (
+        StatusCode::OK,
+        Json(ConsoleEvalResponse {
+            result: outcome.result,
+            error: outcome.error,
+        }),
+    )
+        .into_response()
+}
+
 async fn screenshot_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
     let png_opt = blocking!(move || handle.send_screenshot());
     match png_opt {
@@ -231,6 +257,7 @@ pub fn build_router(handle: EngineHandle) -> Router {
         .route("/click", post(click_handler))
         .route("/type", post(type_handler))
         .route("/js", post(js_handler))
+        .route("/console/eval", post(console_eval_handler))
         .route("/screenshot", get(screenshot_handler))
         .route("/dom", get(dom_handler))
         .route("/layout", get(layout_handler))
@@ -276,6 +303,11 @@ struct DaemonBrowserApp {
     start_time: std::time::Instant,
     console_entries: Vec<browser::js::ConsoleEntry>,
     console_panel_open: bool,
+    console_input: String,
+    console_history: Vec<String>,
+    console_history_index: Option<usize>,
+    console_eval_promise: Option<Promise<browser::js::EvalOutcome>>,
+    has_page: bool,
 }
 
 impl DaemonBrowserApp {
@@ -323,6 +355,11 @@ impl DaemonBrowserApp {
             start_time: std::time::Instant::now(),
             console_entries: vec![],
             console_panel_open: true,
+            console_input: String::new(),
+            console_history: vec![],
+            console_history_index: None,
+            console_eval_promise: None,
+            has_page: false,
         }
     }
 
@@ -357,6 +394,7 @@ impl DaemonBrowserApp {
         self.image_promises.clear();
         self.hovered_id = None;
         self.is_loading = true;
+        self.has_page = false;
 
         let handle = self.handle.clone();
         self.content_promise = Some(Promise::spawn_thread("daemon-navigate", move || {
@@ -386,6 +424,7 @@ impl DaemonBrowserApp {
         self.current_event_handlers = page.event_handlers;
         self.current_element_ids = page.element_ids;
         self.current_focusable_elements = page.focusable_elements;
+        self.has_page = true;
     }
 }
 
@@ -412,6 +451,16 @@ impl eframe::App for DaemonBrowserApp {
         }
 
         self.console_entries = self.handle.send_get_console();
+        if let Some(eval_promise) = &self.console_eval_promise {
+            if eval_promise.ready().is_some() {
+                self.console_eval_promise = None;
+                if self.has_page && self.re_render_promise.is_none() && self.content_promise.is_none() {
+                    self.trigger_re_render(ctx, 800.0);
+                } else {
+                    ctx.request_repaint();
+                }
+            }
+        }
 
         // Tab navigation
         if ctx.input(|i| i.key_pressed(egui::Key::Tab)) {
@@ -542,7 +591,18 @@ impl eframe::App for DaemonBrowserApp {
             ctx,
             &mut self.console_panel_open,
             &mut self.console_entries,
+            &mut self.console_input,
+            &mut self.console_history,
+            &mut self.console_history_index,
             || self.handle.send_clear_console(),
+            |code| {
+                if self.console_eval_promise.is_none() {
+                    let handle = self.handle.clone();
+                    self.console_eval_promise = Some(Promise::spawn_thread("daemon-console-eval", move || {
+                        handle.send_console_eval_result(code)
+                    }));
+                }
+            },
         );
 
         // Content area
@@ -586,6 +646,7 @@ impl eframe::App for DaemonBrowserApp {
                             self.error = Some(e.clone());
                             self.content_promise = None;
                             self.is_loading = false;
+                            self.has_page = false;
                         }
                         Some(Ok(page)) => {
                             let page = page.clone();
@@ -776,11 +837,48 @@ fn console_level_label(level: browser::js::ConsoleLevel) -> (&'static str, egui:
     }
 }
 
+fn apply_console_history_navigation(
+    ui: &egui::Ui,
+    response: &egui::Response,
+    input: &mut String,
+    history: &[String],
+    history_index: &mut Option<usize>,
+) {
+    if !response.has_focus() || history.is_empty() {
+        return;
+    }
+
+    if ui.input(|i| i.key_pressed(egui::Key::ArrowUp)) {
+        let next_index = history_index
+            .map(|index| index.saturating_sub(1))
+            .unwrap_or(history.len() - 1);
+        *history_index = Some(next_index);
+        *input = history[next_index].clone();
+    }
+
+    if ui.input(|i| i.key_pressed(egui::Key::ArrowDown)) {
+        if let Some(index) = *history_index {
+            if index + 1 < history.len() {
+                let next_index = index + 1;
+                *history_index = Some(next_index);
+                *input = history[next_index].clone();
+            } else {
+                *history_index = None;
+                input.clear();
+            }
+        }
+    }
+}
+
 fn render_console_panel(
     ctx: &egui::Context,
     open: &mut bool,
     entries: &mut Vec<browser::js::ConsoleEntry>,
+    input: &mut String,
+    history: &mut Vec<String>,
+    history_index: &mut Option<usize>,
     mut clear_console: impl FnMut(),
+    mut evaluate_console: impl FnMut(String),
 ) {
     let default_height = if *open { 180.0 } else { 32.0 };
     egui::TopBottomPanel::bottom("daemon_console_panel")
@@ -829,6 +927,10 @@ fn render_console_panel(
 
                     for entry in entries.iter() {
                         let (label, color) = console_level_label(entry.level);
+                        let message_color = match entry.level {
+                            browser::js::ConsoleLevel::Error => color,
+                            _ => egui::Color32::WHITE,
+                        };
                         ui.horizontal_wrapped(|ui| {
                             ui.label(
                                 egui::RichText::new(format!("[{}]", label))
@@ -843,12 +945,37 @@ fn render_console_panel(
                             );
                             ui.label(
                                 egui::RichText::new(&entry.message)
-                                    .color(egui::Color32::WHITE)
+                                    .color(message_color)
                                     .monospace(),
                             );
                         });
                     }
                 });
+
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                ui.label(
+                    egui::RichText::new(">")
+                        .color(egui::Color32::from_rgb(140, 190, 255))
+                        .monospace(),
+                );
+                let response = ui.add(
+                    egui::TextEdit::singleline(input)
+                        .desired_width(f32::INFINITY)
+                        .hint_text("Evaluate JavaScript"),
+                );
+                apply_console_history_navigation(ui, &response, input, history, history_index);
+
+                if response.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    let code = input.trim().to_string();
+                    if !code.is_empty() {
+                        history.push(code.clone());
+                        *history_index = None;
+                        input.clear();
+                        evaluate_console(code);
+                    }
+                }
+            });
         });
 }
 
@@ -901,7 +1028,6 @@ fn main() {
 mod tests {
     use super::*;
     use std::sync::mpsc;
-    use browser::engine::run_engine_actor;
     use tower::ServiceExt;
 
     // ── Arg parsing ──────────────────────────────────────────────────────────
@@ -1106,6 +1232,42 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["level"], "warn");
         assert_eq!(entries[0]["message"], "watch out");
+    }
+
+    #[tokio::test]
+    async fn test_http_console_eval_returns_result() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/console/eval")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from(r#"{"code":"1+1"}"#))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["result"], "2");
+        assert!(json["error"].is_null());
+    }
+
+    #[tokio::test]
+    async fn test_http_console_eval_returns_error() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/console/eval")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from(r#"{"code":"missingVariable"}"#))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["result"].is_null());
+        assert!(json["error"].is_string());
     }
 
     #[tokio::test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -816,16 +816,47 @@ impl BrowserEngine {
         println!("[BrowserEngine] type_text: not yet implemented");
     }
 
-    /// Execute JavaScript in the current page's runtime.
-    pub fn evaluate_js(&mut self, script: &str) -> String {
-        self.js_runtime.execute(script);
-        // Return any queued style override info as a simple diagnostic string
+    /// Execute JavaScript in the current page's runtime and return a result/error.
+    pub fn evaluate_js_with_result(&mut self, script: &str) -> js::EvalOutcome {
+        let outcome = self.js_runtime.execute_with_result(script);
         let overrides = self.js_runtime.get_style_overrides();
-        if overrides.is_empty() {
-            String::new()
-        } else {
-            format!("style_overrides: {:?}", overrides)
+        if !overrides.is_empty() {
+            for (id, props) in overrides {
+                self.js_style_overrides.entry(id).or_default().extend(props);
+            }
         }
+        outcome
+    }
+
+    /// Execute JavaScript in the current page's runtime (fire-and-forget).
+    pub fn evaluate_js(&mut self, script: &str) -> String {
+        let outcome = self.evaluate_js_with_result(script);
+        outcome.result.or(outcome.error).unwrap_or_default()
+    }
+
+    /// Execute JavaScript from the DevTools console REPL.
+    /// Echoes the input as `> code` and the result/error as `< value` in the console buffer.
+    pub fn evaluate_console_repl(&mut self, script: &str) -> js::EvalOutcome {
+        js::append_console_entry(
+            &self.console_buffer,
+            js::ConsoleLevel::Log,
+            format!("> {}", script),
+        );
+        let outcome = self.evaluate_js_with_result(script);
+        if let Some(error) = &outcome.error {
+            js::append_console_entry(
+                &self.console_buffer,
+                js::ConsoleLevel::Error,
+                format!("< {}", error),
+            );
+        } else if let Some(result) = &outcome.result {
+            js::append_console_entry(
+                &self.console_buffer,
+                js::ConsoleLevel::Log,
+                format!("< {}", result),
+            );
+        }
+        outcome
     }
 
     /// Reconstruct a `Pixmap` from the last rendered page's pixel data.
@@ -968,6 +999,11 @@ pub enum EngineCmd {
         script: String,
         reply: mpsc::Sender<String>,
     },
+    /// Evaluate JS from the DevTools console REPL; echoes input/output into the console buffer.
+    EvaluateConsole {
+        script: String,
+        reply: mpsc::Sender<js::EvalOutcome>,
+    },
     Screenshot {
         reply: mpsc::Sender<Option<Vec<u8>>>,
     },
@@ -1030,6 +1066,10 @@ fn run_engine_actor_with_engine(rx: mpsc::Receiver<EngineCmd>, eng: &mut Browser
             EngineCmd::EvaluateJs { script, reply } => {
                 let result = eng.evaluate_js(&script);
                 let _ = reply.send(result);
+            }
+            EngineCmd::EvaluateConsole { script, reply } => {
+                let outcome = eng.evaluate_console_repl(&script);
+                let _ = reply.send(outcome);
             }
             EngineCmd::Screenshot { reply } => {
                 let png = eng.screenshot().and_then(|pm| pm.encode_png().ok());
@@ -1158,6 +1198,17 @@ impl EngineHandle {
         reply_rx.recv().unwrap_or_default()
     }
 
+    pub fn send_console_eval_result(&self, script: String) -> js::EvalOutcome {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(EngineCmd::EvaluateConsole { script, reply: reply_tx }).is_err() {
+            return js::EvalOutcome {
+                result: None,
+                error: Some("engine disconnected".to_string()),
+            };
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
+
     pub fn send_screenshot(&self) -> Option<Vec<u8>> {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.tx.send(EngineCmd::Screenshot { reply: reply_tx }).ok()?;
@@ -1225,6 +1276,33 @@ mod tests {
         assert_eq!(engine.console_entries().len(), 1);
         engine.clear_console();
         assert!(engine.console_entries().is_empty());
+    }
+
+    #[test]
+    fn test_console_repl_returns_result_and_console_entries() {
+        let mut engine = BrowserEngine::new();
+        let outcome = engine.evaluate_console_repl("1 + 1");
+        assert_eq!(outcome.result.as_deref(), Some("2"));
+        assert_eq!(outcome.error, None);
+
+        let entries = engine.console_entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].message, "> 1 + 1");
+        assert_eq!(entries[1].message, "< 2");
+    }
+
+    #[test]
+    fn test_console_repl_returns_error_and_console_entries() {
+        let mut engine = BrowserEngine::new();
+        let outcome = engine.evaluate_console_repl("missingVariable");
+        assert!(outcome.result.is_none());
+        assert!(outcome.error.is_some());
+
+        let entries = engine.console_entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].message, "> missingVariable");
+        assert!(entries[1].message.starts_with("< "));
+        assert_eq!(entries[1].level, js::ConsoleLevel::Error);
     }
 
     #[test]

--- a/src/js.rs
+++ b/src/js.rs
@@ -83,6 +83,12 @@ pub struct ConsoleState {
 
 pub type ConsoleBuffer = Arc<ConsoleState>;
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvalOutcome {
+    pub result: Option<String>,
+    pub error: Option<String>,
+}
+
 fn now_timestamp_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -95,6 +101,20 @@ pub fn new_console_buffer() -> ConsoleBuffer {
         entries: Mutex::new(VecDeque::with_capacity(MAX_CONSOLE_ENTRIES)),
         version: AtomicU64::new(0),
     })
+}
+
+pub fn append_console_entry(buffer: &ConsoleBuffer, level: ConsoleLevel, message: String) {
+    if let Ok(mut entries) = buffer.entries.lock() {
+        if entries.len() >= MAX_CONSOLE_ENTRIES {
+            entries.pop_front();
+        }
+        entries.push_back(ConsoleEntry {
+            level,
+            message,
+            timestamp: now_timestamp_ms(),
+        });
+        buffer.version.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 pub fn clear_console_buffer(buffer: &ConsoleBuffer) {
@@ -119,17 +139,7 @@ pub fn console_version(buffer: &ConsoleBuffer) -> u64 {
 fn push_console_entry(level: ConsoleLevel, message: String) {
     CONSOLE_BUFFER.with(|cell| {
         if let Some(buffer) = cell.borrow().as_ref() {
-            if let Ok(mut entries) = buffer.entries.lock() {
-                if entries.len() >= MAX_CONSOLE_ENTRIES {
-                    entries.pop_front();
-                }
-                entries.push_back(ConsoleEntry {
-                    level,
-                    message,
-                    timestamp: now_timestamp_ms(),
-                });
-                buffer.version.fetch_add(1, Ordering::Relaxed);
-            }
+            append_console_entry(buffer, level, message);
         }
     });
 }
@@ -1230,11 +1240,49 @@ impl JsRuntime {
     }
 
     pub fn execute(&mut self, source: &str) {
-        if source.contains("import.meta") || (source.contains("import ") && source.contains(" from ")) { return; }
-        if let Err(e) = self.context.eval(Source::from_bytes(source.as_bytes())) {
-            println!("[JS Error] execute: {:?}", e);
+        let outcome = self.execute_with_result(source);
+        if let Some(error) = outcome.error {
+            println!("[JS Error] execute: {}", error);
         }
+    }
+
+    pub fn execute_with_result(&mut self, source: &str) -> EvalOutcome {
+        if source.contains("import.meta") || (source.contains("import ") && source.contains(" from ")) {
+            return EvalOutcome {
+                result: None,
+                error: Some("ES module syntax is not supported".to_string()),
+            };
+        }
+
+        let outcome = match self.context.eval(Source::from_bytes(source.as_bytes())) {
+            Ok(value) => {
+                let result = if value.is_undefined() {
+                    Some("undefined".to_string())
+                } else if value.is_null() {
+                    Some("null".to_string())
+                } else {
+                    value
+                        .to_string(&mut self.context)
+                        .ok()
+                        .map(|s| s.to_std_string_escaped())
+                        .or_else(|| Some(String::new()))
+                };
+                EvalOutcome { result, error: None }
+            }
+            Err(error) => {
+                let message = error.to_string();
+                EvalOutcome {
+                    result: None,
+                    error: Some(if message.is_empty() {
+                        format!("{:?}", error)
+                    } else {
+                        message
+                    }),
+                }
+            }
+        };
         self.run_microtasks();
+        outcome
     }
 
     pub fn get_style_overrides(&mut self) -> HashMap<String, HashMap<String, String>> {
@@ -1815,6 +1863,22 @@ mod tests {
         assert_eq!(entries[1].message, "careful");
         assert_eq!(entries[2].level, ConsoleLevel::Error);
         assert_eq!(entries[2].message, "boom");
+    }
+
+    #[test]
+    fn test_execute_with_result_returns_value() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let outcome = rt.execute_with_result("1 + 2");
+        assert_eq!(outcome.result.as_deref(), Some("3"));
+        assert_eq!(outcome.error, None);
+    }
+
+    #[test]
+    fn test_execute_with_result_returns_error() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let outcome = rt.execute_with_result("missingVariable");
+        assert!(outcome.result.is_none());
+        assert!(outcome.error.is_some());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,16 @@ struct BrowserApp {
     start_time: std::time::Instant,
     console_entries: Vec<js::ConsoleEntry>,
     console_panel_open: bool,
+    /// Current text in the REPL input field.
+    console_input: String,
+    /// History of previously evaluated expressions (for arrow-key navigation).
+    console_history: Vec<String>,
+    /// Index into `console_history` while navigating with arrow keys; `None` means fresh input.
+    console_history_index: Option<usize>,
+    /// In-flight promise for a console REPL evaluation.
+    console_eval_promise: Option<Promise<js::EvalOutcome>>,
+    /// True once a page has been successfully rendered (needed to decide whether to re-render after eval).
+    has_page: bool,
 
     /// Engine actor handle — all pipeline work is delegated through this.
     engine: engine::EngineHandle,
@@ -85,6 +95,11 @@ impl BrowserApp {
             start_time: std::time::Instant::now(),
             console_entries: vec![],
             console_panel_open: true,
+            console_input: String::new(),
+            console_history: vec![],
+            console_history_index: None,
+            console_eval_promise: None,
+            has_page: false,
             engine: engine::EngineHandle::spawn(),
         }
     }
@@ -120,6 +135,7 @@ impl BrowserApp {
         self.image_promises.clear();
         self.hovered_id = None;
         self.is_loading = true;
+        self.has_page = false;
 
         // Evict the glyph rasterization cache so that memory freed between
         // navigations and does not grow without bound across many page loads.
@@ -155,6 +171,7 @@ impl BrowserApp {
         self.current_event_handlers = page_data.event_handlers.clone();
         self.current_element_ids = page_data.element_ids.clone();
         self.current_focusable_elements = page_data.focusable_elements.clone();
+        self.has_page = true;
     }
 }
 
@@ -181,6 +198,21 @@ impl eframe::App for BrowserApp {
         }
 
         self.console_entries = self.engine.send_get_console();
+
+        // Poll console eval promise; trigger re-render if a page is loaded
+        if let Some(eval_promise) = &self.console_eval_promise {
+            if eval_promise.ready().is_some() {
+                self.console_eval_promise = None;
+                if self.has_page
+                    && self.re_render_promise.is_none()
+                    && self.content_promise.is_none()
+                {
+                    self.trigger_re_render(ctx, 800.0);
+                } else {
+                    ctx.request_repaint();
+                }
+            }
+        }
 
         // Handle Tab navigation
         if ctx.input(|i| i.key_pressed(egui::Key::Tab)) {
@@ -300,7 +332,19 @@ impl eframe::App for BrowserApp {
             ctx,
             &mut self.console_panel_open,
             &mut self.console_entries,
+            &mut self.console_input,
+            &mut self.console_history,
+            &mut self.console_history_index,
             || self.engine.send_clear_console(),
+            |code| {
+                if self.console_eval_promise.is_none() {
+                    let handle = self.engine.clone();
+                    self.console_eval_promise =
+                        Some(Promise::spawn_thread("console_eval", move || {
+                            handle.send_console_eval_result(code)
+                        }));
+                }
+            },
         );
 
         // ── Content area ─────────────────────────────────────────────────────────
@@ -348,6 +392,7 @@ impl eframe::App for BrowserApp {
                             self.error = Some(e.clone());
                             self.content_promise = None;
                             self.is_loading = false;
+                            self.has_page = false;
                         }
                         Some(Ok(page_data)) => {
                             // Clone everything we need before releasing the borrow on content_promise
@@ -534,11 +579,48 @@ fn console_level_label(level: js::ConsoleLevel) -> (&'static str, egui::Color32)
     }
 }
 
+fn apply_console_history_navigation(
+    ui: &egui::Ui,
+    response: &egui::Response,
+    input: &mut String,
+    history: &[String],
+    history_index: &mut Option<usize>,
+) {
+    if !response.has_focus() || history.is_empty() {
+        return;
+    }
+
+    if ui.input(|i| i.key_pressed(egui::Key::ArrowUp)) {
+        let next_index = history_index
+            .map(|index| index.saturating_sub(1))
+            .unwrap_or(history.len() - 1);
+        *history_index = Some(next_index);
+        *input = history[next_index].clone();
+    }
+
+    if ui.input(|i| i.key_pressed(egui::Key::ArrowDown)) {
+        if let Some(index) = *history_index {
+            if index + 1 < history.len() {
+                let next_index = index + 1;
+                *history_index = Some(next_index);
+                *input = history[next_index].clone();
+            } else {
+                *history_index = None;
+                input.clear();
+            }
+        }
+    }
+}
+
 fn render_console_panel(
     ctx: &egui::Context,
     open: &mut bool,
     entries: &mut Vec<js::ConsoleEntry>,
+    input: &mut String,
+    history: &mut Vec<String>,
+    history_index: &mut Option<usize>,
     mut clear_console: impl FnMut(),
+    mut evaluate_console: impl FnMut(String),
 ) {
     let default_height = if *open { 180.0 } else { 32.0 };
     egui::TopBottomPanel::bottom("browser_console_panel")
@@ -587,6 +669,10 @@ fn render_console_panel(
 
                     for entry in entries.iter() {
                         let (label, color) = console_level_label(entry.level);
+                        let message_color = match entry.level {
+                            js::ConsoleLevel::Error => color,
+                            _ => egui::Color32::WHITE,
+                        };
                         ui.horizontal_wrapped(|ui| {
                             ui.label(
                                 egui::RichText::new(format!("[{}]", label))
@@ -601,12 +687,37 @@ fn render_console_panel(
                             );
                             ui.label(
                                 egui::RichText::new(&entry.message)
-                                    .color(egui::Color32::WHITE)
+                                    .color(message_color)
                                     .monospace(),
                             );
                         });
                     }
                 });
+
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                ui.label(
+                    egui::RichText::new(">")
+                        .color(egui::Color32::from_rgb(140, 190, 255))
+                        .monospace(),
+                );
+                let response = ui.add(
+                    egui::TextEdit::singleline(input)
+                        .desired_width(f32::INFINITY)
+                        .hint_text("Evaluate JavaScript"),
+                );
+                apply_console_history_navigation(ui, &response, input, history, history_index);
+
+                if response.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    let code = input.trim().to_string();
+                    if !code.is_empty() {
+                        history.push(code.clone());
+                        *history_index = None;
+                        input.clear();
+                        evaluate_console(code);
+                    }
+                }
+            });
         });
 }
 


### PR DESCRIPTION
## Summary
- add structured JS eval results and REPL echo entries in the engine console buffer
- add GUI console input/history for browser and daemon windows
- add daemon POST /console/eval and browser-cli console/repl command support

## Test plan
- [x] cargo build --bins
- [x] cargo test -q
- [x] cargo test -q --bin browser-daemon test_http_console_eval
- [x] cargo test -q test_console_repl_returns_result_and_console_entries
- [x] live daemon/CLI review: navigate https://yunseong.dev and https://google.com
- [x] live POST /console/eval returned {"result":"2","error":null}

Closes #108