### PR TITLE
feat(dom): add live NodeIterator traversal

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -2631,6 +2631,73 @@ mod tests {
     }
 
     #[test]
+    fn test_node_iterator_tracks_reference_node_and_pointer_state() {
+        let mut rt = make_runtime("<html><body><div id='app'><span id='one'></span><span id='two'></span></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var iterator = document.createNodeIterator(app, NodeFilter.SHOW_ELEMENT);
+                var first = iterator.nextNode();
+                var second = iterator.nextNode();
+                var back = iterator.previousNode();
+                return [
+                    iterator instanceof NodeIterator,
+                    first.id,
+                    second.id,
+                    back.id,
+                    iterator.referenceNode.id,
+                    iterator.pointerBeforeReferenceNode
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:app:one:one:one:true");
+    }
+
+    #[test]
+    fn test_node_iterator_filters_mixed_nodes_and_observes_later_mutations() {
+        let mut rt = make_runtime("<html><body><div id='app'>alpha<!--note--><span id='one'>x</span></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var iterator = document.createNodeIterator(
+                    app,
+                    NodeFilter.SHOW_TEXT | NodeFilter.SHOW_COMMENT,
+                    function(node) {
+                        return node.nodeType === Node.TEXT_NODE && node.nodeValue === 'x'
+                            ? NodeFilter.FILTER_SKIP
+                            : NodeFilter.FILTER_ACCEPT;
+                    }
+                );
+                var first = iterator.nextNode();
+                var second = iterator.nextNode();
+                var tail = document.createComment('tail');
+                app.appendChild(tail);
+                var third = iterator.nextNode();
+                return [
+                    first.nodeType + ':' + first.nodeValue,
+                    second.nodeType + ':' + second.nodeValue,
+                    third.nodeType + ':' + third.nodeValue
+                ].join('|');
+            })()
+        "#);
+        assert_eq!(result, "3:alpha|8:note|8:tail");
+    }
+
+    #[test]
+    fn test_node_iterator_detach_stops_future_traversal() {
+        let mut rt = make_runtime("<html><body><div id='app'><span id='one'></span></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var iterator = document.createNodeIterator(document.getElementById('app'), NodeFilter.SHOW_ELEMENT);
+                var first = iterator.nextNode();
+                iterator.detach();
+                return [first.id, iterator.nextNode() === null, iterator.previousNode() === null].join(':');
+            })()
+        "#);
+        assert_eq!(result, "app:true:true");
+    }
+
+    #[test]
     fn test_add_event_listener_fires() {
         let mut rt = make_runtime("<html><body><button id='btn'>click</button></body></html>");
         eval(&mut rt, "var clicked = false; var btn = document.getElementById('btn'); btn.addEventListener('click', function() { clicked = true; });");

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -619,6 +619,54 @@ class TreeWalker {
     }
 }
 
+class NodeIterator {
+    constructor(root, whatToShow, filter) {
+        this.root = root;
+        this.whatToShow = whatToShow === undefined || whatToShow === null ? NodeFilter.SHOW_ALL : whatToShow;
+        this.filter = filter || null;
+        this.referenceNode = root;
+        this.pointerBeforeReferenceNode = true;
+        this._detached = false;
+    }
+    _visible(node) {
+        return __aura_filter_result(node, this.whatToShow, this.filter) === NodeFilter.FILTER_ACCEPT;
+    }
+    _visibleNodes() {
+        return __aura_tree_order(this.root).filter(node => this._visible(node));
+    }
+    nextNode() {
+        if (this._detached) return null;
+        let nodes = this._visibleNodes();
+        let index = nodes.indexOf(this.referenceNode);
+        if (this.pointerBeforeReferenceNode && index >= 0) {
+            this.pointerBeforeReferenceNode = false;
+            return this.referenceNode;
+        }
+        let next = nodes[index + 1];
+        if (!next) return null;
+        this.referenceNode = next;
+        this.pointerBeforeReferenceNode = false;
+        return next;
+    }
+    previousNode() {
+        if (this._detached) return null;
+        let nodes = this._visibleNodes();
+        let index = nodes.indexOf(this.referenceNode);
+        if (!this.pointerBeforeReferenceNode && index >= 0) {
+            this.pointerBeforeReferenceNode = true;
+            return this.referenceNode;
+        }
+        let previous = nodes[index - 1];
+        if (!previous) return null;
+        this.referenceNode = previous;
+        this.pointerBeforeReferenceNode = true;
+        return previous;
+    }
+    detach() {
+        this._detached = true;
+    }
+}
+
 // -- Node & Element Classes ---------------------------------------------------
 
 // Node type constants (static properties added after class definition)
@@ -1336,23 +1384,8 @@ var document = {
         return new TreeWalker(root, whatToShow, filter);
     },
 
-    // createNodeIterator stub
     createNodeIterator: function(root, whatToShow, filter) {
-        var nodes = [];
-        function collect(node) {
-            nodes.push(node);
-            var children = node && node.childNodes ? node.childNodes : [];
-            for (var i = 0; i < children.length; i++) {
-                collect(children[i]);
-            }
-        }
-        if (root && root._id) collect(root);
-        var i = 0;
-        return {
-            nextNode: function() { return i < nodes.length ? nodes[i++] : null; },
-            previousNode: function() { return i > 0 ? nodes[--i] : null; },
-            detach: function() {},
-        };
+        return new NodeIterator(root, whatToShow, filter);
     },
 
     // createRange stub
@@ -2026,6 +2059,7 @@ window.NodeList = NodeList;
 window.HTMLCollection = HTMLCollection;
 window.NodeFilter = NodeFilter;
 window.TreeWalker = TreeWalker;
+window.NodeIterator = NodeIterator;
 window.EventTarget = EventTarget;
 window.XMLHttpRequest = XMLHttpRequest;
 window.DOMTokenList = DOMTokenList;


### PR DESCRIPTION
## Summary
- replace the createNodeIterator stub with a live NodeIterator implementation
- track referenceNode and pointerBeforeReferenceNode across next/previous traversal
- support whatToShow masks, callback filters, mutation-aware traversal, and detach behavior

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_node_iterator_tracks_reference_node_and_pointer_state -- --nocapture
- cargo test -q test_node_iterator_filters_mixed_nodes_and_observes_later_mutations -- --nocapture
- cargo test -q test_node_iterator_detach_stops_future_traversal -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #208