### PR TITLE
feat(dom): improve form control state

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -801,6 +801,7 @@ impl BrowserEngine {
         // Focus change
         for (rect, id) in &page.focusable_elements {
             if hit_test(x, y, rect) {
+                self.js_runtime.set_focused_node_id(Some(id.clone()));
                 results.push(ClickResult::FocusChanged { id: id.clone() });
             }
         }
@@ -835,10 +836,31 @@ impl BrowserEngine {
         results
     }
 
-    /// Stub: inject text into the currently focused form input.
-    /// Full implementation deferred to follow-up issue.
-    pub fn type_text(&mut self, _text: &str) {
-        println!("[BrowserEngine] type_text: not yet implemented");
+    /// Inject text into the currently focused text-like form control.
+    pub fn type_text(&mut self, text: &str) {
+        let Some(id) = self.js_runtime.get_focused_node_id() else {
+            return;
+        };
+        let id_json = serde_json::to_string(&id).unwrap_or_else(|_| "\"\"".to_string());
+        let text_json = serde_json::to_string(text).unwrap_or_else(|_| "\"\"".to_string());
+        let code = format!(
+            r#"
+            (function() {{
+                var el = document.getElementById({id_json});
+                var text = {text_json};
+                if (!el || el.disabled) return;
+                var tag = el.tagName;
+                var type = (el.type || '').toLowerCase();
+                if (tag === 'TEXTAREA' || tag === 'INPUT') {{
+                    if (type === 'checkbox' || type === 'radio' || type === 'button' || type === 'submit' || type === 'reset') return;
+                    el.value = (el.value || '') + text;
+                    el.dispatchEvent(new InputEvent('input', {{ bubbles: true, data: text, inputType: 'insertText' }}));
+                    el.dispatchEvent(new Event('change', {{ bubbles: true }}));
+                }}
+            }})();
+            "#
+        );
+        self.js_runtime.execute(&code);
     }
 
     fn cache_missing_images_with<F>(&mut self, image_urls: &[String], mut fetch: F) -> bool
@@ -1370,6 +1392,35 @@ mod tests {
 
         assert!(!loaded);
         assert!(engine.image_cache.is_empty());
+    }
+
+    #[test]
+    fn test_type_text_updates_focused_input_dom_state_and_events() {
+        let mut engine = BrowserEngine::new();
+        let base_url = Url::parse("https://example.com/").unwrap();
+        let mut css_cache = HashMap::new();
+        let (page, _) = process_html_with_cache(
+            "<html><body><input id='field' value='a'><script>window.events=[]; var field = document.getElementById('field'); field.addEventListener('input', function(e) { window.events.push('input:' + e.data); }); field.addEventListener('change', function() { window.events.push('change'); });</script></body></html>",
+            &base_url,
+            &HashMap::new(),
+            &mut css_cache,
+            None,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            800.0,
+        )
+        .unwrap();
+        engine.init_js_for_page(&page);
+
+        engine.js_runtime.set_focused_node_id(Some("field".to_string()));
+        engine.type_text("bc");
+
+        let value = engine.evaluate_js("document.getElementById('field').value");
+        let events = engine.evaluate_js("window.events.join('|')");
+        assert_eq!(value, "abc");
+        assert_eq!(events, "input:bc|change");
     }
 
     #[test]

--- a/src/js.rs
+++ b/src/js.rs
@@ -2894,6 +2894,58 @@ mod tests {
     }
 
     #[test]
+    fn test_form_input_and_textarea_value_state_stays_coherent() {
+        let mut rt = make_runtime("<html><body><form id='form'><input id='field' name='q' value='old'><textarea id='ta'>hello</textarea></form></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var field = document.getElementById('field');
+                var textarea = document.getElementById('ta');
+                field.value = 'new';
+                textarea.value = 'world';
+                return [
+                    field.value,
+                    field.getAttribute('value'),
+                    field.defaultValue,
+                    field.form.id,
+                    textarea.value,
+                    textarea.textContent,
+                    textarea.getAttribute('value')
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "new:new:new:form:world:world:world");
+    }
+
+    #[test]
+    fn test_form_checkbox_radio_and_select_state_parity() {
+        let mut rt = make_runtime("<html><body><form><input id='check' type='checkbox'><input id='r1' type='radio' name='group' checked><input id='r2' type='radio' name='group'><select id='sel'><option value='a'>A</option><option id='b' value='b'>B</option><option>C</option></select></form></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var check = document.getElementById('check');
+                var r1 = document.getElementById('r1');
+                var r2 = document.getElementById('r2');
+                var sel = document.getElementById('sel');
+                check.checked = true;
+                r2.checked = true;
+                sel.value = 'b';
+                var afterValue = [sel.selectedIndex, sel.value, document.getElementById('b').selected].join(',');
+                sel.selectedIndex = 2;
+                return [
+                    check.checked,
+                    check.hasAttribute('checked'),
+                    r1.checked,
+                    r2.checked,
+                    afterValue,
+                    sel.selectedIndex,
+                    sel.value,
+                    sel.options.length
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:true:false:true:1,b,true:2:C:3");
+    }
+
+    #[test]
     fn test_add_event_listener_fires() {
         let mut rt = make_runtime("<html><body><button id='btn'>click</button></body></html>");
         eval(&mut rt, "var clicked = false; var btn = document.getElementById('btn'); btn.addEventListener('click', function() { clicked = true; });");

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -1234,8 +1234,15 @@ class Element extends Node {
     }
     focus() {
         __aura_set_focus(this.id);
+        document.activeElement = this;
+        this.dispatchEvent(new Event('focus', { bubbles: false }));
+        this.dispatchEvent(new Event('focusin', { bubbles: true }));
     }
-    blur() {}
+    blur() {
+        if (document.activeElement === this) document.activeElement = document.body;
+        this.dispatchEvent(new Event('blur', { bubbles: false }));
+        this.dispatchEvent(new Event('focusout', { bubbles: true }));
+    }
     matches(selector) {
         // Use querySelector from root to check if this element matches
         // Simplified: just check tag/class/id
@@ -1365,18 +1372,74 @@ class Element extends Node {
             }
         });
     }
-    // checked / value properties (for input elements)
-    get value() { return __aura_get_attribute(this._id, 'value') || ''; }
-    set value(v) { __aura_set_attribute(this._id, 'value', String(v)); }
+    get form() {
+        let node = this.parentElement;
+        while (node) {
+            if (node.tagName === 'FORM') return node;
+            node = node.parentElement;
+        }
+        return null;
+    }
+    get defaultValue() {
+        if (this.tagName === 'TEXTAREA') return __aura_get_attribute(this._id, 'value') || this.textContent || '';
+        return __aura_get_attribute(this._id, 'value') || '';
+    }
+    set defaultValue(v) {
+        this.setAttribute('value', String(v));
+    }
+    get value() {
+        if (this.tagName === 'TEXTAREA') return this.textContent || '';
+        if (this.tagName === 'SELECT') {
+            let option = this.options.item(this.selectedIndex);
+            return option ? option.value : '';
+        }
+        if (this.tagName === 'OPTION') {
+            let attr = __aura_get_attribute(this._id, 'value');
+            return attr !== null ? attr : this.textContent;
+        }
+        return __aura_get_attribute(this._id, 'value') || '';
+    }
+    set value(v) {
+        let value = String(v);
+        if (this.tagName === 'TEXTAREA') {
+            this.textContent = value;
+            this.setAttribute('value', value);
+            return;
+        }
+        if (this.tagName === 'SELECT') {
+            let options = Array.from(this.options);
+            let matched = false;
+            for (let i = 0; i < options.length; i++) {
+                let selected = !matched && options[i].value === value;
+                options[i].selected = selected;
+                matched = matched || selected;
+            }
+            return;
+        }
+        this.setAttribute('value', value);
+    }
     get checked() { return __aura_has_attribute(this._id, 'checked'); }
     set checked(v) {
-        if (v) __aura_set_attribute(this._id, 'checked', 'checked');
-        else __aura_remove_attribute(this._id, 'checked');
+        let checked = !!v;
+        if (checked && this.type === 'radio' && this.name) {
+            let root = this.form || document;
+            let radios = root.querySelectorAll('input');
+            for (let i = 0; i < radios.length; i++) {
+                let radio = radios.item(i);
+                if (radio !== this && radio.type === 'radio' && radio.name === this.name) {
+                    radio.removeAttribute('checked');
+                }
+            }
+        }
+        if (checked) this.setAttribute('checked', 'checked');
+        else this.removeAttribute('checked');
     }
+    get defaultChecked() { return this.checked; }
+    set defaultChecked(v) { this.checked = v; }
     get disabled() { return __aura_has_attribute(this._id, 'disabled'); }
     set disabled(v) {
-        if (v) __aura_set_attribute(this._id, 'disabled', 'disabled');
-        else __aura_remove_attribute(this._id, 'disabled');
+        if (v) this.setAttribute('disabled', 'disabled');
+        else this.removeAttribute('disabled');
     }
     get href() { return __aura_get_attribute(this._id, 'href') || ''; }
     set href(v) { __aura_set_attribute(this._id, 'href', String(v)); }
@@ -1386,10 +1449,53 @@ class Element extends Node {
     set type(v) { __aura_set_attribute(this._id, 'type', String(v)); }
     get name() { return __aura_get_attribute(this._id, 'name') || ''; }
     set name(v) { __aura_set_attribute(this._id, 'name', String(v)); }
-    // Form select stubs
-    get selectedIndex() { return -1; }
-    set selectedIndex(v) {}
-    get options() { return new NodeList([]); }
+    get options() {
+        if (this.tagName !== 'SELECT') return new NodeList([]);
+        return this.querySelectorAll('option');
+    }
+    get selectedIndex() {
+        if (this.tagName !== 'SELECT') return -1;
+        let options = Array.from(this.options);
+        for (let i = 0; i < options.length; i++) {
+            if (options[i].selected) return i;
+        }
+        return options.length > 0 ? 0 : -1;
+    }
+    set selectedIndex(v) {
+        if (this.tagName !== 'SELECT') return;
+        let index = Number(v);
+        let options = Array.from(this.options);
+        for (let i = 0; i < options.length; i++) {
+            options[i].selected = i === index;
+        }
+    }
+    get selected() {
+        if (this.tagName !== 'OPTION') return false;
+        return __aura_has_attribute(this._id, 'selected');
+    }
+    set selected(v) {
+        if (this.tagName !== 'OPTION') return;
+        if (v) {
+            let select = this.parentElement;
+            while (select && select.tagName !== 'SELECT') select = select.parentElement;
+            if (select && !select.multiple) {
+                let options = Array.from(select.options);
+                for (let i = 0; i < options.length; i++) {
+                    if (options[i] !== this) options[i].removeAttribute('selected');
+                }
+            }
+            this.setAttribute('selected', 'selected');
+        } else {
+            this.removeAttribute('selected');
+        }
+    }
+    get defaultSelected() { return this.selected; }
+    set defaultSelected(v) { this.selected = v; }
+    get multiple() { return __aura_has_attribute(this._id, 'multiple'); }
+    set multiple(v) {
+        if (v) this.setAttribute('multiple', 'multiple');
+        else this.removeAttribute('multiple');
+    }
     get offsetWidth() { return this._layoutMetrics().width; }
     get offsetHeight() { return this._layoutMetrics().height; }
     get offsetTop() { return this._layoutMetrics().top; }


### PR DESCRIPTION
## Summary
- improve input, textarea, checkbox/radio, select, and option JS state parity
- add form/defaultValue/defaultChecked/defaultSelected/options/selectedIndex behavior for supported controls
- connect BrowserEngine typing to focused text-like controls and dispatch input/change events

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_form_ -- --nocapture
- cargo test -q test_type_text_updates_focused_input_dom_state_and_events -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #175