### PR TITLE
fix: implement basic flex row layout

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -358,16 +358,19 @@ pub fn parse_css(source: &str) -> Stylesheet {
                                 "none"    => {
                                     declarations.push(Declaration { name: intern("flex-grow"),   value: Value::Number(0.0), important });
                                     declarations.push(Declaration { name: intern("flex-shrink"), value: Value::Number(0.0), important });
+                                    declarations.push(Declaration { name: intern("flex-basis"),  value: Value::Keyword(intern("auto")), important });
                                 }
                                 "auto"    => {
                                     declarations.push(Declaration { name: intern("flex-grow"),   value: Value::Number(1.0), important });
                                     declarations.push(Declaration { name: intern("flex-shrink"), value: Value::Number(1.0), important });
+                                    declarations.push(Declaration { name: intern("flex-basis"),  value: Value::Keyword(intern("auto")), important });
                                 }
                                 _ => {
-                                    // single unitless number → flex-grow
+                                    // Single unitless number expands to `flex: <n> 1 0%`.
                                     if let Ok(n) = parts[0].parse::<f32>() {
                                         declarations.push(Declaration { name: intern("flex-grow"),   value: Value::Number(n),   important });
                                         declarations.push(Declaration { name: intern("flex-shrink"), value: Value::Number(1.0), important });
+                                        declarations.push(Declaration { name: intern("flex-basis"),  value: Value::Length(0.0, Unit::Percent), important });
                                     }
                                 }
                             }
@@ -376,6 +379,10 @@ pub fn parse_css(source: &str) -> Stylesheet {
                             if let (Ok(g), Ok(s)) = (parts[0].parse::<f32>(), parts[1].parse::<f32>()) {
                                 declarations.push(Declaration { name: intern("flex-grow"),   value: Value::Number(g), important });
                                 declarations.push(Declaration { name: intern("flex-shrink"), value: Value::Number(s), important });
+                            } else if let Ok(g) = parts[0].parse::<f32>() {
+                                declarations.push(Declaration { name: intern("flex-grow"),   value: Value::Number(g), important });
+                                declarations.push(Declaration { name: intern("flex-shrink"), value: Value::Number(1.0), important });
+                                declarations.push(Declaration { name: intern("flex-basis"),  value: parse_value(parts[1]), important });
                             }
                         }
                         _ => {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1183,8 +1183,27 @@ impl<'a> LayoutBox<'a> {
                         | Some(Value::FitContent(_))
                 );
                 let child_display = get_display_type(child_node);
+                let flex_basis = child_node
+                    .specified_values
+                    .get(&crate::css::intern("flex-basis"))
+                    .and_then(|v| {
+                        if !is_row {
+                            return None;
+                        }
+                        match v {
+                            Value::Length(px, Unit::Px) => Some((*px).max(0.0)),
+                            Value::Length(pct, Unit::Percent) => {
+                                Some((inner_width * (*pct / 100.0)).max(0.0))
+                            }
+                            Value::Number(n) => Some((*n).max(0.0)),
+                            Value::Keyword(k) if &**k == "auto" => None,
+                            _ => None,
+                        }
+                    });
                 let measure_width =
-                    if is_row && is_block_level(child_display) && !child_has_explicit_width {
+                    if let Some(basis) = flex_basis {
+                        basis.min(inner_width).max(0.0)
+                    } else if is_row && is_block_level(child_display) && !child_has_explicit_width {
                         // Shrink-wrap: use max-content so block items don't fill the flex container.
                         intrinsic_cache
                             .max_content_width(child_node, vw, vh)
@@ -1205,6 +1224,9 @@ impl<'a> LayoutBox<'a> {
                     intrinsic_cache,
                 );
                 if let Some(mut cb) = cb_opt {
+                    if let Some(basis) = flex_basis {
+                        cb.dimensions.width = basis.min(inner_width).max(0.0);
+                    }
                     if cb.dimensions.width > inner_width {
                         cb.dimensions.width = inner_width;
                     }
@@ -4919,6 +4941,215 @@ mod tests {
             sep.dimensions.width > 0.0,
             "sep must have positive width (space + text): width={}",
             sep.dimensions.width
+        );
+    }
+
+    // ── Flexbox row layout tests (issue #142) ─────────────────────────────────
+
+    /// `display:flex` children must lay out in a row (left-to-right) instead of
+    /// stacking vertically like block children.
+    #[test]
+    fn test_flex_row_children_are_placed_horizontally() {
+        let html = r#"<div style="display:flex;flex-direction:row;width:300px;height:50px;">
+            <div id="a" style="width:80px;height:50px;">A</div>
+            <div id="b" style="width:80px;height:50px;">B</div>
+            <div id="c" style="width:80px;height:50px;">C</div>
+        </div>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+
+        let a = find_element_by_id(&layout, "a").expect("child A");
+        let b = find_element_by_id(&layout, "b").expect("child B");
+        let c = find_element_by_id(&layout, "c").expect("child C");
+
+        // All children should be on the same row (same y coordinate).
+        assert!(
+            (a.dimensions.y - b.dimensions.y).abs() < 2.0,
+            "A and B should be on the same row: a.y={}, b.y={}",
+            a.dimensions.y, b.dimensions.y
+        );
+        assert!(
+            (b.dimensions.y - c.dimensions.y).abs() < 2.0,
+            "B and C should be on the same row: b.y={}, c.y={}",
+            b.dimensions.y, c.dimensions.y
+        );
+        // Children should be ordered left-to-right.
+        assert!(
+            a.dimensions.x < b.dimensions.x,
+            "A should be to the left of B: a.x={}, b.x={}",
+            a.dimensions.x, b.dimensions.x
+        );
+        assert!(
+            b.dimensions.x < c.dimensions.x,
+            "B should be to the left of C: b.x={}, c.x={}",
+            b.dimensions.x, c.dimensions.x
+        );
+    }
+
+    /// `justify-content: center` must center flex children horizontally within
+    /// the flex container.
+    #[test]
+    fn test_flex_justify_content_center() {
+        let html = r#"<div style="display:flex;justify-content:center;width:400px;height:50px;">
+            <div id="a" style="width:80px;height:50px;">A</div>
+            <div id="b" style="width:80px;height:50px;">B</div>
+        </div>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+
+        let a = find_element_by_id(&layout, "a").expect("child A");
+        let b = find_element_by_id(&layout, "b").expect("child B");
+
+        // Total child width = 80 + 80 = 160px; container = 400px; free = 240px.
+        // With justify-content:center, the left offset should be ~120px.
+        assert!(
+            a.dimensions.x > 80.0,
+            "justify-content:center should offset children from the left: a.x={}",
+            a.dimensions.x
+        );
+        // Right edge of last child should not reach the container's right edge.
+        let b_right = b.dimensions.x + b.dimensions.width;
+        assert!(
+            b_right < 380.0,
+            "justify-content:center should leave space on the right: b_right={}",
+            b_right
+        );
+        // The gap on the left and right should be roughly equal (±10px tolerance).
+        let flex_div = find_element_by_tag(&layout, "div").expect("flex container");
+        let left_gap = a.dimensions.x - flex_div.dimensions.x;
+        let right_gap = (flex_div.dimensions.x + flex_div.dimensions.width) - b_right;
+        assert!(
+            (left_gap - right_gap).abs() < 10.0,
+            "left and right gaps should be roughly equal: left={}, right={}",
+            left_gap, right_gap
+        );
+    }
+
+    /// `align-items: center` must center flex children vertically within the
+    /// cross axis of the flex container.
+    #[test]
+    fn test_flex_align_items_center() {
+        let html = r#"<div style="display:flex;align-items:center;width:300px;height:100px;">
+            <div id="a" style="width:80px;height:30px;">A</div>
+            <div id="b" style="width:80px;height:60px;">B</div>
+        </div>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+
+        let flex_div = find_element_by_tag(&layout, "div").expect("flex container");
+        let a = find_element_by_id(&layout, "a").expect("child A");
+        let b = find_element_by_id(&layout, "b").expect("child B");
+
+        let container_top = flex_div.dimensions.y;
+        let container_height = flex_div.dimensions.height;
+
+        // Child A (30px tall) should be vertically centered in the line height (60px max).
+        // Expected center offset: (60 - 30) / 2 = 15px from the container top.
+        let a_center = a.dimensions.y + a.dimensions.height / 2.0;
+        let container_center = container_top + container_height / 2.0;
+        assert!(
+            (a_center - container_center).abs() < 10.0,
+            "align-items:center should center child A vertically: a_center={}, container_center={}",
+            a_center, container_center
+        );
+
+        // Child B (60px tall) should also be centered (which means it starts near container top).
+        let b_center = b.dimensions.y + b.dimensions.height / 2.0;
+        assert!(
+            (b_center - container_center).abs() < 10.0,
+            "align-items:center should center child B vertically: b_center={}, container_center={}",
+            b_center, container_center
+        );
+    }
+
+    /// `flex: 1` shorthand sets flex-grow:1 so that children with `flex:1` each
+    /// receive an equal share of the remaining space in the flex container.
+    #[test]
+    fn test_flex_one_distributes_space_equally() {
+        let html = r#"<div style="display:flex;width:300px;height:50px;">
+            <div id="a" style="flex:1;">A</div>
+            <div id="b" style="flex:1;">B</div>
+            <div id="c" style="flex:1;">C</div>
+        </div>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+
+        let a = find_element_by_id(&layout, "a").expect("child A");
+        let b = find_element_by_id(&layout, "b").expect("child B");
+        let c = find_element_by_id(&layout, "c").expect("child C");
+
+        // Each child should get ~100px (300px / 3).
+        assert!(
+            (a.dimensions.width - 100.0).abs() < 5.0,
+            "flex:1 child A should get ~100px, got {}",
+            a.dimensions.width
+        );
+        assert!(
+            (b.dimensions.width - 100.0).abs() < 5.0,
+            "flex:1 child B should get ~100px, got {}",
+            b.dimensions.width
+        );
+        assert!(
+            (c.dimensions.width - 100.0).abs() < 5.0,
+            "flex:1 child C should get ~100px, got {}",
+            c.dimensions.width
+        );
+        // All three children should be on the same row.
+        assert!(
+            (a.dimensions.y - b.dimensions.y).abs() < 2.0,
+            "all flex:1 children should be on the same row"
+        );
+    }
+
+    #[test]
+    fn test_flex_basis_sets_initial_main_size() {
+        let html = r#"<div style="display:flex;width:300px;height:50px;">
+            <div id="a" style="flex:0 0 120px;">A</div>
+            <div id="b" style="flex:0 0 80px;">B</div>
+        </div>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+
+        let a = find_element_by_id(&layout, "a").expect("child A");
+        let b = find_element_by_id(&layout, "b").expect("child B");
+
+        assert!(
+            (a.dimensions.width - 120.0).abs() < 2.0,
+            "flex-basis should drive child A width, got {}",
+            a.dimensions.width
+        );
+        assert!(
+            (b.dimensions.width - 80.0).abs() < 2.0,
+            "flex-basis should drive child B width, got {}",
+            b.dimensions.width
+        );
+        assert!(
+            b.dimensions.x >= a.dimensions.x + a.dimensions.width - 1.0,
+            "child B should be placed after child A in the row: a_right={}, b.x={}",
+            a.dimensions.x + a.dimensions.width,
+            b.dimensions.x
+        );
+    }
+
+    /// Google header cluster: a `.gb_Xd` flex container (display:flex, align-items:center)
+    /// must lay out its children (Gmail link and image link) side by side on a single row.
+    #[test]
+    fn test_flex_google_header_cluster_gmail_and_images_on_same_row() {
+        let html = r#"<div style="display:flex;align-items:center;height:48px;">
+            <a id="gmail" href="https://mail.google.com">Gmail</a>
+            <a id="images" href="/imghp">Images</a>
+        </div>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+
+        let gmail = find_element_by_id(&layout, "gmail").expect("Gmail link");
+        let images = find_element_by_id(&layout, "images").expect("Images link");
+
+        // Both links must be on the same horizontal row (same y ± 2px).
+        assert!(
+            (gmail.dimensions.y - images.dimensions.y).abs() < 2.0,
+            "Gmail and Images must be on the same row: gmail.y={}, images.y={}",
+            gmail.dimensions.y, images.dimensions.y
+        );
+        // Images link must be to the right of Gmail.
+        assert!(
+            images.dimensions.x > gmail.dimensions.x,
+            "Images must be to the right of Gmail: gmail.x={}, images.x={}",
+            gmail.dimensions.x, images.dimensions.x
         );
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1124,6 +1124,29 @@ mod tests {
         let c = get_color(p, "color").expect("color not found");
         assert_eq!(c, Color { r: 0, g: 128, b: 0, a: 255 });
     }
+
+    #[test]
+    fn test_inline_flex_shorthand_expands_to_longhands() {
+        let mut decls = Vec::new();
+        parse_inline_style_into_vec("flex: 1;", &mut decls);
+
+        let grow = decls
+            .iter()
+            .find(|d| d.name.as_ref() == "flex-grow")
+            .map(|d| d.value.clone());
+        let shrink = decls
+            .iter()
+            .find(|d| d.name.as_ref() == "flex-shrink")
+            .map(|d| d.value.clone());
+        let basis = decls
+            .iter()
+            .find(|d| d.name.as_ref() == "flex-basis")
+            .map(|d| d.value.clone());
+
+        assert_eq!(grow, Some(Value::Number(1.0)));
+        assert_eq!(shrink, Some(Value::Number(1.0)));
+        assert_eq!(basis, Some(Value::Length(0.0, crate::css::Unit::Percent)));
+    }
 }
 
 pub fn parse_inline_style_into_vec(style_str: &str, list: &mut Vec<crate::css::Declaration>) {
@@ -1175,6 +1198,69 @@ pub fn parse_inline_style_into_vec(style_str: &str, list: &mut Vec<crate::css::D
                 list.push(crate::css::Declaration { name: intern("right"),  value: parse_value(right),  important });
                 list.push(crate::css::Declaration { name: intern("bottom"), value: parse_value(bottom), important });
                 list.push(crate::css::Declaration { name: intern("left"),   value: parse_value(left),   important });
+            }
+            "flex" => {
+                let parts: Vec<&str> = val.split_whitespace().collect();
+                match parts.len() {
+                    0 => {}
+                    1 => match parts[0] {
+                        "none" => {
+                            list.push(crate::css::Declaration { name: intern("flex-grow"), value: crate::css::Value::Number(0.0), important });
+                            list.push(crate::css::Declaration { name: intern("flex-shrink"), value: crate::css::Value::Number(0.0), important });
+                            list.push(crate::css::Declaration { name: intern("flex-basis"), value: crate::css::Value::Keyword(intern("auto")), important });
+                        }
+                        "auto" => {
+                            list.push(crate::css::Declaration { name: intern("flex-grow"), value: crate::css::Value::Number(1.0), important });
+                            list.push(crate::css::Declaration { name: intern("flex-shrink"), value: crate::css::Value::Number(1.0), important });
+                            list.push(crate::css::Declaration { name: intern("flex-basis"), value: crate::css::Value::Keyword(intern("auto")), important });
+                        }
+                        _ => {
+                            if let Ok(n) = parts[0].parse::<f32>() {
+                                list.push(crate::css::Declaration { name: intern("flex-grow"), value: crate::css::Value::Number(n), important });
+                                list.push(crate::css::Declaration { name: intern("flex-shrink"), value: crate::css::Value::Number(1.0), important });
+                                list.push(crate::css::Declaration { name: intern("flex-basis"), value: crate::css::Value::Length(0.0, crate::css::Unit::Percent), important });
+                            }
+                        }
+                    },
+                    2 => {
+                        if let (Ok(g), Ok(s)) = (parts[0].parse::<f32>(), parts[1].parse::<f32>()) {
+                            list.push(crate::css::Declaration { name: intern("flex-grow"), value: crate::css::Value::Number(g), important });
+                            list.push(crate::css::Declaration { name: intern("flex-shrink"), value: crate::css::Value::Number(s), important });
+                        } else if let Ok(g) = parts[0].parse::<f32>() {
+                            list.push(crate::css::Declaration { name: intern("flex-grow"), value: crate::css::Value::Number(g), important });
+                            list.push(crate::css::Declaration { name: intern("flex-shrink"), value: crate::css::Value::Number(1.0), important });
+                            list.push(crate::css::Declaration {
+                                name: intern("flex-basis"),
+                                value: crate::css::parse_value(parts[1]),
+                                important,
+                            });
+                        }
+                    }
+                    _ => {
+                        if let (Ok(g), Ok(s)) = (parts[0].parse::<f32>(), parts[1].parse::<f32>()) {
+                            list.push(crate::css::Declaration { name: intern("flex-grow"), value: crate::css::Value::Number(g), important });
+                            list.push(crate::css::Declaration { name: intern("flex-shrink"), value: crate::css::Value::Number(s), important });
+                            list.push(crate::css::Declaration {
+                                name: intern("flex-basis"),
+                                value: crate::css::parse_value(parts[2]),
+                                important,
+                            });
+                        }
+                    }
+                }
+            }
+            "gap" => {
+                let parts: Vec<&str> = val.split_whitespace().collect();
+                let row_val = parts
+                    .first()
+                    .map(|s| crate::css::parse_value(s))
+                    .unwrap_or(crate::css::Value::Number(0.0));
+                let col_val = parts
+                    .get(1)
+                    .map(|s| crate::css::parse_value(s))
+                    .unwrap_or_else(|| row_val.clone());
+                list.push(crate::css::Declaration { name: intern("row-gap"), value: row_val, important });
+                list.push(crate::css::Declaration { name: intern("column-gap"), value: col_val, important });
             }
             _ => {
                 // CSS custom properties (--foo) in inline styles keep their raw string value.


### PR DESCRIPTION
## Summary
- implement basic flex row layout behavior for issue #142
- expand flex shorthand in both stylesheet and inline style parsing
- honor row flex-basis during initial item sizing and add focused regressions

## Testing
- cargo test -q test_inline_flex_shorthand_expands_to_longhands -- --nocapture
- cargo test -q test_flex_ -- --nocapture
- cargo build --bins
- headless browser review against https://yunseong.dev and https://google.com

Closes #142