### PR TITLE
fix: stabilize viewport width across all re-render paths (#137)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1540,4 +1540,106 @@ mod tests {
         let tag = "input type=text name=user";
         assert_eq!(extract_attr(tag, "type"), Some("text".to_string()));
     }
+
+    // ── Viewport width stability regression tests ────────────────────────────────
+
+    /// Verify that `process_html_with_cache` uses the exact width passed in and
+    /// returns a `PageResult` whose `width` field matches that value.
+    /// This ensures that navigate and re-render paths produce bit-identical layout
+    /// when given the same width.
+    #[test]
+    fn test_process_html_stable_width() {
+        use url::Url;
+        let html = "<html><body><p>hello</p></body></html>";
+        let base = Url::parse("https://example.com").unwrap();
+        let mut cache = HashMap::new();
+
+        let navigate_width = 800.0_f32;
+        let (page, _ss) = process_html_with_cache(
+            html,
+            &base,
+            &HashMap::new(),
+            &mut cache,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            navigate_width,
+        )
+        .expect("process_html_with_cache failed");
+
+        assert_eq!(
+            page.width, navigate_width as u32,
+            "page.width should equal the navigate width"
+        );
+
+        // Re-render with the same width: result must be identical.
+        let (re_rendered, _) = process_html_with_cache(
+            html,
+            &base,
+            &HashMap::new(),
+            &mut cache,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            navigate_width, // same width — no drift
+        )
+        .expect("re-render failed");
+
+        assert_eq!(
+            page.width, re_rendered.width,
+            "re-render width must match navigate width — no viewport drift"
+        );
+        assert_eq!(
+            page.height, re_rendered.height,
+            "re-render height must match — no layout churn from width drift"
+        );
+    }
+
+    /// Verify that a different width produces a different layout, confirming that
+    /// the test above is not trivially true.
+    #[test]
+    fn test_process_html_different_widths_differ() {
+        use url::Url;
+        // Use enough content that a width difference is likely to change final_y or width.
+        let html = "<html><body><p>some content</p></body></html>";
+        let base = Url::parse("https://example.com").unwrap();
+        let mut cache = HashMap::new();
+
+        let (page_800, _) = process_html_with_cache(
+            html,
+            &base,
+            &HashMap::new(),
+            &mut cache,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            800.0,
+        )
+        .expect("800 failed");
+
+        let (page_400, _) = process_html_with_cache(
+            html,
+            &base,
+            &HashMap::new(),
+            &mut cache,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            400.0,
+        )
+        .expect("400 failed");
+
+        assert_ne!(
+            page_800.width, page_400.width,
+            "different widths must produce different page.width values"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,14 @@ struct BrowserApp {
 
     /// Engine actor handle — all pipeline work is delegated through this.
     engine: engine::EngineHandle,
+
+    /// The single authoritative viewport width for all layout and re-render operations.
+    ///
+    /// Set once on each navigation (to 800.0 px) and reused verbatim for every
+    /// subsequent re-render triggered by hover, focus, image-load, or JS eval.
+    /// This prevents layout jitter caused by measuring `ui.available_width()` from
+    /// different egui containers, which varies slightly frame-to-frame.
+    viewport_width: f32,
 }
 
 impl BrowserApp {
@@ -101,35 +109,42 @@ impl BrowserApp {
             console_eval_promise: None,
             has_page: false,
             engine: engine::EngineHandle::spawn(),
+            viewport_width: 800.0,
         }
     }
 
-    fn load_url(&mut self, url: String, width: f32) {
+    fn load_url(&mut self, url: String) {
         if self.history.is_empty() || self.history[self.history_index] != url {
             self.history.truncate(self.history_index + 1);
             self.history.push(url.clone());
             self.history_index = self.history.len() - 1;
         }
-        self.load_url_direct(url, width);
+        self.load_url_direct(url);
     }
 
-    fn navigate_back(&mut self, width: f32) {
+    fn navigate_back(&mut self) {
         if self.history_index > 0 {
             self.history_index -= 1;
             let url = self.history[self.history_index].clone();
-            self.load_url_direct(url, width);
+            self.load_url_direct(url);
         }
     }
 
-    fn navigate_forward(&mut self, width: f32) {
+    fn navigate_forward(&mut self) {
         if self.history_index + 1 < self.history.len() {
             self.history_index += 1;
             let url = self.history[self.history_index].clone();
-            self.load_url_direct(url, width);
+            self.load_url_direct(url);
         }
     }
 
-    fn load_url_direct(&mut self, url: String, width: f32) {
+    fn load_url_direct(&mut self, url: String) {
+        // Fix viewport_width at 800.0 on every navigation so all subsequent
+        // re-renders (hover, focus, image-load, JS eval) use the exact same width
+        // and never cause layout jitter.
+        self.viewport_width = 800.0;
+        println!("[Viewport] navigate width={:.1}", self.viewport_width);
+
         self.url = url.clone();
         self.error = None;
         self.image_promises.clear();
@@ -137,10 +152,11 @@ impl BrowserApp {
         self.is_loading = true;
         self.has_page = false;
 
-        // Evict the glyph rasterization cache so that memory freed between
+        // Evict the glyph rasterization cache so that memory is freed between
         // navigations and does not grow without bound across many page loads.
         render::clear_glyph_cache();
 
+        let width = self.viewport_width;
         let handle = self.engine.clone();
         self.content_promise = Some(Promise::spawn_thread("fetcher", move || {
             handle.send_navigate(url, width)
@@ -148,7 +164,13 @@ impl BrowserApp {
     }
 
     /// Re-render the current page (e.g. after hover/focus state change).
-    fn trigger_re_render(&mut self, ctx: &egui::Context, width: f32) {
+    ///
+    /// Always uses `self.viewport_width` — the single authoritative width set at
+    /// navigate time — so that layout is bit-identical across all re-render triggers.
+    fn trigger_re_render(&mut self, ctx: &egui::Context, trigger: &str) {
+        let width = self.viewport_width;
+        println!("[Viewport] re-render trigger={} width={:.1}", trigger, width);
+
         let handle = self.engine.clone();
         let hovered_id = self.hovered_id.clone();
         let focused_id = self.focused_id.clone();
@@ -207,7 +229,7 @@ impl eframe::App for BrowserApp {
                     && self.re_render_promise.is_none()
                     && self.content_promise.is_none()
                 {
-                    self.trigger_re_render(ctx, 800.0);
+                    self.trigger_re_render(ctx, "console-eval");
                 } else {
                     ctx.request_repaint();
                 }
@@ -236,7 +258,7 @@ impl eframe::App for BrowserApp {
                 };
 
                 self.focused_id = Some(focusables[next_index].1.clone());
-                self.trigger_re_render(ctx, 800.0);
+                self.trigger_re_render(ctx, "tab-focus");
             }
         }
 
@@ -268,14 +290,14 @@ impl eframe::App for BrowserApp {
                     };
 
                     if btn_style(ui, "←", self.history_index > 0).clicked() {
-                        self.navigate_back(ui.available_width());
+                        self.navigate_back();
                     }
                     if btn_style(ui, "→", self.history_index + 1 < self.history.len()).clicked() {
-                        self.navigate_forward(ui.available_width());
+                        self.navigate_forward();
                     }
                     if btn_style(ui, "⟳", true).clicked() {
                         let url = self.url.clone();
-                        self.load_url_direct(url, ui.available_width());
+                        self.load_url_direct(url);
                     }
 
                     ui.spacing_mut().item_spacing.x = 8.0;
@@ -295,10 +317,7 @@ impl eframe::App for BrowserApp {
                         let resp = ui.add(edit);
                         if resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                             let url = self.url.clone();
-                            let width = ui.available_width();
-                            if width >= 1.0 {
-                                self.load_url(url, width);
-                            }
+                            self.load_url(url);
                         }
                     });
 
@@ -311,10 +330,7 @@ impl eframe::App for BrowserApp {
                         .min_size(egui::vec2(50.0, 28.0)),
                     ).clicked() {
                         let url = self.url.clone();
-                        let width = ui.available_width();
-                        if width >= 1.0 {
-                            self.load_url(url, width);
-                        }
+                        self.load_url(url);
                     }
                 });
 
@@ -357,7 +373,7 @@ impl eframe::App for BrowserApp {
                         let had_script = results.iter().any(|r| matches!(r, engine::ClickResult::ScriptExecuted));
                         self.click_promise = None;
                         if had_script {
-                            self.trigger_re_render(ctx, 800.0);
+                            self.trigger_re_render(ctx, "click-script");
                         }
                     }
                 }
@@ -446,8 +462,7 @@ impl eframe::App for BrowserApp {
                     }
                 });
                 if newly_loaded {
-                    let width = ui.available_width();
-                    self.trigger_re_render(ctx, width);
+                    self.trigger_re_render(ctx, "image-load");
                 }
 
                 // Error message
@@ -512,7 +527,7 @@ impl eframe::App for BrowserApp {
                                 }
                                 if new_focus != self.focused_id {
                                     self.focused_id = new_focus;
-                                    self.trigger_re_render(ctx, ui.available_width());
+                                    self.trigger_re_render(ctx, "click-focus");
                                 }
 
                                 for (l_rect, link) in &self.current_links {
@@ -544,19 +559,16 @@ impl eframe::App for BrowserApp {
                             }
                             if new_hovered_id != self.hovered_id {
                                 self.hovered_id = new_hovered_id;
-                                let width = ui.available_width();
-                                self.trigger_re_render(ctx, width);
+                                self.trigger_re_render(ctx, "hover-enter");
                             }
                         } else if self.hovered_id.is_some() {
                             self.hovered_id = None;
-                            let width = ui.available_width();
-                            self.trigger_re_render(ctx, width);
+                            self.trigger_re_render(ctx, "hover-leave");
                         }
                     });
 
                     if let Some(url) = url_to_load {
-                        let width = ui.available_width();
-                        self.load_url(url, width);
+                        self.load_url(url);
                     }
                 }
             });


### PR DESCRIPTION
## Summary

- Store a single authoritative `viewport_width: f32` field in `BrowserApp`, initialized to `800.0` on every navigation
- Remove all `ui.available_width()` measurements from re-render trigger paths (hover, focus, image-load, click-script, console-eval, tab-focus) — they now unconditionally use `self.viewport_width`
- Simplify navigation method signatures: `load_url`, `navigate_back`, `navigate_forward`, `load_url_direct` no longer take a `width` parameter
- Add trigger-source instrumentation logging: each re-render logs `[Viewport] re-render trigger=<source> width=<n>` to confirm width stability at runtime
- Add two regression tests in `engine::tests`: `test_process_html_stable_width` (same width = identical layout) and `test_process_html_different_widths_differ` (different widths = different layout, confirming the first test is non-trivial)

## Root cause

Some re-render paths in `src/main.rs` used `ui.available_width()` measured from different egui containers (scroll area, toolbar, content panel), which varies slightly frame-to-frame. Other paths hardcoded `800.0`. This inconsistency forced full re-layouts with different widths, causing visible component size jitter and unnecessary layout churn on hover/focus/image-load events.

## Test plan

- [x] `cargo test --lib` — 191 tests pass (2 new regression tests added)
- [x] `browser-cli navigate https://yunseong.dev` — page loads and renders correctly
- [x] `browser-cli navigate https://google.com` — page loads and renders correctly
- [x] Screenshots verified: Google logo, search input, footer links, header nav all render correctly; yunseong.dev full content renders correctly

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)