### PR TITLE
feat(dom): add basic Range API

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -2698,6 +2698,113 @@ mod tests {
     }
 
     #[test]
+    fn test_range_select_node_contents_and_clone_range_state() {
+        let mut rt = make_runtime("<html><body><div id='app'><span>one</span><b>two</b></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var range = document.createRange();
+                range.selectNodeContents(app);
+                var clone = range.cloneRange();
+                range.collapse(false);
+                return [
+                    range instanceof Range,
+                    clone.startContainer.id,
+                    clone.startOffset,
+                    clone.endContainer.id,
+                    clone.endOffset,
+                    clone.toString(),
+                    range.collapsed
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:app:0:app:2:onetwo:true");
+    }
+
+    #[test]
+    fn test_range_clone_extract_and_delete_child_contents() {
+        let mut rt = make_runtime("<html><body><div id='app'><span id='one'>one</span><b id='two'>two</b><i id='three'>three</i></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var range = document.createRange();
+                range.setStart(app, 0);
+                range.setEnd(app, 2);
+                var cloned = range.cloneContents();
+                var extracted = range.extractContents();
+                var afterExtract = app.textContent;
+
+                var deleteRange = document.createRange();
+                deleteRange.selectNodeContents(app);
+                deleteRange.deleteContents();
+
+                return [
+                    cloned.textContent,
+                    extracted.textContent,
+                    afterExtract,
+                    app.childNodes.length,
+                    range.collapsed,
+                    range.startContainer.id,
+                    range.startOffset
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "onetwo:onetwo:three:0:true:app:0");
+    }
+
+    #[test]
+    fn test_range_insert_node_at_child_and_text_boundaries() {
+        let mut rt = make_runtime("<html><body><div id='app'><span id='one'>one</span><span id='two'>two</span></div><p id='text'>hello</p></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var app = document.getElementById('app');
+                var middle = document.createElement('em');
+                middle.id = 'middle';
+                middle.textContent = 'middle';
+                var range = document.createRange();
+                range.setStart(app, 1);
+                range.insertNode(middle);
+
+                var text = document.getElementById('text').firstChild;
+                var strong = document.createElement('strong');
+                strong.textContent = 'X';
+                var textRange = document.createRange();
+                textRange.setStart(text, 2);
+                textRange.insertNode(strong);
+
+                return [
+                    Array.from(app.children).map(function(node) { return node.id; }).join(','),
+                    document.getElementById('text').textContent
+                ].join('|');
+            })()
+        "#);
+        assert_eq!(result, "one,middle,two|heXllo");
+    }
+
+    #[test]
+    fn test_range_text_offsets_extract_and_to_string() {
+        let mut rt = make_runtime("<html><body><p id='p'>abcdef</p></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var text = document.getElementById('p').firstChild;
+                var range = document.createRange();
+                range.setStart(text, 1);
+                range.setEnd(text, 4);
+                var before = range.toString();
+                var extracted = range.extractContents();
+                return [
+                    before,
+                    extracted.textContent,
+                    text.data,
+                    range.collapsed,
+                    range.startOffset
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "bcd:bcd:aef:true:1");
+    }
+
+    #[test]
     fn test_add_event_listener_fires() {
         let mut rt = make_runtime("<html><body><button id='btn'>click</button></body></html>");
         eval(&mut rt, "var clicked = false; var btn = document.getElementById('btn'); btn.addEventListener('click', function() { clicked = true; });");

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -667,6 +667,177 @@ class NodeIterator {
     }
 }
 
+function __aura_child_at(container, offset) {
+    if (!container || !container.childNodes) return null;
+    return container.childNodes.item(offset);
+}
+
+function __aura_node_index(node) {
+    if (!node || !node.parentNode) return -1;
+    let siblings = node.parentNode.childNodes;
+    for (let i = 0; i < siblings.length; i++) {
+        if (siblings[i] === node) return i;
+    }
+    return -1;
+}
+
+function __aura_is_character_data(node) {
+    return node && (node.nodeType === Node.TEXT_NODE || node.nodeType === Node.COMMENT_NODE);
+}
+
+function __aura_common_ancestor(a, b) {
+    let ancestors = [];
+    let current = a;
+    while (current) {
+        ancestors.push(current);
+        current = current.parentNode;
+    }
+    current = b;
+    while (current) {
+        if (ancestors.includes(current)) return current;
+        current = current.parentNode;
+    }
+    return null;
+}
+
+class Range {
+    constructor() {
+        this.startContainer = document;
+        this.startOffset = 0;
+        this.endContainer = document;
+        this.endOffset = 0;
+    }
+    setStart(node, offset) {
+        this.startContainer = node;
+        this.startOffset = Math.max(0, Number(offset) || 0);
+    }
+    setEnd(node, offset) {
+        this.endContainer = node;
+        this.endOffset = Math.max(0, Number(offset) || 0);
+    }
+    setStartBefore(node) {
+        this.setStart(node.parentNode, __aura_node_index(node));
+    }
+    setStartAfter(node) {
+        this.setStart(node.parentNode, __aura_node_index(node) + 1);
+    }
+    setEndBefore(node) {
+        this.setEnd(node.parentNode, __aura_node_index(node));
+    }
+    setEndAfter(node) {
+        this.setEnd(node.parentNode, __aura_node_index(node) + 1);
+    }
+    selectNode(node) {
+        let index = __aura_node_index(node);
+        this.setStart(node.parentNode, index);
+        this.setEnd(node.parentNode, index + 1);
+    }
+    selectNodeContents(node) {
+        this.setStart(node, 0);
+        if (__aura_is_character_data(node)) {
+            this.setEnd(node, node.data.length);
+        } else {
+            this.setEnd(node, node.childNodes ? node.childNodes.length : 0);
+        }
+    }
+    collapse(toStart) {
+        if (toStart === false) {
+            this.setStart(this.endContainer, this.endOffset);
+        } else {
+            this.setEnd(this.startContainer, this.startOffset);
+        }
+    }
+    cloneRange() {
+        let range = new Range();
+        range.setStart(this.startContainer, this.startOffset);
+        range.setEnd(this.endContainer, this.endOffset);
+        return range;
+    }
+    get collapsed() {
+        return this.startContainer === this.endContainer && this.startOffset === this.endOffset;
+    }
+    get commonAncestorContainer() {
+        return __aura_common_ancestor(this.startContainer, this.endContainer);
+    }
+    _selectedChildren() {
+        if (this.startContainer !== this.endContainer || __aura_is_character_data(this.startContainer)) return [];
+        let nodes = [];
+        let children = this.startContainer.childNodes || new NodeList([]);
+        let end = Math.min(this.endOffset, children.length);
+        for (let i = this.startOffset; i < end; i++) {
+            let child = children.item(i);
+            if (child) nodes.push(child);
+        }
+        return nodes;
+    }
+    cloneContents() {
+        let fragment = document.createDocumentFragment();
+        if (this.startContainer === this.endContainer && __aura_is_character_data(this.startContainer)) {
+            fragment.appendChild(document.createTextNode(this.startContainer.data.slice(this.startOffset, this.endOffset)));
+            return fragment;
+        }
+        let nodes = this._selectedChildren();
+        for (let i = 0; i < nodes.length; i++) {
+            fragment.appendChild(nodes[i].cloneNode(true));
+        }
+        return fragment;
+    }
+    extractContents() {
+        let fragment = document.createDocumentFragment();
+        if (this.startContainer === this.endContainer && __aura_is_character_data(this.startContainer)) {
+            let node = this.startContainer;
+            let data = node.data;
+            fragment.appendChild(document.createTextNode(data.slice(this.startOffset, this.endOffset)));
+            node.data = data.slice(0, this.startOffset) + data.slice(this.endOffset);
+            this.collapse(true);
+            return fragment;
+        }
+        let nodes = this._selectedChildren();
+        for (let i = 0; i < nodes.length; i++) {
+            fragment.appendChild(nodes[i]);
+        }
+        this.collapse(true);
+        return fragment;
+    }
+    deleteContents() {
+        this.extractContents();
+    }
+    insertNode(node) {
+        if (__aura_is_character_data(this.startContainer)) {
+            let text = this.startContainer;
+            let parent = text.parentNode;
+            let after = document.createTextNode(text.data.slice(this.startOffset));
+            text.data = text.data.slice(0, this.startOffset);
+            parent.insertBefore(after, text.nextSibling);
+            parent.insertBefore(node, after);
+            return;
+        }
+        this.startContainer.insertBefore(node, __aura_child_at(this.startContainer, this.startOffset));
+    }
+    surroundContents(newParent) {
+        let fragment = this.extractContents();
+        newParent.appendChild(fragment);
+        this.insertNode(newParent);
+        this.selectNode(newParent);
+    }
+    toString() {
+        if (this.startContainer === this.endContainer && __aura_is_character_data(this.startContainer)) {
+            return this.startContainer.data.slice(this.startOffset, this.endOffset);
+        }
+        let nodes = this._selectedChildren();
+        if (nodes.length > 0) {
+            return nodes.map(node => node.textContent || '').join('');
+        }
+        return '';
+    }
+    getBoundingClientRect() {
+        return { x:0, y:0, width:0, height:0, top:0, left:0, right:0, bottom:0 };
+    }
+    getClientRects() {
+        return [];
+    }
+}
+
 // -- Node & Element Classes ---------------------------------------------------
 
 // Node type constants (static properties added after class definition)
@@ -1388,24 +1559,8 @@ var document = {
         return new NodeIterator(root, whatToShow, filter);
     },
 
-    // createRange stub
     createRange: function() {
-        return {
-            setStart: function() {},
-            setEnd: function() {},
-            selectNode: function() {},
-            selectNodeContents: function() {},
-            collapse: function() {},
-            cloneRange: function() { return document.createRange(); },
-            deleteContents: function() {},
-            extractContents: function() { return document.createDocumentFragment(); },
-            insertNode: function() {},
-            surroundContents: function() {},
-            getBoundingClientRect: function() { return { x:0, y:0, width:0, height:0, top:0, left:0, right:0, bottom:0 }; },
-            getClientRects: function() { return []; },
-            toString: function() { return ''; },
-            commonAncestorContainer: null,
-        };
+        return new Range();
     },
 
     // execCommand stub
@@ -2060,6 +2215,7 @@ window.HTMLCollection = HTMLCollection;
 window.NodeFilter = NodeFilter;
 window.TreeWalker = TreeWalker;
 window.NodeIterator = NodeIterator;
+window.Range = Range;
 window.EventTarget = EventTarget;
 window.XMLHttpRequest = XMLHttpRequest;
 window.DOMTokenList = DOMTokenList;


### PR DESCRIPTION
## Summary
- replace the createRange stub with a real Range class
- track start/end boundaries, collapsed state, common ancestor, and cloneRange state
- support selectNodeContents, child/text toString, cloneContents, extractContents, deleteContents, insertNode, and surroundContents basics

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_range -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #207