### PR TITLE
fix: border-radius on form controls and CSS transform percent

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -118,11 +118,32 @@ impl Hash for Value {
     }
 }
 
+/// A length value for CSS transform translate functions: either px or percent.
+///
+/// Percentages are relative to the element's own width (for translateX) or
+/// height (for translateY) at paint time, so they must be stored unevaluated
+/// and resolved when the element dimensions are known.
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+pub enum TranslateLength {
+    Px(OrderedFloat),
+    Percent(OrderedFloat),
+}
+
+impl TranslateLength {
+    /// Resolve the length against `element_size` (width for X, height for Y).
+    pub fn resolve(&self, element_size: f32) -> f32 {
+        match self {
+            TranslateLength::Px(v) => v.0,
+            TranslateLength::Percent(v) => v.0 / 100.0 * element_size,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
 pub enum TransformOp {
-    Translate(OrderedFloat, OrderedFloat), // px
-    Scale(OrderedFloat, OrderedFloat),     // factor
-    Rotate(OrderedFloat),                  // radians
+    Translate(TranslateLength, TranslateLength),
+    Scale(OrderedFloat, OrderedFloat),
+    Rotate(OrderedFloat),
     Matrix(OrderedFloat, OrderedFloat, OrderedFloat, OrderedFloat, OrderedFloat, OrderedFloat),
 }
 
@@ -281,6 +302,17 @@ pub fn parse_css(source: &str) -> Stylesheet {
                     for (k, v) in temp_map {
                         declarations.push(Declaration { name: intern(&k), value: v, important });
                     }
+                }
+                // border-radius shorthand: "border-radius: <tl> [<tr> [<br> [<bl>]]]"
+                // CSS allows up to 4 corner values.  We use the top-left (first) value as a
+                // uniform radius for all corners — sufficient for the rounded-input / button
+                // use-case (Google search bar, etc.).  The "/" elliptical syntax is not supported.
+                "border-radius" => {
+                    let first = val_raw.split_whitespace().next().unwrap_or("0");
+                    // Strip the "/" elliptical part if present (e.g. "8px / 4px")
+                    let first = first.split('/').next().unwrap_or("0").trim();
+                    let value = parse_value(first);
+                    declarations.push(Declaration { name: key, value, important });
                 }
                 "padding" => {
                     let mut temp_map = HashMap::new();
@@ -1361,6 +1393,60 @@ mod tests {
             other => panic!("expected linear gradient, got {:?}", other),
         }
     }
+
+    #[test]
+    fn test_translate_y_percent_parses_correctly() {
+        let v = parse_value("translateY(-50%)");
+        match v {
+            Value::Transform(ops) => {
+                assert_eq!(ops.len(), 1);
+                match &ops[0] {
+                    TransformOp::Translate(x, y) => {
+                        assert_eq!(*x, TranslateLength::Px(OrderedFloat(0.0)));
+                        assert_eq!(*y, TranslateLength::Percent(OrderedFloat(-50.0)));
+                    }
+                    other => panic!("expected Translate, got {:?}", other),
+                }
+            }
+            other => panic!("expected Transform, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_xy_px_parses_correctly() {
+        let v = parse_value("translate(10px, 20px)");
+        match v {
+            Value::Transform(ops) => {
+                assert_eq!(ops.len(), 1);
+                match &ops[0] {
+                    TransformOp::Translate(x, y) => {
+                        assert_eq!(*x, TranslateLength::Px(OrderedFloat(10.0)));
+                        assert_eq!(*y, TranslateLength::Px(OrderedFloat(20.0)));
+                    }
+                    other => panic!("expected Translate, got {:?}", other),
+                }
+            }
+            other => panic!("expected Transform, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_x_percent_parses_correctly() {
+        let v = parse_value("translateX(50%)");
+        match v {
+            Value::Transform(ops) => {
+                assert_eq!(ops.len(), 1);
+                match &ops[0] {
+                    TransformOp::Translate(x, y) => {
+                        assert_eq!(*x, TranslateLength::Percent(OrderedFloat(50.0)));
+                        assert_eq!(*y, TranslateLength::Px(OrderedFloat(0.0)));
+                    }
+                    other => panic!("expected Translate, got {:?}", other),
+                }
+            }
+            other => panic!("expected Transform, got {:?}", other),
+        }
+    }
 }
 
 fn parse_transform_list(val: &str) -> Vec<TransformOp> {
@@ -1369,17 +1455,25 @@ fn parse_transform_list(val: &str) -> Vec<TransformOp> {
     for part in parts {
         let part = part.trim();
         if part.is_empty() { continue; }
-        
+
         if let Some(open) = part.find('(') {
             let name = &part[..open].to_lowercase();
             let args_str = &part[open + 1..part.len() - 1];
             let args: Vec<&str> = args_str.split(',').map(|s| s.trim()).collect();
-            
+
             match name.as_str() {
                 "translate" => {
-                    let x = parse_px_or_zero(args.get(0).copied().unwrap_or("0"));
-                    let y = parse_px_or_zero(args.get(1).copied().unwrap_or("0"));
-                    ops.push(TransformOp::Translate(OrderedFloat(x), OrderedFloat(y)));
+                    let x = parse_translate_length(args.get(0).copied().unwrap_or("0"));
+                    let y = parse_translate_length(args.get(1).copied().unwrap_or("0"));
+                    ops.push(TransformOp::Translate(x, y));
+                }
+                "translatex" => {
+                    let x = parse_translate_length(args.get(0).copied().unwrap_or("0"));
+                    ops.push(TransformOp::Translate(x, TranslateLength::Px(OrderedFloat(0.0))));
+                }
+                "translatey" => {
+                    let y = parse_translate_length(args.get(0).copied().unwrap_or("0"));
+                    ops.push(TransformOp::Translate(TranslateLength::Px(OrderedFloat(0.0)), y));
                 }
                 "scale" => {
                     let x = args.get(0).and_then(|s| s.parse::<f32>().ok()).unwrap_or(1.0);
@@ -1417,6 +1511,17 @@ fn parse_transform_list(val: &str) -> Vec<TransformOp> {
     ops
 }
 
-fn parse_px_or_zero(s: &str) -> f32 {
-    s.trim_end_matches("px").parse::<f32>().unwrap_or(0.0)
+fn parse_translate_length(s: &str) -> TranslateLength {
+    let s = s.trim();
+    if s.ends_with('%') {
+        let v = s.trim_end_matches('%').parse::<f32>().unwrap_or(0.0);
+        TranslateLength::Percent(OrderedFloat(v))
+    } else {
+        let v = s.trim_end_matches("px")
+                  .trim_end_matches("rem")
+                  .trim_end_matches("em")
+                  .parse::<f32>()
+                  .unwrap_or(0.0);
+        TranslateLength::Px(OrderedFloat(v))
+    }
 }

--- a/src/layer_tree.rs
+++ b/src/layer_tree.rs
@@ -433,7 +433,9 @@ impl LayerTreeBuilder {
         }
 
         if let Some(Value::Transform(ops)) = sv.get(&crate::css::intern("transform")) {
-            matrix = Self::compute_transform_matrix(ops);
+            let w = layout.dimensions.width;
+            let h = layout.dimensions.height;
+            matrix = Self::compute_transform_matrix(ops, w, h);
             triggers.push(CompositingTrigger::Transform(matrix));
         }
 
@@ -452,11 +454,13 @@ impl LayerTreeBuilder {
         (triggers, matrix)
     }
 
-    fn compute_transform_matrix(ops: &[TransformOp]) -> Matrix4x4 {
+    fn compute_transform_matrix(ops: &[TransformOp], elem_width: f32, elem_height: f32) -> Matrix4x4 {
         let mut result = Matrix4x4::identity();
         for op in ops {
             let m = match op {
-                TransformOp::Translate(x, y) => Matrix4x4::translate(x.0, y.0, 0.0),
+                TransformOp::Translate(x, y) => {
+                    Matrix4x4::translate(x.resolve(elem_width), y.resolve(elem_height), 0.0)
+                }
                 TransformOp::Scale(x, y) => Matrix4x4::from_2d(Matrix3x3::scale(x.0, y.0)),
                 TransformOp::Rotate(rad) => Matrix4x4::from_2d(Matrix3x3::rotate(rad.0)),
                 TransformOp::Matrix(a, b, c, d, e, f) => Matrix4x4::from_2d(Matrix3x3([a.0, c.0, e.0, b.0, d.0, f.0, 0.0, 0.0, 1.0])),
@@ -804,6 +808,69 @@ mod tests {
     }
 
     #[test]
+    fn test_transform_translate_y_percent_resolves_against_element_height() {
+        // translateY(-50%) on a 100px-tall element should produce ty = -50px in the matrix.
+        let tree = build_tree_from_html(
+            r#"<div style="width:200px; height:100px; transform:translateY(-50%);">Content</div>"#,
+            "",
+        );
+        assert!(tree.layers.len() >= 2, "element with transform should create a new layer");
+        let t_layer = tree.layers.iter().find(|l| l.id != 0).expect("child layer");
+        // Matrix row-major: translation is at indices [3] (tx) and [7] (ty).
+        // translateY(-50%) on height=100 should resolve to ty = -50.
+        let ty = t_layer.transform.0[7];
+        assert!((ty - (-50.0)).abs() < 1.0,
+            "translateY(-50%) on height:100px should produce ty=-50, got {}", ty);
+    }
+
+    #[test]
+    fn test_transform_translate_x_percent_resolves_against_element_width() {
+        // translateX(50%) on a 200px-wide element should produce tx = 100px in the matrix.
+        let tree = build_tree_from_html(
+            r#"<div style="width:200px; height:100px; transform:translateX(50%);">Content</div>"#,
+            "",
+        );
+        assert!(tree.layers.len() >= 2, "element with transform should create a new layer");
+        let t_layer = tree.layers.iter().find(|l| l.id != 0).expect("child layer");
+        let tx = t_layer.transform.0[3];
+        assert!((tx - 100.0).abs() < 1.0,
+            "translateX(50%) on width:200px should produce tx=100, got {}", tx);
+    }
+
+    #[test]
+    fn test_transform_translate_px_both_axes() {
+        // translate(10px, 20px) should produce tx=10, ty=20 in the matrix.
+        let tree = build_tree_from_html(
+            r#"<div style="width:100px; height:50px; transform:translate(10px, 20px);">Content</div>"#,
+            "",
+        );
+        assert!(tree.layers.len() >= 2, "element with transform should create a new layer");
+        let t_layer = tree.layers.iter().find(|l| l.id != 0).expect("child layer");
+        let tx = t_layer.transform.0[3];
+        let ty = t_layer.transform.0[7];
+        assert!((tx - 10.0).abs() < 0.5,
+            "translate(10px, 20px) should produce tx=10, got {}", tx);
+        assert!((ty - 20.0).abs() < 0.5,
+            "translate(10px, 20px) should produce ty=20, got {}", ty);
+    }
+
+    #[test]
+    fn test_transform_scale_creates_matrix() {
+        // scale(1.5) should produce a scale matrix with sx=sy=1.5.
+        let tree = build_tree_from_html(
+            r#"<div style="width:100px; height:50px; transform:scale(1.5);">Content</div>"#,
+            "",
+        );
+        assert!(tree.layers.len() >= 2, "element with transform should create a new layer");
+        let t_layer = tree.layers.iter().find(|l| l.id != 0).expect("child layer");
+        // For a scale matrix, indices [0] and [5] hold sx and sy respectively.
+        let sx = t_layer.transform.0[0];
+        let sy = t_layer.transform.0[5];
+        assert!((sx - 1.5).abs() < 0.01, "scale(1.5) should produce sx=1.5, got {}", sx);
+        assert!((sy - 1.5).abs() < 0.01, "scale(1.5) should produce sy=1.5, got {}", sy);
+    }
+
+    #[test]
     fn test_image_paint_command_carries_object_fit_and_alt() {
         let tree = build_tree_from_html(
             r#"<img src="x.png" alt="test" style="width:100px;height:100px;object-fit:cover;">"#,
@@ -1038,5 +1105,83 @@ mod tests {
             .flat_map(|l| l.content_commands.iter().chain(l.background_commands.iter()))
             .any(|cmd| matches!(cmd, PaintCommand::Text { text, .. } if text == "user input"));
         assert!(!found, "input[type=text] must not emit a Text paint command for value");
+    }
+
+    /// `<input style="border-radius: 24px">` must emit a Rect command with radius > 0.
+    #[test]
+    fn test_input_border_radius_emits_rounded_rect() {
+        let tree = build_tree_from_html(
+            r#"<input type="text" style="border-radius: 24px; width: 200px; height: 40px;">"#,
+            "",
+        );
+        let has_rounded = tree.layers.iter()
+            .flat_map(|l| l.background_commands.iter().chain(l.content_commands.iter()))
+            .any(|cmd| matches!(cmd, PaintCommand::Rect(_, _, r) if *r > 0.0));
+        assert!(has_rounded, "input with border-radius:24px must emit Rect with radius > 0");
+    }
+
+    /// `<input style="border-radius: 0">` must NOT emit a rounded Rect.
+    #[test]
+    fn test_input_no_border_radius_emits_flat_rect() {
+        let tree = build_tree_from_html(
+            r#"<input type="text" style="border-radius: 0px; width: 200px; height: 40px;">"#,
+            "",
+        );
+        let has_rounded = tree.layers.iter()
+            .flat_map(|l| l.background_commands.iter().chain(l.content_commands.iter()))
+            .any(|cmd| matches!(cmd, PaintCommand::Rect(_, _, r) if *r > 0.0));
+        assert!(!has_rounded, "input with border-radius:0 must not emit Rect with radius > 0");
+    }
+
+    /// `<button style="border-radius: 8px">` must emit a Rect command with radius > 0.
+    #[test]
+    fn test_button_border_radius_emits_rounded_rect() {
+        let tree = build_tree_from_html(
+            r#"<button style="border-radius: 8px; width: 100px; height: 36px;">Click</button>"#,
+            "",
+        );
+        let has_rounded = tree.layers.iter()
+            .flat_map(|l| l.background_commands.iter().chain(l.content_commands.iter()))
+            .any(|cmd| matches!(cmd, PaintCommand::Rect(_, _, r) if *r > 0.0));
+        assert!(has_rounded, "button with border-radius:8px must emit Rect with radius > 0");
+    }
+
+    /// `border-radius` applied via an external stylesheet (not inline) must also round the input.
+    #[test]
+    fn test_input_border_radius_from_stylesheet() {
+        let tree = build_tree_from_html(
+            r#"<input type="text" style="width: 200px; height: 40px;">"#,
+            "input { border-radius: 24px; }",
+        );
+        let has_rounded = tree.layers.iter()
+            .flat_map(|l| l.background_commands.iter().chain(l.content_commands.iter()))
+            .any(|cmd| matches!(cmd, PaintCommand::Rect(_, _, r) if *r > 0.0));
+        assert!(has_rounded, "input with stylesheet border-radius:24px must emit Rect with radius > 0");
+    }
+
+    /// `border-radius` applied via attribute selector `input[name=q]` must round the input.
+    #[test]
+    fn test_input_border_radius_from_attr_selector() {
+        let tree = build_tree_from_html(
+            r#"<input type="text" name="q" style="width: 200px; height: 40px;">"#,
+            r#"input[name="q"] { border-radius: 24px; }"#,
+        );
+        let has_rounded = tree.layers.iter()
+            .flat_map(|l| l.background_commands.iter().chain(l.content_commands.iter()))
+            .any(|cmd| matches!(cmd, PaintCommand::Rect(_, _, r) if *r > 0.0));
+        assert!(has_rounded, "input matched by attr selector with border-radius:24px must emit Rect with radius > 0");
+    }
+
+    /// `border-radius: 24px 24px 24px 24px` (four values) must still produce a rounded rect.
+    #[test]
+    fn test_input_border_radius_multi_value() {
+        let tree = build_tree_from_html(
+            r#"<input type="text" style="border-radius: 24px 24px 24px 24px; width: 200px; height: 40px;">"#,
+            "",
+        );
+        let has_rounded = tree.layers.iter()
+            .flat_map(|l| l.background_commands.iter().chain(l.content_commands.iter()))
+            .any(|cmd| matches!(cmd, PaintCommand::Rect(_, _, r) if *r > 0.0));
+        assert!(has_rounded, "input with border-radius:24px 24px 24px 24px must emit Rect with radius > 0");
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1262,6 +1262,16 @@ pub fn parse_inline_style_into_vec(style_str: &str, list: &mut Vec<crate::css::D
                 list.push(crate::css::Declaration { name: intern("row-gap"), value: row_val, important });
                 list.push(crate::css::Declaration { name: intern("column-gap"), value: col_val, important });
             }
+            // border-radius shorthand: "border-radius: <tl> [<tr> [<br> [<bl>]]]"
+            // Use the first (top-left) value as a uniform radius.  The "/" elliptical syntax
+            // is not supported; we take the text before any "/" as the horizontal radii list
+            // and use the first token from that.
+            "border-radius" => {
+                let first = val.split_whitespace().next().unwrap_or("0");
+                let first = first.split('/').next().unwrap_or("0").trim();
+                let value = crate::css::parse_value(first);
+                list.push(crate::css::Declaration { name: key, value, important });
+            }
             _ => {
                 // CSS custom properties (--foo) in inline styles keep their raw string value.
                 let value = if key.starts_with("--") {


### PR DESCRIPTION
## Summary
- Fix `border-radius` being silently dropped on `<input>` and `<button>` elements when the value has multiple space-separated tokens (e.g. `border-radius: 24px 24px 24px 24px`). Previously, multi-value border-radius fell through to `Value::Keyword` instead of `Value::Length`, so `collect_paint_commands` always read `0.0` and rendered flat rectangles.
- Fix applies to both external stylesheet rules (`css.rs` parser) and inline `style` attributes (`style.rs` `parse_inline_style_into_vec`). Both paths now extract the first token (top-left corner) as a uniform radius.
- Also add `TranslateLength` enum to support `translateX(50%)`/`translateY(-50%)` CSS transform values that resolve percentages against the element's own dimensions (issue #144).

## Test plan
- [x] `<input style="border-radius: 24px">` emits `Rect` with `radius > 0`
- [x] `<input style="border-radius: 0px">` emits `Rect` with `radius == 0` (no regression)
- [x] `<input style="border-radius: 24px 24px 24px 24px">` (multi-value) emits rounded rect
- [x] `<input>` with `border-radius` from external stylesheet emits rounded rect
- [x] `<input>` matched by attribute selector `input[name="q"]` with stylesheet border-radius emits rounded rect
- [x] `<button style="border-radius: 8px">` emits rounded rect
- [x] All 224 unit tests pass (`cargo test --lib`)
- [x] `browser-cli navigate https://yunseong.dev` renders correctly
- [x] `browser-cli navigate https://google.com` renders correctly

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)