### PR TITLE
fix Google login pill rendering

### DIFF
--- a/.agents/PRIORITY.md
+++ b/.agents/PRIORITY.md
@@ -101,8 +101,8 @@ Sub-issues of #103. Fix in order — each builds on the previous layer of visibl
 | #113 | ~~[Runtime] google.com — pre-layout DOM/runtime parity gaps~~ ✓ | Runtime parity layer completed before the remaining visual follow-ups. |
 | #124 | ~~[Layout] google.com — hero/logo and search cluster composition~~ ✓ | Fixed the missing top-center Google logo/hero composition in headless rendering. |
 | #127 | ~~[Layout] google.com — search row control sizing and inline alignment~~ ✓ | Fixed the `<br>`-driven button row break so the search controls stay grouped below the input. |
-| #126 | [Layout] google.com — stray right-edge overflow artifact | Isolated visual overflow cleanup after the primary structure is corrected. |
-| #125 | [Layout] google.com — footer anchoring and link grouping | Lowest user-impact remaining defect once the hero/search region is stable. |
+| #126 | ~~[Layout] google.com — stray right-edge overflow artifact~~ ✓ | Isolated visual overflow cleanup after the primary structure is corrected. |
+| #125 | ~~[Layout] google.com — footer anchoring and link grouping~~ ✓ | Lowest user-impact remaining defect once the hero/search region is stable. |
 
 ---
 
@@ -110,8 +110,8 @@ Sub-issues of #103. Fix in order — each builds on the previous layer of visibl
 
 | # | Issue | Why this order |
 |---|---|---|
-| #107 | [DevTools] Developer console panel — display JS console output | Foundation for DevTools. #108 depends on this. |
-| #108 | [DevTools] Console REPL — execute JS from developer console | Depends on #107 console panel. |
+| #107 | ~~[DevTools] Developer console panel — display JS console output~~ ✓ | Foundation for DevTools. #108 depends on this. |
+| #108 | ~~[DevTools] Console REPL — execute JS from developer console~~ ✓ | Depends on #107 console panel. |
 
 ---
 

--- a/src/css.rs
+++ b/src/css.rs
@@ -301,6 +301,53 @@ pub fn parse_css(source: &str) -> Stylesheet {
                         declarations.push(Declaration { name: key, value: Value::BoxShadow(shadow), important });
                     }
                 }
+                // font shorthand: "font: <style> <variant> <weight> <size>/<line-height> <family>"
+                // We only extract the size / line-height / family pieces that affect layout.
+                "font" => {
+                    let parts: Vec<&str> = val_raw.split_whitespace().collect();
+                    let size_idx = parts.iter().position(|part| {
+                        let size_part = part.split_once('/').map(|(sz, _)| sz).unwrap_or(part);
+                        matches!(parse_value(size_part), Value::Length(_, _))
+                    });
+
+                    if let Some(idx) = size_idx {
+                        let size_token = parts[idx];
+                        let (size_str, line_height_str) =
+                            size_token.split_once('/').map_or((size_token, None), |(size, line)| {
+                                (size, Some(line))
+                            });
+
+                        if let Value::Length(v, unit) = parse_value(size_str) {
+                            declarations.push(Declaration {
+                                name: intern("font-size"),
+                                value: Value::Length(v, unit),
+                                important,
+                            });
+                        }
+
+                        if let Some(line) = line_height_str {
+                            let line = line.trim();
+                            if !line.is_empty() && line != "normal" {
+                                declarations.push(Declaration {
+                                    name: intern("line-height"),
+                                    value: parse_value(line),
+                                    important,
+                                });
+                            }
+                        }
+
+                        if idx + 1 < parts.len() {
+                            let family = parts[idx + 1..].join(" ");
+                            if !family.is_empty() {
+                                declarations.push(Declaration {
+                                    name: intern("font-family"),
+                                    value: Value::Keyword(intern(&family)),
+                                    important,
+                                });
+                            }
+                        }
+                    }
+                }
                 // flex shorthand: "flex: <grow> [<shrink> [<basis>]]" or keyword
                 "flex" => {
                     let parts: Vec<&str> = val_raw.split_whitespace().collect();
@@ -1174,6 +1221,23 @@ mod tests {
     fn test_parse_percent() {
         let v = parse_value("50%");
         assert_eq!(v, Value::Length(50.0, Unit::Percent));
+    }
+
+    #[test]
+    fn test_parse_font_shorthand_extracts_size_and_line_height() {
+        let ss = parse_css("a { font: 13px/27px Roboto,Arial,sans-serif; }");
+        let rule = match &ss.items[0] {
+            RuleOrAtRule::Rule(rule) => rule,
+            _ => panic!("expected rule"),
+        };
+        assert!(rule.declarations.iter().any(|d| {
+            d.name.as_ref() == "font-size"
+                && matches!(d.value, Value::Length(v, Unit::Px) if (v - 13.0).abs() < 1e-5)
+        }));
+        assert!(rule.declarations.iter().any(|d| {
+            d.name.as_ref() == "line-height"
+                && matches!(d.value, Value::Length(v, Unit::Px) if (v - 27.0).abs() < 1e-5)
+        }));
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -125,18 +125,24 @@ impl IntrinsicSizeCache {
 
                     let mut inline_run_width: f32 = 0.0;
                     let mut max_w: f32 = 0.0;
+                    let mut float_width: f32 = 0.0;
                     for (child_val, child) in child_vals.into_iter().zip(non_skip_children.iter()) {
+                        let child_total = child_val + horiz_margin(child);
+                        if get_float(child).is_some() {
+                            float_width += child_total;
+                            continue;
+                        }
                         let child_disp = get_display_type(child);
                         if is_block_level(child_disp) {
                             max_w = max_w.max(inline_run_width);
                             inline_run_width = 0.0;
-                            max_w = max_w.max(child_val);
+                            max_w = max_w.max(child_total);
                         } else {
-                            inline_run_width += child_val;
+                            inline_run_width += child_total;
                         }
                     }
                     max_w = max_w.max(inline_run_width);
-                    let width = max_w + pad_border;
+                    let width = max_w + float_width + pad_border;
                     self.max_content.insert(key, width);
                     val_stack.push(width);
                 }
@@ -289,6 +295,26 @@ fn horiz_padding_border(sn: &StyledNode) -> f32 {
     read_px_direct(sn, "padding-left")
         + read_px_direct(sn, "padding-right")
         + read_px_direct(sn, "border-width") * 2.0
+}
+
+fn horiz_margin(sn: &StyledNode) -> f32 {
+    read_px_direct(sn, "margin-left") + read_px_direct(sn, "margin-right")
+}
+
+fn border_box_width(cb: &LayoutBox<'_>) -> f32 {
+    cb.dimensions.width + cb.padding.left + cb.padding.right + cb.border.left + cb.border.right
+}
+
+fn border_box_height(cb: &LayoutBox<'_>) -> f32 {
+    cb.dimensions.height + cb.padding.top + cb.padding.bottom + cb.border.top + cb.border.bottom
+}
+
+fn margin_box_width(cb: &LayoutBox<'_>) -> f32 {
+    border_box_width(cb) + cb.margin.left + cb.margin.right
+}
+
+fn margin_box_height(cb: &LayoutBox<'_>) -> f32 {
+    border_box_height(cb) + cb.margin.top + cb.margin.bottom
 }
 
 /// Compute the **max-content** width of a `StyledNode` subtree.
@@ -836,14 +862,26 @@ impl<'a> LayoutBox<'a> {
             .specified_values
             .get(&crate::css::intern("max-width"))
         {
-            width = width.min(*v);
+            let max_w = if box_sizing == "border-box" {
+                (*v - self.padding.left - self.padding.right - self.border.left - self.border.right)
+                    .max(0.0)
+            } else {
+                *v
+            };
+            width = width.min(max_w);
         }
         if let Some(Value::Length(v, Unit::Px)) = self
             .style_node
             .specified_values
             .get(&crate::css::intern("min-width"))
         {
-            width = width.max(*v);
+            let min_w = if box_sizing == "border-box" {
+                (*v - self.padding.left - self.padding.right - self.border.left - self.border.right)
+                    .max(0.0)
+            } else {
+                *v
+            };
+            width = width.max(min_w);
         }
 
         if is_block && width < container_width {
@@ -1191,16 +1229,16 @@ impl<'a> LayoutBox<'a> {
             // ── Helper: compute main/cross size of a laid-out box ─────────────
             let main_size = |cb: &LayoutBox<'_>| -> f32 {
                 if is_row {
-                    cb.dimensions.width + cb.margin.left + cb.margin.right
+                    margin_box_width(cb)
                 } else {
-                    cb.dimensions.height + cb.margin.top + cb.margin.bottom
+                    margin_box_height(cb)
                 }
             };
             let cross_size = |cb: &LayoutBox<'_>| -> f32 {
                 if is_row {
-                    cb.dimensions.height + cb.margin.top + cb.margin.bottom
+                    margin_box_height(cb)
                 } else {
-                    cb.dimensions.width + cb.margin.left + cb.margin.right
+                    margin_box_width(cb)
                 }
             };
 
@@ -1462,16 +1500,16 @@ impl<'a> LayoutBox<'a> {
                     offset_layout_box(&mut item.cb, dx, dy);
 
                     main_cursor += if is_row {
-                        item.cb.dimensions.width + item.cb.margin.left + item.cb.margin.right
+                        margin_box_width(&item.cb)
                     } else {
-                        item.cb.dimensions.height + item.cb.margin.top + item.cb.margin.bottom
+                        margin_box_height(&item.cb)
                     };
 
                     max_child_x = max_child_x.max(
-                        item.cb.dimensions.x + item.cb.dimensions.width + item.cb.margin.right,
+                        item.cb.dimensions.x + border_box_width(&item.cb) + item.cb.margin.right,
                     );
                     child_y = child_y.max(
-                        item.cb.dimensions.y + item.cb.dimensions.height + item.cb.margin.bottom,
+                        item.cb.dimensions.y + border_box_height(&item.cb) + item.cb.margin.bottom,
                     );
                 }
 
@@ -1500,9 +1538,14 @@ impl<'a> LayoutBox<'a> {
             } else {
                 0.0
             };
-            if self.dimensions.width <= 0.0 {
+            if self.dimensions.width <= 0.0 || (is_floated && auto_width) {
+                let derived = max_child_x - self.dimensions.x + self.padding.right + self.border.right;
                 self.dimensions.width = if is_row {
-                    main_container_size
+                    if container_width.is_finite() {
+                        derived.min(container_width)
+                    } else {
+                        derived
+                    }
                 } else {
                     total_cross
                 };
@@ -1746,8 +1789,8 @@ impl<'a> LayoutBox<'a> {
                         let dy = cursor_y - (m.dimensions.y - m.margin.top);
                         offset_layout_box(&mut m, dx, dy);
                         max_child_x =
-                            max_child_x.max(m.dimensions.x + m.dimensions.width + m.margin.right);
-                        lx += m.dimensions.width + m.margin.left + m.margin.right;
+                            max_child_x.max(m.dimensions.x + border_box_width(&m) + m.margin.right);
+                        lx += margin_box_width(&m);
                         result.push(m);
                     }
                     cursor_y += cur_line.height;
@@ -1800,8 +1843,8 @@ impl<'a> LayoutBox<'a> {
                         intrinsic_cache,
                     );
                     if let Some(mut cb) = cb_opt {
-                        let float_w = cb.dimensions.width + cb.margin.left + cb.margin.right;
-                        let float_h = cb.dimensions.height + cb.margin.top + cb.margin.bottom;
+                        let float_w = margin_box_width(&cb);
+                        let float_h = margin_box_height(&cb);
                         let (avail_w, left_indent) = float_ctx.available_at(cursor_y, float_h);
                         let fx = match side {
                             FloatSide::Left => container_x + left_indent,
@@ -1817,7 +1860,7 @@ impl<'a> LayoutBox<'a> {
                             side,
                         });
                         max_child_x = max_child_x
-                            .max(cb.dimensions.x + cb.dimensions.width + cb.margin.right);
+                            .max(cb.dimensions.x + border_box_width(&cb) + cb.margin.right);
                         result.push(cb);
                     }
                     // cursor_y does NOT advance for floats
@@ -1875,7 +1918,7 @@ impl<'a> LayoutBox<'a> {
                         cursor_y = normal_flow_bottom;
                         prev_margin_bottom = cb.margin.bottom;
                         max_child_x = max_child_x
-                            .max(cb.dimensions.x + cb.dimensions.width + cb.margin.right);
+                            .max(cb.dimensions.x + border_box_width(&cb) + cb.margin.right);
                         result.push(cb);
                     }
                     line_start_y = cursor_y; // keep line_start_y in sync after block advances cursor_y
@@ -1914,7 +1957,7 @@ impl<'a> LayoutBox<'a> {
                         // actually placed.  Empty/whitespace-only text nodes return None and
                         // must NOT interrupt adjacent-block margin collapsing.
                         prev_margin_bottom = 0.0;
-                        let item_w = cb.dimensions.width + cb.margin.left + cb.margin.right;
+                        let item_w = margin_box_width(&cb);
                         if cur_line.width + item_w > avail_w && !cur_line.members.is_empty() {
                             flush_line!();
                             // Re-lay out for new line with updated float-aware width
@@ -1950,9 +1993,9 @@ impl<'a> LayoutBox<'a> {
                                     apply_relative_offset(&mut cb2, vw, vh);
                                 }
                                 cur_line.width =
-                                    cb2.dimensions.width + cb2.margin.left + cb2.margin.right;
+                                    margin_box_width(&cb2);
                                 cur_line.height =
-                                    cb2.dimensions.height + cb2.margin.top + cb2.margin.bottom;
+                                    margin_box_height(&cb2);
                                 cur_line.members.push(cb2);
                             }
                         } else {
@@ -1964,7 +2007,7 @@ impl<'a> LayoutBox<'a> {
                             cur_line.width += item_w;
                             cur_line.height = cur_line
                                 .height
-                                .max(cb.dimensions.height + cb.margin.top + cb.margin.bottom);
+                                .max(margin_box_height(&cb));
                             cur_line.members.push(cb);
                         }
                     }
@@ -2004,14 +2047,26 @@ impl<'a> LayoutBox<'a> {
             .specified_values
             .get(&crate::css::intern("max-height"))
         {
-            final_h = final_h.min(*v);
+            let max_h = if box_sizing == "border-box" {
+                (*v - self.padding.top - self.padding.bottom - self.border.top - self.border.bottom)
+                    .max(0.0)
+            } else {
+                *v
+            };
+            final_h = final_h.min(max_h);
         }
         if let Some(Value::Length(v, Unit::Px)) = self
             .style_node
             .specified_values
             .get(&crate::css::intern("min-height"))
         {
-            final_h = final_h.max(*v);
+            let min_h = if box_sizing == "border-box" {
+                (*v - self.padding.top - self.padding.bottom - self.border.top - self.border.bottom)
+                    .max(0.0)
+            } else {
+                *v
+            };
+            final_h = final_h.max(min_h);
         }
         self.dimensions.height = final_h;
 
@@ -2416,6 +2471,12 @@ fn should_skip(child: &StyledNode) -> bool {
             t.as_str(),
             "head" | "style" | "meta" | "title" | "script" | "link" | "noscript"
         ) {
+            return true;
+        }
+        if t == "svg" {
+            // This engine does not rasterize SVG content yet.
+            // Skipping the subtree avoids malformed icon blobs and keeps the
+            // surrounding layout box size driven by CSS width/height.
             return true;
         }
         // <input type="hidden"> never renders, regardless of CSS.
@@ -3373,6 +3434,107 @@ mod tests {
             "shrink-wrapped float contents should stay within the viewport, got right edge {}",
             login.dimensions.x + login.dimensions.width
         );
+    }
+
+    #[test]
+    fn test_float_right_header_with_nested_utility_cluster_stays_in_viewport() {
+        let html = r#"
+            <style>
+                .gb_Xd { height:48px; vertical-align:middle; white-space:nowrap; align-items:center; display:flex; }
+                .gb_7d { box-sizing:border-box; height:48px; padding:0 4px; padding-left:5px; flex:0 0 auto; justify-content:flex-end; }
+                .gb_Jd .gb_7d { float:right; padding-left:32px; }
+                .gb_Q { line-height:normal; padding-right:15px; }
+                .gb_5 { display:inline-block; padding-left:15px; }
+                .gb_5 .gb_4 { display:inline-block; line-height:24px; vertical-align:middle; }
+                .gb_Id { position:relative; float:right; }
+                .gb_od { display:inline; }
+                .gb_Ad { display:inline-block; vertical-align:middle; padding:4px; }
+                .gb_C { display:inline-block; height:40px; width:40px; padding:8px; box-sizing:border-box; }
+                .gb_Td { display:inline-block; padding:10px 12px; margin:12px 16px 12px 10px; min-width:85px; min-height:40px; }
+            </style>
+            <div style="width:800px; padding:6px;">
+                <div class="gb_Jd">
+                    <div id="actions" class="gb_7d gb_Xd">
+                        <div>
+                            <div class="gb_Q">
+                                <div class="gb_5"><a id="gmail" class="gb_4">Gmail</a></div>
+                                <div class="gb_5"><a id="images" class="gb_4">Images</a></div>
+                            </div>
+                        </div>
+                        <div class="gb_Id">
+                            <div class="gb_od">
+                                <div class="gb_Ad"><a id="apps" class="gb_C">A</a></div>
+                            </div>
+                            <a id="login" class="gb_Td">Login</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        "#;
+        let dom_tree = dom::parse_html(html);
+        let ss = css::parse_css("");
+        let style_tree = style::build_style_tree(
+            &dom_tree.document,
+            &ss,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+        );
+        let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
+        let layout = layout_opt.expect("layout");
+        let apps = find_element_by_id(&layout, "apps").expect("apps not found");
+        let login = find_element_by_id(&layout, "login").expect("login not found");
+
+        assert!(
+            apps.dimensions.x >= 0.0,
+            "app launcher should not be pushed off the left edge, got x={}",
+            apps.dimensions.x
+        );
+        assert!(
+            apps.dimensions.x + border_box_width(apps) <= 800.0,
+            "app launcher should stay inside the viewport, got right edge {}",
+            apps.dimensions.x + border_box_width(apps)
+        );
+        assert!(
+            login.dimensions.x + border_box_width(login) <= 800.0,
+            "login button should stay inside the viewport, got right edge {}",
+            login.dimensions.x + border_box_width(login)
+        );
+    }
+
+    #[test]
+    fn test_border_box_min_size_includes_padding() {
+        let html = r#"
+            <div style="width:800px;">
+                <a id="login" style="display:inline-block; box-sizing:border-box; min-width:85px; min-height:40px; padding:10px 12px;">Login</a>
+            </div>
+        "#;
+        let dom_tree = dom::parse_html(html);
+        let ss = css::parse_css("");
+        let style_tree = style::build_style_tree(
+            &dom_tree.document,
+            &ss,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+        );
+        let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
+        let layout = layout_opt.expect("layout");
+        let login = find_element_by_id(&layout, "login").expect("login not found");
+
+        let border_w = login.dimensions.width + login.padding.left + login.padding.right + login.border.left + login.border.right;
+        let border_h = login.dimensions.height + login.padding.top + login.padding.bottom + login.border.top + login.border.bottom;
+
+        assert!(
+            (border_w - 85.0).abs() < 2.0,
+            "border-box min-width should include padding: got border width {}",
+            border_w
+        );
+        assert!(border_h >= 40.0, "border-box min-height should not shrink below 40px, got {}", border_h);
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -762,11 +762,14 @@ impl<'a> LayoutBox<'a> {
             current_y += 5.0; // Break line before block
         }
 
-        let mut width = match self
+        let is_floated = get_float(self.style_node).is_some();
+        let specified_width = self
             .style_node
             .specified_values
-            .get(&crate::css::intern("width"))
-        {
+            .get(&crate::css::intern("width"));
+        let auto_width = specified_width.is_none();
+
+        let mut width = match specified_width {
             Some(Value::Length(v, Unit::Px)) => *v,
             Some(Value::Length(v, Unit::Percent)) => container_width * (v / 100.0),
             Some(Value::Length(v, Unit::Vw)) => vw * (v / 100.0),
@@ -793,10 +796,10 @@ impl<'a> LayoutBox<'a> {
                 max_c.min(available).max(min_c)
             }
             _ => {
-                if is_shrink_wrap(self.display) {
+                if is_floated || is_shrink_wrap(self.display) {
                     let max_c = intrinsic_cache.max_content_width(self.style_node, vw, vh);
                     let min_c = intrinsic_cache.min_content_width(self.style_node, vw, vh);
-                    // Shrink-wrap: min(max-content, max(min-content, available))
+                    // Auto-width floats use shrink-to-fit sizing instead of filling the line.
                     max_c.min(container_width).max(min_c)
                 } else if is_block {
                     (container_width - self.margin.left - self.margin.right).max(0.0)
@@ -1645,7 +1648,7 @@ impl<'a> LayoutBox<'a> {
                 entries.push(ChildEntry {
                     node: child_node,
                     kind: ChildKind::LineBreak,
-                    clear: None,
+                    clear: get_line_break_clear(child_node),
                 });
                 continue;
             }
@@ -1692,6 +1695,9 @@ impl<'a> LayoutBox<'a> {
         let mut result: Vec<LayoutBox<'a>> = Vec::new();
 
         // Read text-align for this container (used by flush_line! to position inline lines).
+        // Only block containers should align their inline contents. Applying inherited
+        // `text-align` inside inline boxes like <a> makes short links behave like wide
+        // centered containers, which breaks grouping in legacy centered footers.
         let text_align = self
             .style_node
             .specified_values
@@ -1699,6 +1705,10 @@ impl<'a> LayoutBox<'a> {
             .and_then(|v| if let Value::Keyword(k) = v { Some(&**k as &str) } else { None })
             .unwrap_or("left")
             .to_string();
+        let applies_text_align = matches!(
+            self.display,
+            DisplayType::Block | DisplayType::Flex | DisplayType::InlineBlock | DisplayType::TableCell
+        );
 
         // Inline line accumulator
         struct InlineLine<'a> {
@@ -1721,10 +1731,14 @@ impl<'a> LayoutBox<'a> {
                     let (avail_w, left_indent) =
                         float_ctx.available_at(line_start_y, cur_line.height.max(1.0));
                     // Compute text-align offset within the available width.
-                    let align_offset = match text_align.as_str() {
-                        "center" => ((avail_w - cur_line.width) / 2.0).max(0.0),
-                        "right" => (avail_w - cur_line.width).max(0.0),
-                        _ => 0.0, // left / default
+                    let align_offset = if applies_text_align {
+                        match text_align.as_str() {
+                            "center" => ((avail_w - cur_line.width) / 2.0).max(0.0),
+                            "right" => (avail_w - cur_line.width).max(0.0),
+                            _ => 0.0, // left / default
+                        }
+                    } else {
+                        0.0
                     };
                     let mut lx = container_x + left_indent + align_offset;
                     for mut m in cur_line.members.drain(..) {
@@ -1756,7 +1770,15 @@ impl<'a> LayoutBox<'a> {
 
                 // ── Forced line break (`<br>`) ───────────────────────────────
                 ChildKind::LineBreak => {
+                    if let Some(cv) = entry.clear {
+                        cursor_y = float_ctx.clear_y(cv).max(cursor_y);
+                    }
+                    let had_inline_content = !cur_line.members.is_empty();
+                    let break_height = resolved_line_height_px(entry.node);
                     flush_line!();
+                    if !had_inline_content {
+                        cursor_y += break_height;
+                    }
                     prev_margin_bottom = 0.0;
                     line_start_y = cursor_y;
                 }
@@ -1965,7 +1987,7 @@ impl<'a> LayoutBox<'a> {
         // Now safe to mutably assign self.children (immutable borrow of self.style_node ended above).
         self.children = result;
 
-        if self.dimensions.width <= 0.0 {
+        if self.dimensions.width <= 0.0 || (is_floated && auto_width) {
             let derived = max_child_x - self.dimensions.x + self.padding.right + self.border.right;
             self.dimensions.width = if container_width.is_finite() {
                 derived.min(container_width)
@@ -2275,6 +2297,44 @@ fn apply_relative_offset(layout: &mut LayoutBox, vw: f32, vh: f32) {
     if dx != 0.0 || dy != 0.0 {
         offset_layout_box(layout, dx, dy);
     }
+}
+
+fn resolved_font_size_px(sn: &StyledNode) -> f32 {
+    match sn.specified_values.get(&crate::css::intern("font-size")) {
+        Some(Value::Length(v, Unit::Px)) => (*v).max(1.0),
+        _ => 16.0,
+    }
+}
+
+fn resolved_line_height_px(sn: &StyledNode) -> f32 {
+    let font_size = resolved_font_size_px(sn);
+    match sn.specified_values.get(&crate::css::intern("line-height")) {
+        Some(Value::Length(v, Unit::Px)) => (*v).max(0.0),
+        Some(Value::Number(v)) => (font_size * *v).max(0.0),
+        _ => font_size * 1.4,
+    }
+}
+
+fn get_line_break_clear(sn: &StyledNode) -> Option<ClearValue> {
+    if let Some(clear) = get_clear(sn) {
+        return Some(clear);
+    }
+
+    if let NodeData::Element { ref attrs, .. } = sn.node.data {
+        for attr in attrs.borrow().iter() {
+            if attr.name.local.as_ref() != "clear" {
+                continue;
+            }
+            return match attr.value.as_ref() {
+                "left" => Some(ClearValue::Left),
+                "right" => Some(ClearValue::Right),
+                "all" | "both" => Some(ClearValue::Both),
+                _ => None,
+            };
+        }
+    }
+
+    None
 }
 
 fn get_prop(sn: &StyledNode, p1: &str, p2: &str, cw: f32, vw: f32, vh: f32) -> f32 {
@@ -3062,6 +3122,75 @@ mod tests {
     }
 
     #[test]
+    fn test_consecutive_br_adds_blank_line_height() {
+        let html = r#"
+            <div style="width: 400px;">
+                first
+                <br>
+                <br>
+                <span id="second">second</span>
+            </div>
+        "#;
+        let dom = dom::parse_html(html);
+        let stylesheet = css::parse_css("");
+        let style_tree = style::build_style_tree(
+            &dom.document,
+            &stylesheet,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+        );
+
+        let (layout_opt, _, _) =
+            build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 400.0, 400.0, 600.0);
+        let layout = layout_opt.expect("layout");
+        let first = find_text_box_containing(&layout, "first").expect("first text");
+        let second = find_element_by_id(&layout, "second").expect("second span");
+
+        assert!(
+            second.dimensions.y >= first.dimensions.y + 40.0,
+            "consecutive <br> should create a blank line of vertical space: first.y={}, second.y={}",
+            first.dimensions.y,
+            second.dimensions.y
+        );
+    }
+
+    #[test]
+    fn test_br_clear_all_pushes_content_below_float() {
+        let html = r#"
+            <div style="width: 800px;">
+                <div style="float:right; width:120px; height:60px;">header</div>
+                <br clear="all">
+                <span id="after">after</span>
+            </div>
+        "#;
+        let dom = dom::parse_html(html);
+        let stylesheet = css::parse_css("");
+        let style_tree = style::build_style_tree(
+            &dom.document,
+            &stylesheet,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+        );
+
+        let (layout_opt, _, _) =
+            build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
+        let layout = layout_opt.expect("layout");
+        let after = find_element_by_id(&layout, "after").expect("after span");
+
+        assert!(
+            after.dimensions.y >= 60.0,
+            "<br clear=\"all\"> should push following content below the float, got y={}",
+            after.dimensions.y
+        );
+    }
+
+    #[test]
     fn test_inline_zero_width_falls_back_to_intrinsic_for_positioned_children() {
         let html = r#"
             <div style="width: 160px;">
@@ -3205,6 +3334,44 @@ mod tests {
             float_child.dimensions.x, 700.0,
             "float:right child (width 100px) in 800px container should have x=700.0, got {}",
             float_child.dimensions.x
+        );
+    }
+
+    #[test]
+    fn test_float_right_auto_width_shrink_wraps_contents() {
+        let html = r#"
+            <div style="width:800px;">
+                <div id="header-actions" style="float:right; position:relative;">
+                    <a id="apps" style="display:inline-block; width:24px; height:40px;">A</a>
+                    <a id="login" style="display:inline-block; min-width:85px; min-height:40px; margin:12px 16px 12px 10px; padding:10px 12px; background:#0b57d0; border-radius:100px; color:#fff;">Login</a>
+                </div>
+            </div>
+        "#;
+        let dom_tree = dom::parse_html(html);
+        let ss = css::parse_css("");
+        let style_tree = style::build_style_tree(
+            &dom_tree.document,
+            &ss,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+        );
+        let (layout_opt, _, _) = build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
+        let layout = layout_opt.expect("layout");
+        let actions = find_element_by_id(&layout, "header-actions").expect("header-actions not found");
+        let login = find_element_by_id(&layout, "login").expect("login not found");
+
+        assert!(
+            actions.dimensions.width < 300.0,
+            "auto-width float should shrink-wrap its contents instead of expanding to the full line, got {}",
+            actions.dimensions.width
+        );
+        assert!(
+            login.dimensions.x + login.dimensions.width <= 800.0,
+            "shrink-wrapped float contents should stay within the viewport, got right edge {}",
+            login.dimensions.x + login.dimensions.width
         );
     }
 
@@ -4235,6 +4402,53 @@ mod tests {
             first_child_x > 100.0,
             "text-align:center should shift content to roughly midpoint; got x={}",
             first_child_x
+        );
+    }
+
+    #[test]
+    fn test_centered_inline_links_keep_intrinsic_width() {
+        let html = r#"
+            <center>
+                <p style="font-size:8pt;color:#636363">
+                    &copy; 2026 -
+                    <a id="privacy" href="/privacy">개인정보처리방침</a>
+                    -
+                    <a id="terms" href="/terms">약관</a>
+                </p>
+            </center>
+        "#;
+        let dom = dom::parse_html(html);
+        let ss = css::parse_css("");
+        let style_tree =
+            style::build_style_tree(&dom.document, &ss, None, &HashMap::new(), None, None, None);
+        let (layout_opt, _, _) =
+            build_layout_tree(&style_tree, 0.0, 0.0, 0.0, 800.0, 800.0, 600.0);
+        let layout = layout_opt.expect("layout tree");
+
+        let copyright = find_text_box_containing(&layout, "2026").expect("copyright text");
+        let privacy = find_element_by_id(&layout, "privacy").expect("privacy link");
+        let terms = find_element_by_id(&layout, "terms").expect("terms link");
+
+        assert!(
+            privacy.dimensions.width < 220.0,
+            "center-inherited inline link should keep intrinsic width, got {}",
+            privacy.dimensions.width
+        );
+        assert!(
+            (privacy.dimensions.y - copyright.dimensions.y).abs() < 2.0,
+            "privacy link should stay grouped on the same policy line: copyright.y={}, privacy.y={}",
+            copyright.dimensions.y,
+            privacy.dimensions.y
+        );
+        assert!(
+            (terms.dimensions.y - privacy.dimensions.y).abs() < 2.0,
+            "terms link should stay on the same policy line as privacy: privacy.y={}, terms.y={}",
+            privacy.dimensions.y,
+            terms.dimensions.y
+        );
+        assert!(
+            terms.dimensions.x > privacy.dimensions.x,
+            "terms link should remain to the right of privacy on the shared line"
         );
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -622,6 +622,9 @@ fn draw_broken_image(pixmap: &mut Pixmap, r: LayoutRect, alt: &str, transform: T
 fn create_rounded_rect_path(r: LayoutRect, radius: f32) -> Option<tiny_skia::Path> {
     let mut pb = PathBuilder::new();
     let rect = tiny_skia::Rect::from_xywh(r.x, r.y, r.width, r.height)?;
+    let radius = radius
+        .max(0.0)
+        .min(rect.width().min(rect.height()) / 2.0);
     pb.move_to(rect.left() + radius, rect.top());
     pb.line_to(rect.right() - radius, rect.top());
     pb.quad_to(rect.right(), rect.top(), rect.right(), rect.top() + radius);
@@ -1310,5 +1313,19 @@ mod tests {
                     "pixel at ({}, {}) must remain white under right-half clip", col, row);
             }
         }
+    }
+
+    #[test]
+    fn test_create_rounded_rect_path_clamps_large_radius() {
+        let path = create_rounded_rect_path(
+            LayoutRect {
+                x: 0.0,
+                y: 0.0,
+                width: 85.0,
+                height: 40.0,
+            },
+            100.0,
+        );
+        assert!(path.is_some(), "large border radius should still produce a valid path");
     }
 }


### PR DESCRIPTION
Fix the remaining Google header artifact caused by oversized border-radius rendering.\n\nChanges:\n- Clamp rounded-rect radii to half the box size in the renderer\n- Preserve the earlier font shorthand and layout sizing fixes\n- Add regression coverage for oversized radii\n\nVerification:\n- cargo test -q test_create_rounded_rect_path_clamps_large_radius -- --nocapture\n- cargo test -q test_border_box_min_size_includes_padding -- --nocapture\n- cargo test -q test_float_right_header_with_nested_utility_cluster_stays_in_viewport -- --nocapture\n- cargo build --bins\n- Live screenshot review on Google at 127.0.0.1:7071