### PR TITLE
fix: load Google hero images in headless mode

### DIFF
--- a/.agents/PRIORITY.md
+++ b/.agents/PRIORITY.md
@@ -90,14 +90,19 @@ Addresses severe crashes (OOM/Stack overflow) and massive rendering latency (>1.
 
 ## Priority 7 - Google.com Layout Fidelity
 
-Sub-issues of #103. Fix in order — each builds on previous layer of correctness.
+Sub-issues of #103. Fix in order — each builds on the previous layer of visible correctness.
 
 | # | Issue | Why this order |
 |---|---|---|
-| #110 | [Layout] google.com — form control intrinsic sizing | Most foundational. Search input collapsed = nothing else matters. No deps. |
-| #111 | [Layout] google.com — absolute/fixed header positioning | Affects nav placement. Depends on baseline sizing from #110. |
-| #112 | [Layout] google.com — spacing and line-box alignment in dense header | Refinement after positioning is correct. |
-| #113 | [Runtime] google.com — pre-layout DOM/runtime parity gaps | JS-level pre-layout mutations. Best addressed after visual structure is correct. |
+| #103 | [Layout] google.com search page layout fidelity | Umbrella tracker for the remaining Google layout work. |
+| #110 | ~~[Layout] google.com — form control intrinsic sizing~~ ✓ | Most foundational. Search input collapsed = nothing else matters. |
+| #111 | ~~[Layout] google.com — absolute/fixed header positioning~~ ✓ | Affects nav placement after baseline sizing is correct. |
+| #112 | ~~[Layout] google.com — spacing and line-box alignment in dense header~~ ✓ | Refinement after positioning is correct. |
+| #113 | ~~[Runtime] google.com — pre-layout DOM/runtime parity gaps~~ ✓ | Runtime parity layer completed before the remaining visual follow-ups. |
+| #124 | ~~[Layout] google.com — hero/logo and search cluster composition~~ ✓ | Fixed the missing top-center Google logo/hero composition in headless rendering. |
+| #127 | [Layout] google.com — search row control sizing and inline alignment | Depends on the hero/search cluster being composed as one coherent region. |
+| #126 | [Layout] google.com — stray right-edge overflow artifact | Isolated visual overflow cleanup after the primary structure is corrected. |
+| #125 | [Layout] google.com — footer anchoring and link grouping | Lowest user-impact remaining defect once the hero/search region is stable. |
 
 ---
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -471,6 +471,7 @@ pub fn fetch_and_process(
     width: f32,
 ) -> Result<(PageResult, css::Stylesheet), Box<dyn std::error::Error + Send + Sync>> {
     let response = reqwest::blocking::get(url_str)?;
+    let base_url = response.url().clone();
     let csp_header = response
         .headers()
         .get("content-security-policy")
@@ -478,7 +479,6 @@ pub fn fetch_and_process(
         .map(|s| js::CspPolicy::parse(s));
 
     let body = response.text()?;
-    let base_url = Url::parse(url_str)?;
     process_html_with_cache(
         &body,
         &base_url,
@@ -594,7 +594,7 @@ pub fn process_html_with_cache(
     let mut focusable_elements = Vec::new();
     let image_urls: Vec<String>;
 
-    render::render_layout_tree(&layout_tree, &mut pixmap, image_cache);
+    render::render_layout_tree(&layout_tree, &mut pixmap, image_cache, &base_url);
 
     layout_tree.collect_links(&mut links);
     layout_tree.collect_event_handlers(&mut event_handlers);
@@ -719,7 +719,7 @@ impl BrowserEngine {
         self.current_csp_policy = page.csp_policy.clone();
         self.last_page = Some(page.clone());
         self.init_js_for_page(&page.body);
-        Ok(page)
+        self.refresh_after_image_loads(page, width)
     }
 
     /// Re-render the current page (e.g. after JS style changes or hover state).
@@ -753,7 +753,7 @@ impl BrowserEngine {
         let (page, stylesheet) = result;
         self.last_stylesheet = Some(stylesheet);
         self.last_page = Some(page.clone());
-        Ok(page)
+        self.refresh_after_image_loads(page, width)
     }
 
     /// Hit-test a click at `(x, y)` against the last rendered page.
@@ -814,6 +814,44 @@ impl BrowserEngine {
     /// Full implementation deferred to follow-up issue.
     pub fn type_text(&mut self, _text: &str) {
         println!("[BrowserEngine] type_text: not yet implemented");
+    }
+
+    fn cache_missing_images_with<F>(&mut self, image_urls: &[String], mut fetch: F) -> bool
+    where
+        F: FnMut(&str) -> Result<Vec<u8>, String>,
+    {
+        let mut loaded_any = false;
+        for url in image_urls {
+            if self.image_cache.contains_key(url) {
+                continue;
+            }
+            if let Ok(bytes) = fetch(url) {
+                self.image_cache.insert(url.clone(), bytes);
+                loaded_any = true;
+            }
+        }
+        loaded_any
+    }
+
+    fn cache_missing_images(&mut self, image_urls: &[String]) -> bool {
+        self.cache_missing_images_with(image_urls, |url| {
+            let response = reqwest::blocking::get(url).map_err(|e| e.to_string())?;
+            let bytes = response.bytes().map_err(|e| e.to_string())?;
+            Ok(bytes.to_vec())
+        })
+    }
+
+    fn refresh_after_image_loads(
+        &mut self,
+        page: PageResult,
+        width: f32,
+    ) -> Result<PageResult, String> {
+        if !self.cache_missing_images(&page.image_urls) {
+            return Ok(page);
+        }
+
+        let refreshed = self.re_render(None, None, width)?;
+        Ok(refreshed)
     }
 
     /// Execute JavaScript in the current page's runtime and return a result/error.
@@ -1267,6 +1305,46 @@ mod tests {
         assert!(engine.last_stylesheet.is_none());
         assert!(engine.current_csp_policy.is_none());
         assert!(engine.console_entries().is_empty());
+    }
+
+    #[test]
+    fn test_cache_missing_images_with_inserts_only_uncached_urls() {
+        let mut engine = BrowserEngine::new();
+        engine
+            .image_cache
+            .insert("https://example.com/already.png".into(), vec![1, 2, 3]);
+        let urls = vec![
+            "https://example.com/already.png".to_string(),
+            "https://example.com/new.png".to_string(),
+        ];
+
+        let mut fetched = Vec::new();
+        let loaded = engine.cache_missing_images_with(&urls, |url| {
+            fetched.push(url.to_string());
+            Ok(vec![9, 9, 9])
+        });
+
+        assert!(loaded);
+        assert_eq!(fetched, vec!["https://example.com/new.png".to_string()]);
+        assert_eq!(
+            engine.image_cache.get("https://example.com/already.png"),
+            Some(&vec![1, 2, 3])
+        );
+        assert_eq!(
+            engine.image_cache.get("https://example.com/new.png"),
+            Some(&vec![9, 9, 9])
+        );
+    }
+
+    #[test]
+    fn test_cache_missing_images_with_ignores_fetch_errors() {
+        let mut engine = BrowserEngine::new();
+        let urls = vec!["https://example.com/missing.png".to_string()];
+
+        let loaded = engine.cache_missing_images_with(&urls, |_url| Err("boom".into()));
+
+        assert!(!loaded);
+        assert!(engine.image_cache.is_empty());
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use lazy_static::lazy_static;
 use std::time::Instant;
+use url::Url;
 
 const FONT_DATA: &[u8] = include_bytes!("../assets/fonts/NanumGothic.ttf");
 
@@ -99,7 +100,12 @@ impl TexturePool {
 
 /// Entry point for rendering. Builds a `LayerTree` from the layout, then
 /// composites all layers onto `pixmap` in a parallel viewport-tiled approach.
-pub fn render_layout_tree(layout: &LayoutBox, pixmap: &mut Pixmap, image_cache: &HashMap<String, Vec<u8>>) {
+pub fn render_layout_tree(
+    layout: &LayoutBox,
+    pixmap: &mut Pixmap,
+    image_cache: &HashMap<String, Vec<u8>>,
+    base_url: &Url,
+) {
     let start = Instant::now();
 
     let viewport = LayoutRect {
@@ -113,7 +119,7 @@ pub fn render_layout_tree(layout: &LayoutBox, pixmap: &mut Pixmap, image_cache: 
     let layer_gen_elapsed = start.elapsed();
 
     let start_render = Instant::now();
-    composite_layer_to_surface(0, &tree, pixmap, viewport, image_cache);
+    composite_layer_to_surface(0, &tree, pixmap, viewport, image_cache, base_url);
 
     let render_elapsed = start_render.elapsed();
     println!("[Perf] render_layout_tree (Surface): Layer gen: {:?}, Actual render: {:?}", layer_gen_elapsed, render_elapsed);
@@ -125,6 +131,7 @@ fn composite_layer_to_surface(
     target: &mut Pixmap,
     surface_rect: LayoutRect,
     image_cache: &HashMap<String, Vec<u8>>,
+    base_url: &Url,
 ) {
     let layer = &tree.layers[layer_id];
     if layer.opacity <= 0.0 {
@@ -145,34 +152,34 @@ fn composite_layer_to_surface(
     let (negative, zero, positive) = tree.categorize_children(layer_id);
 
     if let Some(ref mut pixmap) = effect_pixmap {
-        execute_commands_on_tile(&layer.background_commands, pixmap, layer.bounds, image_cache);
+        execute_commands_on_tile(&layer.background_commands, pixmap, layer.bounds, image_cache, base_url);
 
         for &child_id in &negative {
-            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache);
+            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache, base_url);
         }
 
-        execute_commands_on_tile(&layer.content_commands, pixmap, layer.bounds, image_cache);
+        execute_commands_on_tile(&layer.content_commands, pixmap, layer.bounds, image_cache, base_url);
 
         for &child_id in &zero {
-            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache);
+            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache, base_url);
         }
         for &child_id in &positive {
-            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache);
+            composite_layer_to_surface(child_id, tree, pixmap, layer.bounds, image_cache, base_url);
         }
     } else {
-        execute_commands_on_tile(&layer.background_commands, target, surface_rect, image_cache);
+        execute_commands_on_tile(&layer.background_commands, target, surface_rect, image_cache, base_url);
 
         for &child_id in &negative {
-            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache);
+            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache, base_url);
         }
 
-        execute_commands_on_tile(&layer.content_commands, target, surface_rect, image_cache);
+        execute_commands_on_tile(&layer.content_commands, target, surface_rect, image_cache, base_url);
 
         for &child_id in &zero {
-            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache);
+            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache, base_url);
         }
         for &child_id in &positive {
-            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache);
+            composite_layer_to_surface(child_id, tree, target, surface_rect, image_cache, base_url);
         }
     }
 
@@ -225,7 +232,13 @@ fn build_clip_mask(
     Some(m)
 }
 
-fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile_rect: LayoutRect, image_cache: &HashMap<String, Vec<u8>>) {
+fn execute_commands_on_tile(
+    commands: &[PaintCommand],
+    pixmap: &mut Pixmap,
+    tile_rect: LayoutRect,
+    image_cache: &HashMap<String, Vec<u8>>,
+    base_url: &Url,
+) {
     let tx = -tile_rect.x;
     let ty = -tile_rect.y;
     let transform = Transform::from_translate(tx, ty);
@@ -316,7 +329,15 @@ fn execute_commands_on_tile(commands: &[PaintCommand], pixmap: &mut Pixmap, tile
                 }
             }
             PaintCommand::Image { rect: r, url, object_fit, alt } => {
-                let drawn = if let Some(data) = image_cache.get(url) {
+                let resolved_url = if image_cache.contains_key(url) {
+                    None
+                } else {
+                    base_url.join(url).ok().map(|u| u.to_string())
+                };
+                let drawn = if let Some(data) = image_cache
+                    .get(url)
+                    .or_else(|| resolved_url.as_ref().and_then(|u| image_cache.get(u)))
+                {
                     if let Ok(img) = image::load_from_memory(data) {
                         let rgba = img.to_rgba8();
                         let img_w = rgba.width() as f32;
@@ -1170,6 +1191,7 @@ mod tests {
     fn test_shadow_zero_blur_renders_rect() {
         use crate::css::{BoxShadow, OrderedFloat};
         use crate::layer_tree::PaintCommand;
+        use url::Url;
 
         let mut pixmap = Pixmap::new(100, 100).unwrap();
         let shadow = BoxShadow {
@@ -1185,7 +1207,8 @@ mod tests {
 
         let tile_rect = LayoutRect { x: 0.0, y: 0.0, width: 100.0, height: 100.0 };
         let cmds = vec![PaintCommand::Shadow(rect, shadow)];
-        execute_commands_on_tile(&cmds, &mut pixmap, tile_rect, &HashMap::new());
+        let base_url = Url::parse("https://example.com/").unwrap();
+        execute_commands_on_tile(&cmds, &mut pixmap, tile_rect, &HashMap::new(), &base_url);
 
         assert_ne!(pixmap.data(), before.as_slice(), "zero-blur shadow must modify the pixmap");
     }
@@ -1196,6 +1219,7 @@ mod tests {
     fn test_shadow_with_blur_produces_halo() {
         use crate::css::{BoxShadow, OrderedFloat};
         use crate::layer_tree::PaintCommand;
+        use url::Url;
 
         let mut pixmap = Pixmap::new(100, 100).unwrap();
         let shadow = BoxShadow {
@@ -1210,12 +1234,46 @@ mod tests {
 
         let tile_rect = LayoutRect { x: 0.0, y: 0.0, width: 100.0, height: 100.0 };
         let cmds = vec![PaintCommand::Shadow(rect, shadow)];
-        execute_commands_on_tile(&cmds, &mut pixmap, tile_rect, &HashMap::new());
+        let base_url = Url::parse("https://example.com/").unwrap();
+        execute_commands_on_tile(&cmds, &mut pixmap, tile_rect, &HashMap::new(), &base_url);
 
         // The pixel several pixels outside the shadow rect should have non-zero alpha
         // due to the blur halo.  Shadow at (40,40) size (20,20); check pixel at (34,40).
         let halo_alpha = pixmap.data()[(40 * 100 + 34) * 4 + 3];
         assert!(halo_alpha > 0, "blurred shadow halo pixel should be non-zero alpha, got {}", halo_alpha);
+    }
+
+    #[test]
+    fn test_relative_image_url_uses_absolute_cached_bytes() {
+        use crate::layer_tree::{ObjectFit, PaintCommand};
+        use url::Url;
+
+        let png_1x1_red: Vec<u8> = vec![
+            137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0,
+            0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120,
+            156, 99, 248, 207, 192, 240, 31, 0, 5, 0, 1, 255, 137, 153, 61, 29, 0, 0, 0,
+            0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ];
+
+        let mut pixmap = Pixmap::new(8, 8).unwrap();
+        let tile_rect = LayoutRect { x: 0.0, y: 0.0, width: 8.0, height: 8.0 };
+        let rect = LayoutRect { x: 0.0, y: 0.0, width: 8.0, height: 8.0 };
+        let cmds = vec![PaintCommand::Image {
+            rect,
+            url: "/tiny.png".to_string(),
+            object_fit: ObjectFit::Fill,
+            alt: String::new(),
+        }];
+        let base_url = Url::parse("https://example.com/path").unwrap();
+        let mut image_cache = HashMap::new();
+        image_cache.insert("https://example.com/tiny.png".to_string(), png_1x1_red);
+
+        execute_commands_on_tile(&cmds, &mut pixmap, tile_rect, &image_cache, &base_url);
+
+        assert!(
+            pixmap.data().chunks_exact(4).any(|px| px[0] != 0 || px[1] != 0 || px[2] != 0 || px[3] != 0),
+            "relative image paint command should render using absolute cached bytes"
+        );
     }
 
     /// Text rendered via the cache must respect the clip rectangle (pixels outside


### PR DESCRIPTION
## Summary
- use the final redirected response URL as the page base URL so relative assets resolve against the real document origin
- fetch missing page images inside the engine and trigger one internal re-render so headless daemon screenshots include hero assets
- let image paint commands reuse absolute cached image bytes when the DOM  is relative, and add regression coverage for that lookup path
- update  to reflect the split Google roadmap and mark #124 done

## Tests
- cargo test -q
- cargo build --bins
- browser-cli reviewer flow on headless daemon
- navigate https://yunseong.dev
- navigate https://google.com
- screenshot review of google.com headless render (logo now present)

Closes #124