### PR TITLE
feat: add live HTMLCollection

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -2495,6 +2495,72 @@ mod tests {
     }
 
     #[test]
+    fn test_html_collection_children_is_live_after_mutations() {
+        let mut rt = make_runtime("<html><body><div id='app'><span id='one'>1</span></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var children = app.children;
+                var before = [children instanceof HTMLCollection, children.length, children[0].id].join(':');
+                var two = document.createElement('span');
+                two.id = 'two';
+                app.appendChild(two);
+                app.removeChild(document.getElementById('one'));
+                return before + '|' + [children.length, children.item(0).id, children.namedItem('two') === two].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:1:one|1:two:true");
+    }
+
+    #[test]
+    fn test_get_elements_collections_are_live_and_support_named_access() {
+        let mut rt = make_runtime("<html><body><div id='app'><span id='one' class='card' name='first'>1</span></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var cards = document.getElementsByClassName('card');
+                var spans = app.getElementsByTagName('span');
+                var two = document.createElement('span');
+                two.id = 'two';
+                two.className = 'card';
+                two.setAttribute('name', 'second');
+                app.appendChild(two);
+                return [
+                    cards instanceof HTMLCollection,
+                    cards.length,
+                    spans.length,
+                    cards.namedItem('second') === two,
+                    cards.second === two,
+                    spans[1] === two
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:2:2:true:true:true");
+    }
+
+    #[test]
+    fn test_query_selector_all_remains_static_while_html_collections_are_live() {
+        let mut rt = make_runtime("<html><body><div id='app'><p class='item'>a</p></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var snapshot = app.querySelectorAll('.item');
+                var live = app.getElementsByClassName('item');
+                var next = document.createElement('p');
+                next.className = 'item';
+                app.appendChild(next);
+                return [
+                    snapshot instanceof NodeList,
+                    snapshot.length,
+                    live.length,
+                    Array.from(live).length
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:1:2:2");
+    }
+
+    #[test]
     fn test_add_event_listener_fires() {
         let mut rt = make_runtime("<html><body><button id='btn'>click</button></body></html>");
         eval(&mut rt, "var clicked = false; var btn = document.getElementById('btn'); btn.addEventListener('click', function() { clicked = true; });");

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -413,6 +413,66 @@ class NodeList {
     }
 }
 
+function __aura_collection_node(item) {
+    if (typeof item === 'object') {
+        return __get_or_create_node(item.nid, item.tag, item.id, item.kind);
+    }
+    let info = __aura_get_node_info(item);
+    return info ? __get_or_create_node(item, info.tag, info.id, info.kind) : __get_or_create_node(item);
+}
+
+class HTMLCollection {
+    constructor(resolver) {
+        this._resolver = resolver;
+        return new Proxy(this, {
+            get(target, prop, receiver) {
+                if (prop === 'length') return target._items().length;
+                if (prop === Symbol.iterator) return target[Symbol.iterator].bind(target);
+                if (typeof prop === 'string') {
+                    if (/^(0|[1-9]\d*)$/.test(prop)) return target.item(Number(prop));
+                    if (!(prop in target)) {
+                        let named = target.namedItem(prop);
+                        if (named) return named;
+                    }
+                }
+                let value = Reflect.get(target, prop, receiver);
+                return typeof value === 'function' ? value.bind(target) : value;
+            },
+            has(target, prop) {
+                if (typeof prop === 'string' && /^(0|[1-9]\d*)$/.test(prop)) {
+                    return Number(prop) < target.length;
+                }
+                return prop in target;
+            }
+        });
+    }
+    _items() {
+        return this._resolver();
+    }
+    item(index) {
+        let item = this._items()[index];
+        return item === undefined ? null : __aura_collection_node(item);
+    }
+    namedItem(name) {
+        name = String(name);
+        for (let item of this._items()) {
+            let node = __aura_collection_node(item);
+            if (!node || node.nodeType !== Node.ELEMENT_NODE) continue;
+            if (node.id === name || node.getAttribute('name') === name) return node;
+        }
+        return null;
+    }
+    [Symbol.iterator]() {
+        let i = 0;
+        return {
+            next: () => {
+                let value = this.item(i++);
+                return value ? { value, done: false } : { done: true };
+            }
+        };
+    }
+}
+
 // -- Node & Element Classes ---------------------------------------------------
 
 // Node type constants (static properties added after class definition)
@@ -713,18 +773,24 @@ class Element extends Node {
         }).map(el => el._id));
     }
     getElementsByClassName(cls) {
-        let nids_json = __aura_get_elements_by_class(this._id, cls);
-        let nids = JSON.parse(nids_json);
-        return new NodeList(nids);
+        let rootId = this._id;
+        let className = String(cls);
+        return new HTMLCollection(function() {
+            return JSON.parse(__aura_get_elements_by_class(rootId, className));
+        });
     }
     getElementsByTagName(tag) {
-        let nids_json = __aura_get_elements_by_tag(this._id, tag.toLowerCase());
-        let nids = JSON.parse(nids_json);
-        return new NodeList(nids);
+        let rootId = this._id;
+        let tagName = String(tag).toLowerCase();
+        return new HTMLCollection(function() {
+            return JSON.parse(__aura_get_elements_by_tag(rootId, tagName));
+        });
     }
     get children() {
-        let arr = JSON.parse(__aura_get_children(this._id));
-        return new NodeList(arr.filter(c => c.kind === 'element'));
+        let rootId = this._id;
+        return new HTMLCollection(function() {
+            return JSON.parse(__aura_get_children(rootId)).filter(c => c.kind === 'element');
+        });
     }
     get childElementCount() {
         let arr = JSON.parse(__aura_get_children(this._id));
@@ -1071,14 +1137,16 @@ var document = {
         return new NodeList(nodes.map(n => n._id));
     },
     getElementsByClassName: function(cls) {
-        let nids_json = __aura_get_elements_by_class(0, cls);
-        let nids = JSON.parse(nids_json);
-        return new NodeList(nids);
+        let className = String(cls);
+        return new HTMLCollection(function() {
+            return JSON.parse(__aura_get_elements_by_class(0, className));
+        });
     },
     getElementsByTagName: function(tag) {
-        let nids_json = __aura_get_elements_by_tag(0, tag.toLowerCase());
-        let nids = JSON.parse(nids_json);
-        return new NodeList(nids);
+        let tagName = String(tag).toLowerCase();
+        return new HTMLCollection(function() {
+            return JSON.parse(__aura_get_elements_by_tag(0, tagName));
+        });
     },
     // Document surface getters follow the parsed tree shape, not arbitrary descendants.
     get body() {
@@ -1835,6 +1903,7 @@ window.Comment = Comment;
 window.DocumentType = DocumentType;
 window.DocumentFragment = DocumentFragment;
 window.NodeList = NodeList;
+window.HTMLCollection = HTMLCollection;
 window.EventTarget = EventTarget;
 window.XMLHttpRequest = XMLHttpRequest;
 window.DOMTokenList = DOMTokenList;


### PR DESCRIPTION
## Summary
- add a live `HTMLCollection` implementation with indexed access, `item()`, `namedItem()`, named property lookup, and iteration
- return live collections from `children`, `getElementsByClassName()`, and `getElementsByTagName()`
- keep `querySelectorAll()` as a static `NodeList`

## Testing
- node --check src/js_bootstrap.js
- cargo test -q test_html_collection_children_is_live_after_mutations -- --nocapture
- cargo test -q test_get_elements_collections_are_live_and_support_named_access -- --nocapture
- cargo test -q test_query_selector_all_remains_static_while_html_collections_are_live -- --nocapture
- cargo build --bins
- curl -fsS http://127.0.0.1:7070/health
- drun --network host rust:latest timeout 30s ./target/debug/browser-cli navigate https://yunseong.dev
- drun --network host rust:latest timeout 30s ./target/debug/browser-cli navigate https://google.com
