### PR TITLE
feat: support @media (prefers-color-scheme: dark)

### DIFF
--- a/.agents/PRIORITY.md
+++ b/.agents/PRIORITY.md
@@ -128,6 +128,7 @@ Stabilizes same-page rendering so hover/focus/image-triggered updates do not rel
 | #145 | ~~[CSS] border-radius on form controls~~ ✓ | Fixed CSS parser — shorthand was parsed as keyword. |
 | #144 | ~~[CSS] CSS transform property support~~ ✓ | Already in #153; PR closed issue + fixed flaky render test. |
 | #150 | ~~[CSS] @media query parsing and evaluation~~ ✓ | Responsive CSS activation. yunseong.dev dark navbar/hero needs this. |
+| #156 | ~~[CSS] @media (prefers-color-scheme: dark) support~~ ✓ | Headless renderer defaults to dark; dark-scheme rules now activate. |
 | #151 | [Render] box-shadow support | Card depth/elevation. yunseong.dev content card flat without it. |
 | #152 | [Layout] list-style-type and list indentation | Bullet markers missing on yunseong.dev project lists. |
 

--- a/src/css.rs
+++ b/src/css.rs
@@ -494,6 +494,10 @@ fn media_query_matches(query: &str) -> bool {
         if let Ok(max) = val_str.parse::<f32>() {
             return VIEWPORT_WIDTH_PX <= max;
         }
+    } else if let Some(rest) = q.strip_prefix("prefers-color-scheme:") {
+        // Headless renderer defaults to dark preference.
+        let scheme = rest.trim();
+        return scheme == "dark";
     }
     false
 }
@@ -1438,6 +1442,32 @@ mod tests {
         let ss = parse_css("@media screen and (min-width: 600px) { p { color: green; } }");
         let rules = ss.all_rules();
         assert!(!rules.is_empty(), "@media screen and (min-width: 600px) should apply at 800px");
+    }
+
+    #[test]
+    fn test_media_prefers_color_scheme_dark_activates() {
+        // @media (prefers-color-scheme: dark) must activate (headless renderer is dark).
+        let ss = parse_css("@media (prefers-color-scheme: dark) { body { background: black; } }");
+        let rules = ss.all_rules();
+        assert!(
+            !rules.is_empty(),
+            "@media (prefers-color-scheme: dark) should be included"
+        );
+        assert!(rules.iter().any(|r| r.declarations.iter().any(|d| {
+            d.name.as_ref() == "background"
+        })));
+    }
+
+    #[test]
+    fn test_media_prefers_color_scheme_light_does_not_activate() {
+        // @media (prefers-color-scheme: light) must NOT activate.
+        let ss = parse_css("@media (prefers-color-scheme: light) { body { background: white; } }");
+        let rules = ss.all_rules();
+        assert!(
+            rules.is_empty(),
+            "@media (prefers-color-scheme: light) should be excluded, got {} rules",
+            rules.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Extend `media_query_matches()` in `src/css.rs` to recognize `prefers-color-scheme: dark` (returns true) and `prefers-color-scheme: light` (returns false)
- Headless renderer preference is hardcoded as dark per the issue spec
- Width-based media queries (`min-width`, `max-width`) continue to work unchanged

## Test plan
- [x] `@media (prefers-color-scheme: dark)` rules activate (new test `test_media_prefers_color_scheme_dark_activates`)
- [x] `@media (prefers-color-scheme: light)` rules do not activate (new test `test_media_prefers_color_scheme_light_does_not_activate`)
- [x] All 231 existing unit tests pass (`cargo test --lib`)
- [x] CLI review: `https://yunseong.dev` and `https://google.com` both render correctly
- [x] Screenshot taken and visually inspected — page renders without errors

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)