### PR TITLE
feat: list-style-type and list indentation (#152)

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -434,6 +434,20 @@ pub fn parse_css(source: &str) -> Stylesheet {
                     declarations.push(Declaration { name: intern("row-gap"),    value: row_val,  important });
                     declarations.push(Declaration { name: intern("column-gap"), value: col_val,  important });
                 }
+                // list-style shorthand: "list-style: none | disc | decimal | ..."
+                // We only care about list-style-type for now.
+                "list-style" => {
+                    let first = val_raw.split_whitespace().next().unwrap_or("disc");
+                    // Common values: none, disc, circle, square, decimal, etc.
+                    let type_val = match first {
+                        "none" | "disc" | "circle" | "square" | "decimal"
+                        | "lower-alpha" | "upper-alpha" | "lower-roman" | "upper-roman" => {
+                            Value::Keyword(intern(first))
+                        }
+                        _ => parse_value(first),
+                    };
+                    declarations.push(Declaration { name: intern("list-style-type"), value: type_val, important });
+                }
                 // inset shorthand: "inset: <top> [<right> [<bottom> [<left>]]]"
                 // Same quad syntax as margin/padding, maps to top/right/bottom/left.
                 "inset" => {

--- a/src/layer_tree.rs
+++ b/src/layer_tree.rs
@@ -605,6 +605,40 @@ impl LayerTreeBuilder {
             });
         }
 
+        // List item marker (• / ◦ / ▪ / "1." etc.)
+        // Painted to the left of the list item's content box, inside the padding-left area.
+        if layout.display == DisplayType::ListItem {
+            if let Some(ref marker) = layout.list_marker {
+                let font_size = match sv.get(&crate::css::intern("font-size")) {
+                    Some(Value::Length(v, _)) => *v,
+                    _ => 16.0,
+                };
+                let color = match sv.get(&crate::css::intern("color")) {
+                    Some(Value::Color(c)) => c.clone(),
+                    _ => crate::css::Color { r: 0, g: 0, b: 0, a: 255 },
+                };
+                // Place marker ~20px to the left of the content box left edge.
+                // The padding-left (~40px) leaves enough room for the marker.
+                let marker_x = (d.x - 20.0).max(0.0);
+                let marker_rect = crate::layout::Rect {
+                    x: marker_x,
+                    y: d.y,
+                    width: 20.0,
+                    height: font_size,
+                };
+                commands.push(PaintCommand::Text {
+                    rect: marker_rect,
+                    text: marker.clone(),
+                    font_size,
+                    color,
+                    clip,
+                    bold: false,
+                    italic: false,
+                    text_decoration: 0,
+                });
+            }
+        }
+
         // Input button label
         // <input type="submit|button|reset"> carries its visible label in the
         // `input_label` field (populated in LayoutBox::new from the `value` attribute).

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -506,6 +506,9 @@ pub struct LayoutBox<'a> {
     pub display: DisplayType,
     pub z_index: i32,
     pub position: PositionType,
+    /// Marker text for list items (e.g. "•" for disc, "1." for decimal).
+    /// `None` when `list-style-type: none` or the element is not a list item.
+    pub list_marker: Option<String>,
 }
 
 impl<'a> Clone for LayoutBox<'a> {
@@ -555,6 +558,7 @@ impl<'a> Clone for LayoutBox<'a> {
                         display: src.display,
                         z_index: src.z_index,
                         position: src.position,
+                        list_marker: src.list_marker.clone(),
                     };
                     let num_children = src.children.len();
                     // Push Post first so it is processed after all children.
@@ -741,6 +745,7 @@ impl<'a> LayoutBox<'a> {
             display,
             z_index,
             position,
+            list_marker: None,
         };
 
         if let NodeData::Element {
@@ -1823,7 +1828,7 @@ impl<'a> LayoutBox<'a> {
         let no_wrap = white_space == "nowrap";
         let applies_text_align = matches!(
             self.display,
-            DisplayType::Block | DisplayType::Flex | DisplayType::InlineBlock | DisplayType::TableCell
+            DisplayType::Block | DisplayType::ListItem | DisplayType::Flex | DisplayType::InlineBlock | DisplayType::TableCell
         );
 
         // Inline line accumulator
@@ -1875,6 +1880,10 @@ impl<'a> LayoutBox<'a> {
         }
 
         let mut positioned_entries: Vec<&StyledNode> = Vec::new();
+
+        // Counter for ordered list item markers (1., 2., …).
+        // Only incremented when a ListItem child is placed in normal flow.
+        let mut list_item_counter: u32 = 0;
 
         for entry in entries {
             match entry.kind {
@@ -1959,6 +1968,25 @@ impl<'a> LayoutBox<'a> {
                         intrinsic_cache,
                     );
                     if let Some(mut cb) = cb_opt {
+                        // Assign list marker for ListItem boxes.
+                        if cb.display == DisplayType::ListItem {
+                            list_item_counter += 1;
+                            let style_type = cb
+                                .style_node
+                                .specified_values
+                                .get(&crate::css::intern("list-style-type"))
+                                .and_then(|v| {
+                                    if let Value::Keyword(k) = v { Some(k.as_ref()) } else { None }
+                                })
+                                .unwrap_or("disc");
+                            cb.list_marker = match style_type {
+                                "none" => None,
+                                "decimal" => Some(format!("{}.", list_item_counter)),
+                                "circle" => Some("\u{25E6}".to_string()),  // ◦
+                                "square" => Some("\u{25AA}".to_string()),  // ▪
+                                _ => Some("\u{2022}".to_string()),         // • (disc)
+                            };
+                        }
                         // CSS margin collapsing (spec § 8.3.1):
                         //
                         // Case 1 — adjacent siblings: the bottom margin of the previous
@@ -2565,11 +2593,13 @@ fn get_display_type(sn: &StyledNode) -> DisplayType {
         match name.local.to_string().as_str() {
             // Genuine block-level elements (fill container width, force line break)
             "html" | "div" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "body" | "header"
-            | "footer" | "nav" | "section" | "article" | "ul" | "ol" | "li" | "main" | "aside"
+            | "footer" | "nav" | "section" | "article" | "ul" | "ol" | "main" | "aside"
             | "form" | "details" | "summary" | "figure" | "figcaption" | "address"
             | "blockquote" | "pre" | "hr" | "fieldset" | "legend"
             // <center> is a legacy block element with implicit text-align:center
             | "center" => DisplayType::Block,
+            // List items get their own display type so markers can be painted
+            "li" => DisplayType::ListItem,
             // table and its sub-elements: use TableRow/TableCell so they shrink-wrap
             // rather than expand to full container width like block elements do.
             "table" => DisplayType::Table,
@@ -5123,6 +5153,83 @@ mod tests {
             "child B should be placed after child A in the row: a_right={}, b.x={}",
             a.dimensions.x + a.dimensions.width,
             b.dimensions.x
+        );
+    }
+
+    // ── List marker tests ─────────────────────────────────────────────────────
+
+    /// `<ul><li>` elements must have a disc marker (•) and `DisplayType::ListItem`.
+    #[test]
+    fn test_ul_li_has_disc_marker() {
+        let html = r#"<ul><li id="a">Item A</li><li id="b">Item B</li></ul>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+
+        let item_a = find_element_by_id(&layout, "a").expect("li#a not found");
+        let item_b = find_element_by_id(&layout, "b").expect("li#b not found");
+
+        assert_eq!(item_a.display, DisplayType::ListItem, "li must be ListItem");
+        assert_eq!(
+            item_a.list_marker.as_deref(),
+            Some("\u{2022}"),
+            "ul li should have disc marker •"
+        );
+        assert_eq!(
+            item_b.list_marker.as_deref(),
+            Some("\u{2022}"),
+            "second ul li should also have disc marker"
+        );
+    }
+
+    /// `<ol><li>` elements must have decimal markers (1., 2., …).
+    #[test]
+    fn test_ol_li_has_decimal_marker() {
+        let html = r#"<ol><li id="a">First</li><li id="b">Second</li><li id="c">Third</li></ol>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+
+        let item_a = find_element_by_id(&layout, "a").expect("li#a not found");
+        let item_b = find_element_by_id(&layout, "b").expect("li#b not found");
+        let item_c = find_element_by_id(&layout, "c").expect("li#c not found");
+
+        assert_eq!(
+            item_a.list_marker.as_deref(),
+            Some("1."),
+            "first ol li should have marker 1."
+        );
+        assert_eq!(
+            item_b.list_marker.as_deref(),
+            Some("2."),
+            "second ol li should have marker 2."
+        );
+        assert_eq!(
+            item_c.list_marker.as_deref(),
+            Some("3."),
+            "third ol li should have marker 3."
+        );
+    }
+
+    /// `list-style-type: none` suppresses the marker.
+    #[test]
+    fn test_list_style_type_none_suppresses_marker() {
+        let html = r#"<ul style="list-style-type:none"><li id="x">No marker</li></ul>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+        let item = find_element_by_id(&layout, "x").expect("li#x not found");
+        assert!(
+            item.list_marker.is_none(),
+            "list-style-type:none should suppress marker, got {:?}",
+            item.list_marker
+        );
+    }
+
+    /// List items must have left padding so content is indented away from the marker.
+    #[test]
+    fn test_ul_has_default_left_padding() {
+        let html = r#"<ul id="list"><li>Item</li></ul>"#;
+        let (layout, _, _) = layout_from_html(html, 800.0, 600.0);
+        let list = find_element_by_id(&layout, "list").expect("ul not found");
+        assert!(
+            list.padding.left >= 30.0,
+            "ul should have padding-left >= 30px for indentation, got {}",
+            list.padding.left
         );
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -851,8 +851,13 @@ fn apply_default_styles(tag: &str, map: &mut HashMap<Arc<str>, Value>) {
             map.entry(intern("display")).or_insert(Value::Keyword(intern("block")));
             map.entry(intern("text-align")).or_insert(Value::Keyword(intern("center")));
         }
-        "ul" | "ol" => {
-            map.entry(intern("padding-left")).or_insert(Value::Length(24.0, crate::css::Unit::Px));
+        "ul" => {
+            map.entry(intern("padding-left")).or_insert(Value::Length(40.0, crate::css::Unit::Px));
+            map.entry(intern("list-style-type")).or_insert(Value::Keyword(intern("disc")));
+        }
+        "ol" => {
+            map.entry(intern("padding-left")).or_insert(Value::Length(40.0, crate::css::Unit::Px));
+            map.entry(intern("list-style-type")).or_insert(Value::Keyword(intern("decimal")));
         }
         "p" => {
             map.entry(intern("margin-top")).or_insert(Value::Length(8.0, crate::css::Unit::Px));


### PR DESCRIPTION
## Summary

- Map `<li>` elements to `DisplayType::ListItem` so they participate in the list rendering pipeline
- Paint bullet/number markers to the left of each list item's content box
- Default UA stylesheet: `list-style-type: disc` for `<ul>`, `list-style-type: decimal` for `<ol>`
- `list-style-type: none` suppresses the marker; `circle` (◦) and `square` (▪) also supported
- Added `list-style` shorthand parser in `css.rs` (maps to `list-style-type`)
- `ul`/`ol` default `padding-left` set to 40px (from 24px) to give markers proper clearance
- Marker counter auto-increments for `decimal` ordered lists (1., 2., 3., …)
- `list_marker: Option<String>` field added to `LayoutBox` for use by the paint layer

## Files changed

- `src/style.rs` — UA defaults for ul/ol list-style-type
- `src/css.rs` — `list-style` shorthand expansion
- `src/layout.rs` — `DisplayType::ListItem` for `<li>`, `list_marker` field, counter tracking
- `src/layer_tree.rs` — emit `Text` paint command for marker to left of content

## Test plan

- [x] `cargo test --lib` — 233 tests pass (229 existing + 4 new)
- [x] `test_ul_li_has_disc_marker` — `<ul><li>` has • marker
- [x] `test_ol_li_has_decimal_marker` — `<ol><li>` has 1./2./3. markers
- [x] `test_list_style_type_none_suppresses_marker` — `list-style-type: none` works
- [x] `test_ul_has_default_left_padding` — ul has ≥ 30px padding-left
- [x] CLI review PASS: `https://yunseong.dev` — bullet markers visible in Projects & Experiences section
- [x] CLI review PASS: `https://google.com` — layout unchanged, no regressions

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)