### PR TITLE
feat: add layout-backed geometry APIs

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -20,6 +20,7 @@ pub struct PageResult {
     pub element_ids: Vec<(layout::Rect, String)>,
     pub focusable_elements: Vec<(layout::Rect, String)>,
     pub image_urls: Vec<String>,
+    pub layout_metrics: HashMap<String, js::LayoutMetrics>,
     pub body: String,
     pub base_url: Url,
     pub csp_policy: Option<js::CspPolicy>,
@@ -592,6 +593,7 @@ pub fn process_html_with_cache(
     let mut event_handlers = Vec::new();
     let mut element_ids = Vec::new();
     let mut focusable_elements = Vec::new();
+    let mut layout_metrics = HashMap::new();
     let image_urls: Vec<String>;
 
     render::render_layout_tree(&layout_tree, &mut pixmap, image_cache, &base_url);
@@ -600,6 +602,7 @@ pub fn process_html_with_cache(
     layout_tree.collect_event_handlers(&mut event_handlers);
     layout_tree.collect_element_ids(&mut element_ids);
     layout_tree.collect_focusable_elements(&mut focusable_elements);
+    collect_layout_metrics(&layout_tree, &mut layout_metrics);
 
     let mut controls_with_nodes = Vec::new();
     layout_tree.collect_form_controls(&mut controls_with_nodes);
@@ -657,12 +660,33 @@ pub fn process_html_with_cache(
             element_ids,
             focusable_elements,
             image_urls,
+            layout_metrics,
             body: body.to_string(),
             base_url: base_url.clone(),
             csp_policy,
         },
         stylesheet,
     ))
+}
+
+fn collect_layout_metrics(layout_tree: &layout::LayoutBox, out: &mut HashMap<String, js::LayoutMetrics>) {
+    let mut stack = vec![layout_tree];
+    while let Some(layout) = stack.pop() {
+        if matches!(layout.style_node.node.data, markup5ever_rcdom::NodeData::Element { .. }) {
+            out.insert(
+                js::node_path_key(&layout.style_node.node),
+                js::LayoutMetrics {
+                    x: layout.dimensions.x,
+                    y: layout.dimensions.y,
+                    width: layout.dimensions.width,
+                    height: layout.dimensions.height,
+                },
+            );
+        }
+        for child in layout.children.iter().rev() {
+            stack.push(child);
+        }
+    }
 }
 
 // ── BrowserEngine ─────────────────────────────────────────────────────────────
@@ -688,7 +712,7 @@ impl BrowserEngine {
             image_cache: HashMap::new(),
             css_cache: HashMap::new(),
             last_stylesheet: None,
-            js_runtime: js::JsRuntime::new(None, None, None, console_buffer.clone()),
+            js_runtime: js::JsRuntime::new(None, None, None, None, console_buffer.clone()),
             console_buffer,
             current_csp_policy: None,
             js_style_overrides: HashMap::new(),
@@ -718,7 +742,7 @@ impl BrowserEngine {
         self.last_stylesheet = Some(stylesheet);
         self.current_csp_policy = page.csp_policy.clone();
         self.last_page = Some(page.clone());
-        self.init_js_for_page(&page.body);
+        self.init_js_for_page(&page);
         self.refresh_after_image_loads(page, width)
     }
 
@@ -753,6 +777,7 @@ impl BrowserEngine {
         let (page, stylesheet) = result;
         self.last_stylesheet = Some(stylesheet);
         self.last_page = Some(page.clone());
+        self.js_runtime.set_layout_metrics(page.layout_metrics.clone());
         self.refresh_after_image_loads(page, width)
     }
 
@@ -944,13 +969,13 @@ impl BrowserEngine {
     /// Re-initialize the JS runtime for the current page.
     /// Parses the DOM from `body`, runs all page scripts (CSP-gated),
     /// and collects any immediate JS style overrides.
-    pub fn init_js_for_page(&mut self, body: &str) {
-        let base_url = self.last_page.as_ref().map(|p| p.base_url.clone());
-        let dom = dom::parse_html(body);
+    pub fn init_js_for_page(&mut self, page: &PageResult) {
+        let dom = dom::parse_html(&page.body);
         self.js_runtime = js::JsRuntime::new(
             Some(dom.document.clone()),
-            base_url,
+            Some(page.base_url.clone()),
             self.current_csp_policy.clone(),
+            Some(page.layout_metrics.clone()),
             self.console_buffer.clone(),
         );
 
@@ -981,7 +1006,7 @@ impl BrowserEngine {
     pub fn clear_for_new_url(&mut self) {
         self.js_style_overrides.clear();
         self.clear_console();
-        self.js_runtime = js::JsRuntime::new(None, None, None, self.console_buffer.clone());
+        self.js_runtime = js::JsRuntime::new(None, None, None, None, self.console_buffer.clone());
         self.current_csp_policy = None;
         self.last_stylesheet = None;
         self.last_page = None;

--- a/src/js.rs
+++ b/src/js.rs
@@ -56,6 +56,7 @@ thread_local! {
     static PREVIOUS_FOCUSED_NODE: RefCell<Option<String>> = RefCell::new(None);
     static CURRENT_ORIGIN: RefCell<Option<Url>> = RefCell::new(None);
     static CSP_POLICY: RefCell<Option<CspPolicy>> = RefCell::new(None);
+    static LAYOUT_METRICS: RefCell<HashMap<String, LayoutMetrics>> = RefCell::new(HashMap::new());
     static CONSOLE_BUFFER: RefCell<Option<ConsoleBuffer>> = const { RefCell::new(None) };
 }
 
@@ -89,6 +90,24 @@ pub type ConsoleBuffer = Arc<ConsoleState>;
 pub struct EvalOutcome {
     pub result: Option<String>,
     pub error: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct LayoutMetrics {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl LayoutMetrics {
+    pub fn right(&self) -> f32 {
+        self.x + self.width
+    }
+
+    pub fn bottom(&self) -> f32 {
+        self.y + self.height
+    }
 }
 
 fn now_timestamp_ms() -> u64 {
@@ -228,11 +247,13 @@ impl JsRuntime {
         dom: Option<Handle>,
         base_url: Option<Url>,
         policy: Option<CspPolicy>,
+        layout_metrics: Option<HashMap<String, LayoutMetrics>>,
         console_buffer: ConsoleBuffer,
     ) -> Self {
         DOM_ROOT.with(|root| *root.borrow_mut() = dom);
         CURRENT_ORIGIN.with(|origin| *origin.borrow_mut() = base_url);
         CSP_POLICY.with(|p| *p.borrow_mut() = policy);
+        LAYOUT_METRICS.with(|metrics| *metrics.borrow_mut() = layout_metrics.unwrap_or_default());
         CONSOLE_BUFFER.with(|cell| *cell.borrow_mut() = Some(console_buffer));
         let mut context = Context::default();
         let (task_sender, task_receiver) = channel();
@@ -998,6 +1019,36 @@ impl JsRuntime {
         });
         context.register_global_callable(js_string!("__aura_get_text_content"), 1, get_text_content).unwrap();
 
+        // __aura_get_layout_metrics(nid) -> metrics object or null
+        let get_layout_metrics = NativeFunction::from_copy_closure(|_this, args, context| {
+            let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
+            let metrics = NODE_REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                reg.get(&nid)
+                    .and_then(|node| {
+                        let key = node_path_key(node);
+                        LAYOUT_METRICS.with(|metrics| metrics.borrow().get(&key).cloned())
+                    })
+            });
+
+            if let Some(metrics) = metrics {
+                use boa_engine::object::ObjectInitializer;
+                let mut obj = ObjectInitializer::new(context);
+                obj.property(js_string!("x"), JsValue::from(metrics.x), boa_engine::property::Attribute::all());
+                obj.property(js_string!("y"), JsValue::from(metrics.y), boa_engine::property::Attribute::all());
+                obj.property(js_string!("width"), JsValue::from(metrics.width), boa_engine::property::Attribute::all());
+                obj.property(js_string!("height"), JsValue::from(metrics.height), boa_engine::property::Attribute::all());
+                obj.property(js_string!("top"), JsValue::from(metrics.y), boa_engine::property::Attribute::all());
+                obj.property(js_string!("left"), JsValue::from(metrics.x), boa_engine::property::Attribute::all());
+                obj.property(js_string!("right"), JsValue::from(metrics.right()), boa_engine::property::Attribute::all());
+                obj.property(js_string!("bottom"), JsValue::from(metrics.bottom()), boa_engine::property::Attribute::all());
+                Ok(obj.build().into())
+            } else {
+                Ok(JsValue::null())
+            }
+        });
+        context.register_global_callable(js_string!("__aura_get_layout_metrics"), 1, get_layout_metrics).unwrap();
+
         let get_node_value = NativeFunction::from_copy_closure(|_this, args, _context| {
             let nid = args.get(0).and_then(|v| v.as_number()).map(|n| n as u32).unwrap_or(0);
             let value = NODE_REGISTRY.with(|reg| {
@@ -1378,6 +1429,10 @@ impl JsRuntime {
         }
 
         Self { context, task_receiver }
+    }
+
+    pub fn set_layout_metrics(&mut self, layout_metrics: HashMap<String, LayoutMetrics>) {
+        LAYOUT_METRICS.with(|metrics| *metrics.borrow_mut() = layout_metrics);
     }
 
     pub fn tick(&mut self, timestamp: Option<f64>, deadline_ms: Option<f64>) -> bool {
@@ -1764,6 +1819,35 @@ fn mark_document_fragment_id(id: u32) {
 
 fn is_document_fragment_id(id: u32) -> bool {
     DOCUMENT_FRAGMENT_NODE_IDS.with(|ids| ids.borrow().contains(&id))
+}
+
+pub fn node_path_key(node: &Handle) -> String {
+    let mut indices = Vec::new();
+    let mut current = node.clone();
+
+    loop {
+        let parent_weak = current.parent.take();
+        let Some(parent_weak) = parent_weak else {
+            break;
+        };
+        let Some(parent) = parent_weak.upgrade() else {
+            break;
+        };
+
+        let current_ptr = Rc::as_ptr(&current) as usize;
+        let index = parent
+            .children
+            .borrow()
+            .iter()
+            .position(|child| Rc::as_ptr(child) as usize == current_ptr)
+            .unwrap_or(0);
+        indices.push(index.to_string());
+        current.parent.set(Some(Rc::downgrade(&parent)));
+        current = parent;
+    }
+
+    indices.reverse();
+    indices.join("/")
 }
 
 fn detach_node_from_parent(node: &Handle) {
@@ -2218,12 +2302,44 @@ fn steal_fragment_children(doc: &Handle) -> Vec<Handle> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{css, style};
+    use crate::{css, style, engine};
     use crate::dom;
 
     fn make_runtime(html: &str) -> JsRuntime {
         let dom = dom::parse_html(html);
-        JsRuntime::new(Some(dom.document), None, None, new_console_buffer())
+        JsRuntime::new(Some(dom.document), None, None, None, new_console_buffer())
+    }
+
+    fn layout_metrics_for_html(html: &str, width: f32) -> HashMap<String, LayoutMetrics> {
+        let base_url = Url::parse("https://example.com/").unwrap();
+        let image_cache = HashMap::new();
+        let mut css_cache = HashMap::new();
+        let js_overrides = HashMap::new();
+        let (page, _) = engine::process_html_with_cache(
+            html,
+            &base_url,
+            &image_cache,
+            &mut css_cache,
+            None,
+            &js_overrides,
+            None,
+            None,
+            None,
+            width,
+        ).unwrap();
+        page.layout_metrics
+    }
+
+    fn make_runtime_with_layout(html: &str, width: f32) -> JsRuntime {
+        let dom = dom::parse_html(html);
+        let metrics = layout_metrics_for_html(html, width);
+        JsRuntime::new(
+            Some(dom.document),
+            Some(Url::parse("https://example.com/").unwrap()),
+            None,
+            Some(metrics),
+            new_console_buffer(),
+        )
     }
 
     fn eval(rt: &mut JsRuntime, code: &str) -> String {
@@ -2253,7 +2369,7 @@ mod tests {
     fn test_console_methods_are_captured_with_levels() {
         let buffer = new_console_buffer();
         let dom = dom::parse_html("<html><body></body></html>");
-        let mut rt = JsRuntime::new(Some(dom.document), None, None, buffer.clone());
+        let mut rt = JsRuntime::new(Some(dom.document), None, None, None, buffer.clone());
 
         rt.execute("console.log('hello', 1); console.warn('careful'); console.error('boom');");
 
@@ -3028,7 +3144,7 @@ mod tests {
     fn test_history_push_and_replace_state_updates_location() {
         let url = url::Url::parse("https://example.com:8443/app/index.html").unwrap();
         let dom = crate::dom::parse_html("<html><body></body></html>");
-        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, new_console_buffer());
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
 
         let result = eval(&mut rt, r#"
             (function() {
@@ -3103,7 +3219,7 @@ mod tests {
     fn test_history_push_state_updates_pathname_search_hash() {
         let url = url::Url::parse("https://example.com/start").unwrap();
         let dom = crate::dom::parse_html("<html><body></body></html>");
-        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, new_console_buffer());
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
 
         let result = eval(&mut rt, r#"
             (function() {
@@ -3123,7 +3239,7 @@ mod tests {
     fn test_history_replace_state_overwrites_url_and_state() {
         let url = url::Url::parse("https://example.com/page").unwrap();
         let dom = crate::dom::parse_html("<html><body></body></html>");
-        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, new_console_buffer());
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
 
         let result = eval(&mut rt, r#"
             (function() {
@@ -3153,7 +3269,7 @@ mod tests {
     fn test_location_origin_preserves_port() {
         let url = url::Url::parse("https://example.com:9000/path").unwrap();
         let dom = crate::dom::parse_html("<html><body></body></html>");
-        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, new_console_buffer());
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
         let origin = eval(&mut rt, "window.location.origin");
         assert_eq!(origin, "https://example.com:9000");
     }
@@ -3250,7 +3366,7 @@ mod tests {
     fn test_window_location_set_from_url() {
         let url = url::Url::parse("https://www.example.com:8443/path?q=1#hash").unwrap();
         let dom = crate::dom::parse_html("<html><body></body></html>");
-        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, new_console_buffer());
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
         let href = if let Ok(val) = rt.context.eval(Source::from_bytes(b"window.location.href")) {
             if let Ok(s) = val.to_string(&mut rt.context) { s.to_std_string_escaped() } else { String::new() }
         } else { String::new() };
@@ -3293,6 +3409,60 @@ mod tests {
             })()
         "#);
         assert_eq!(result, "true:x:insertText:42:13");
+    }
+
+    #[test]
+    fn test_geometry_apis_return_layout_backed_rects_for_block_elements() {
+        let mut rt = make_runtime_with_layout(
+            "<html><body><div id='box' style='width: 120px; height: 40px; margin-left: 15px;'>box</div></body></html>",
+            800.0,
+        );
+        let result = eval(&mut rt, r#"
+            (function() {
+                var box = document.getElementById('box');
+                var rect = box.getBoundingClientRect();
+                return [
+                    rect.width > 0,
+                    rect.height > 0,
+                    box.offsetWidth === rect.width,
+                    box.offsetHeight === rect.height,
+                    box.clientWidth === rect.width,
+                    box.clientHeight === rect.height,
+                    box.offsetLeft === rect.left,
+                    box.offsetTop === rect.top,
+                    box.getClientRects().length === 1
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:true:true:true:true:true:true:true:true");
+    }
+
+    #[test]
+    fn test_geometry_apis_cover_inline_elements_and_update_after_layout_refresh() {
+        let html = "<html><body><span id='inline' style='display: inline-block; width: 50%; height: 20px;'>x</span></body></html>";
+        let mut rt = make_runtime_with_layout(html, 800.0);
+        let first = eval(&mut rt, r#"
+            (function() {
+                var rect = document.getElementById('inline').getBoundingClientRect();
+                return [rect.width > 0, rect.height > 0, document.getElementById('inline').getClientRects().length].join(':');
+            })()
+        "#);
+        assert_eq!(first, "true:true:1");
+
+        rt.set_layout_metrics(layout_metrics_for_html(html, 400.0));
+        let result = eval(&mut rt, r#"
+            (function() {
+                var el = document.getElementById('inline');
+                var width = el.getBoundingClientRect().width;
+                return [
+                    width > 0,
+                    el.scrollWidth === width,
+                    el.scrollHeight === el.getBoundingClientRect().height,
+                    width < 300
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:true:true:true");
     }
 
     #[test]

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -743,11 +743,20 @@ class Element extends Node {
         }
         return c ? __get_or_create_node(c.nid, c.tag, c.id, c.kind) : null;
     }
-    // getBoundingClientRect stub — returns zeros (layout info not available in JS)
-    getBoundingClientRect() {
+    _layoutMetrics() {
+        if (typeof __aura_get_layout_metrics === 'function') {
+            let metrics = __aura_get_layout_metrics(this._id);
+            if (metrics) return metrics;
+        }
         return { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
     }
-    getClientRects() { return []; }
+    getBoundingClientRect() {
+        return this._layoutMetrics();
+    }
+    getClientRects() {
+        let rect = this._layoutMetrics();
+        return rect.width > 0 || rect.height > 0 ? [rect] : [];
+    }
     // scrollIntoView stub
     scrollIntoView() {}
     scroll() {}
@@ -822,19 +831,18 @@ class Element extends Node {
     get selectedIndex() { return -1; }
     set selectedIndex(v) {}
     get options() { return new NodeList([]); }
-    // offsetWidth / offsetHeight / scrollWidth / scrollHeight stubs
-    get offsetWidth() { return 0; }
-    get offsetHeight() { return 0; }
-    get offsetTop() { return 0; }
-    get offsetLeft() { return 0; }
-    get scrollWidth() { return 0; }
-    get scrollHeight() { return 0; }
+    get offsetWidth() { return this._layoutMetrics().width; }
+    get offsetHeight() { return this._layoutMetrics().height; }
+    get offsetTop() { return this._layoutMetrics().top; }
+    get offsetLeft() { return this._layoutMetrics().left; }
+    get scrollWidth() { return this._layoutMetrics().width; }
+    get scrollHeight() { return this._layoutMetrics().height; }
     get scrollTop() { return 0; }
     set scrollTop(v) {}
     get scrollLeft() { return 0; }
     set scrollLeft(v) {}
-    get clientWidth() { return 0; }
-    get clientHeight() { return 0; }
+    get clientWidth() { return this._layoutMetrics().width; }
+    get clientHeight() { return this._layoutMetrics().height; }
     // namespaceURI
     get namespaceURI() { return 'http://www.w3.org/1999/xhtml'; }
     // setAttributeNS / getAttributeNS / removeAttributeNS

--- a/tests/repro_order.rs
+++ b/tests/repro_order.rs
@@ -3,7 +3,7 @@ use boa_engine::{Source, JsValue};
 
 #[test]
 fn test_repro_order() {
-    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
+    let mut js = JsRuntime::new(None, None, None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         globalThis.order = [];

--- a/tests/test_event_loop.rs
+++ b/tests/test_event_loop.rs
@@ -2,7 +2,7 @@ use browser::js::JsRuntime;
 
 #[test]
 fn test_macro_micro_task_order() {
-    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
+    let mut js = JsRuntime::new(None, None, None, None, browser::js::new_console_buffer());
     
     // This script uses standard Promise (micro) and our setTimeout (macro)
     js.execute(r#"
@@ -34,7 +34,7 @@ fn test_macro_micro_task_order() {
 
 #[test]
 fn test_raf_timestamp() {
-    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
+    let mut js = JsRuntime::new(None, None, None, None, browser::js::new_console_buffer());
 
     js.execute(r#"
         var ts = 0;

--- a/tests/test_event_loop_complex.rs
+++ b/tests/test_event_loop_complex.rs
@@ -15,7 +15,7 @@ fn get_array_results(js: &mut JsRuntime, var_name: &str) -> Vec<String> {
 
 #[test]
 fn test_event_loop_interleaving() {
-    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
+    let mut js = JsRuntime::new(None, None, None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         var results = [];
@@ -47,7 +47,7 @@ fn test_event_loop_interleaving() {
 
 #[test]
 fn test_raf_interleaving() {
-    let mut js = JsRuntime::new(None, None, None, browser::js::new_console_buffer());
+    let mut js = JsRuntime::new(None, None, None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         var results = [];

--- a/tests/test_focus.rs
+++ b/tests/test_focus.rs
@@ -9,7 +9,7 @@ fn test_focus_events() {
         <div id="b" tabindex="0"></div>
     "#;
     let dom = dom::parse_html(html);
-    let mut js = JsRuntime::new(Some(dom.document.clone()), None, None, browser::js::new_console_buffer());
+    let mut js = JsRuntime::new(Some(dom.document.clone()), None, None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         globalThis.log_output = [];
@@ -51,7 +51,7 @@ fn test_focus_blur_interleaving() {
         <div id="b" tabindex="0"></div>
     "#;
     let dom = dom::parse_html(html);
-    let mut js = JsRuntime::new(Some(dom.document.clone()), None, None, browser::js::new_console_buffer());
+    let mut js = JsRuntime::new(Some(dom.document.clone()), None, None, None, browser::js::new_console_buffer());
     
     js.execute(r#"
         globalThis.log_output = [];

--- a/tests/test_idle.rs
+++ b/tests/test_idle.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 
 #[test]
 fn test_request_idle_callback_registration() {
-    let mut runtime = browser::js::JsRuntime::new(None, None, None, browser::js::new_console_buffer());
+    let mut runtime = browser::js::JsRuntime::new(None, None, None, None, browser::js::new_console_buffer());
     
     // Test if requestIdleCallback is available in the global scope
     let code = r#"
@@ -35,7 +35,7 @@ fn test_request_idle_callback_registration() {
 
 #[test]
 fn test_cancel_idle_callback() {
-    let mut runtime = browser::js::JsRuntime::new(None, None, None, browser::js::new_console_buffer());
+    let mut runtime = browser::js::JsRuntime::new(None, None, None, None, browser::js::new_console_buffer());
     
     let code = r#"
         let idleCalled = false;

--- a/tests/test_storage.rs
+++ b/tests/test_storage.rs
@@ -8,26 +8,26 @@ fn test_storage_isolation_and_persistence() {
 
     // 1. Set data for origin A
     {
-        let mut js = JsRuntime::new(None, Some(url1.clone()), None, browser::js::new_console_buffer());
+        let mut js = JsRuntime::new(None, Some(url1.clone()), None, None, browser::js::new_console_buffer());
         js.execute("localStorage.setItem('key', 'valueA')");
     }
 
     // 2. Set data for origin B
     {
-        let mut js = JsRuntime::new(None, Some(url2.clone()), None, browser::js::new_console_buffer());
+        let mut js = JsRuntime::new(None, Some(url2.clone()), None, None, browser::js::new_console_buffer());
         js.execute("localStorage.setItem('key', 'valueB')");
     }
 
     // 3. Verify origin A still has valueA
     {
-        let mut js = JsRuntime::new(None, Some(url1.clone()), None, browser::js::new_console_buffer());
+        let mut js = JsRuntime::new(None, Some(url1.clone()), None, None, browser::js::new_console_buffer());
         let val = js.context.eval(boa_engine::Source::from_bytes(b"localStorage.getItem('key')")).unwrap();
         assert_eq!(val.as_string().unwrap().to_std_string_escaped(), "valueA");
     }
 
     // 4. Verify origin B still has valueB
     {
-        let mut js = JsRuntime::new(None, Some(url2.clone()), None, browser::js::new_console_buffer());
+        let mut js = JsRuntime::new(None, Some(url2.clone()), None, None, browser::js::new_console_buffer());
         let val = js.context.eval(boa_engine::Source::from_bytes(b"localStorage.getItem('key')")).unwrap();
         assert_eq!(val.as_string().unwrap().to_std_string_escaped(), "valueB");
     }


### PR DESCRIPTION
## Summary
- back DOM geometry APIs with real layout metrics keyed by stable DOM child paths
- expose layout-backed `getBoundingClientRect()`, `getClientRects()`, `offset*`, `client*`, and initial `scroll*` values in the JS bootstrap
- add focused geometry tests and update existing `JsRuntime::new` call sites for the new layout-metrics hook

## Testing
- node --check src/js_bootstrap.js
- cargo test -q test_geometry_apis_return_layout_backed_rects_for_block_elements -- --nocapture
- cargo test -q test_geometry_apis_cover_inline_elements_and_update_after_layout_refresh -- --nocapture
- cargo build --bins
- curl -fsS http://127.0.0.1:7070/health
- drun --network host rust:latest timeout 30s ./target/debug/browser-cli navigate https://yunseong.dev
- drun --network host rust:latest timeout 30s ./target/debug/browser-cli navigate https://google.com
