### PR TITLE
feat(dom): add ShadowRoot model

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -2946,6 +2946,72 @@ mod tests {
     }
 
     #[test]
+    fn test_shadow_root_is_fragment_backed_and_scoped_from_document_queries() {
+        let mut rt = make_runtime("<html><body><div id='host'></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var host = document.getElementById('host');
+                var shadow = host.attachShadow({ mode: 'open' });
+                shadow.innerHTML = '<span id="inside">shadow</span>';
+                return [
+                    shadow instanceof ShadowRoot,
+                    shadow instanceof DocumentFragment,
+                    shadow.nodeType,
+                    shadow.host === host,
+                    host.shadowRoot === shadow,
+                    shadow.getElementById('inside').textContent,
+                    document.getElementById('inside') === null,
+                    document.querySelector('#inside') === null
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:true:11:true:true:shadow:true:true");
+    }
+
+    #[test]
+    fn test_closed_shadow_root_and_duplicate_attach_semantics() {
+        let mut rt = make_runtime("<html><body><div id='host'></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var host = document.getElementById('host');
+                var shadow = host.attachShadow({ mode: 'closed' });
+                var duplicate = 'none';
+                try { host.attachShadow({ mode: 'open' }); } catch (e) { duplicate = 'threw'; }
+                return [
+                    shadow instanceof ShadowRoot,
+                    shadow.mode,
+                    shadow.host === host,
+                    host.shadowRoot === null,
+                    duplicate
+                ].join(':');
+            })()
+        "#);
+        assert_eq!(result, "true:closed:true:true:threw");
+    }
+
+    #[test]
+    fn test_shadow_dom_event_path_crosses_shadow_root_to_host() {
+        let mut rt = make_runtime("<html><body><div id='host'></div></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                var host = document.getElementById('host');
+                var shadow = host.attachShadow({ mode: 'open' });
+                shadow.innerHTML = '<button id="btn">go</button>';
+                var btn = shadow.getElementById('btn');
+                var seen = [];
+                host.addEventListener('click', function(e) {
+                    seen = e.composedPath().map(function(node) {
+                        return node.id || (node instanceof ShadowRoot ? '#shadow-root' : node.nodeName || 'window');
+                    });
+                });
+                btn.dispatchEvent(new Event('click', { bubbles: true, composed: true }));
+                return seen.join('>');
+            })()
+        "#);
+        assert_eq!(result, "btn>#shadow-root>host>BODY>HTML>#document>window");
+    }
+
+    #[test]
     fn test_add_event_listener_fires() {
         let mut rt = make_runtime("<html><body><button id='btn'>click</button></body></html>");
         eval(&mut rt, "var clicked = false; var btn = document.getElementById('btn'); btn.addEventListener('click', function() { clicked = true; });");

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -1515,16 +1515,18 @@ class Element extends Node {
     getAttributeNS(ns, name) { return this.getAttribute(name); }
     removeAttributeNS(ns, name) { this.removeAttribute(name); }
     hasAttributeNS(ns, name) { return this.hasAttribute(name); }
-    // attachShadow stub
     attachShadow(options) {
-        var host = this;
-        var shadow = document.createElement('div');
-        shadow._isShadowRoot = true;
-        shadow.host = host;
-        host._shadowRoot = shadow;
-        return shadow;
+        if (this._shadowRoot) throw new Error('Shadow root already attached');
+        let mode = options && options.mode === 'closed' ? 'closed' : 'open';
+        let fragmentId = __aura_create_document_fragment();
+        let root = new ShadowRoot(fragmentId, this, mode);
+        __node_registry.set(fragmentId, root);
+        this._shadowRoot = root;
+        return root;
     }
-    get shadowRoot() { return this._shadowRoot || null; }
+    get shadowRoot() {
+        return this._shadowRoot && this._shadowRoot.mode === 'open' ? this._shadowRoot : null;
+    }
     // dispatchEvent is inherited from EventTarget; no override needed
     // animate stub
     animate(keyframes, options) {
@@ -1642,6 +1644,47 @@ class DocumentFragment extends Node {
     }
     get nodeName() {
         return '#document-fragment';
+    }
+    querySelector(selector) {
+        let nid = __aura_query_selector(this._id, selector);
+        if (!nid) return null;
+        let info = __aura_get_node_info(nid);
+        return info ? __get_or_create_node(nid, info.tag, info.id, info.kind) : __get_or_create_node(nid);
+    }
+    querySelectorAll(selector) {
+        let nids_json = __aura_query_selector_all(this._id, selector);
+        let nids = JSON.parse(nids_json);
+        return new NodeList(nids.map(nid => {
+            let info = __aura_get_node_info(nid);
+            return __get_or_create_node(nid, info ? info.tag : null, info ? info.id : null, info ? info.kind : null);
+        }).map(el => el._id));
+    }
+    getElementById(id) {
+        let matches = this.querySelectorAll('#' + String(id));
+        return matches.item(0);
+    }
+    get innerHTML() {
+        return __aura_get_inner_html(this._id);
+    }
+    set innerHTML(val) {
+        let oldChildren = Array.from(this.childNodes || []);
+        __aura_set_inner_html(this._id, String(val));
+        __aura_child_list_mutation(this, Array.from(this.childNodes || []), oldChildren, null, null);
+    }
+}
+
+class ShadowRoot extends DocumentFragment {
+    constructor(id, host, mode) {
+        super(id);
+        this.host = host;
+        this.mode = mode === 'closed' ? 'closed' : 'open';
+        this._isShadowRoot = true;
+    }
+    get parentNode() {
+        return this.host;
+    }
+    get parentElement() {
+        return this.host;
     }
 }
 
@@ -2476,6 +2519,7 @@ window.Text = TextNode;
 window.Comment = Comment;
 window.DocumentType = DocumentType;
 window.DocumentFragment = DocumentFragment;
+window.ShadowRoot = ShadowRoot;
 window.NodeList = NodeList;
 window.HTMLCollection = HTMLCollection;
 window.NodeFilter = NodeFilter;


### PR DESCRIPTION
## Summary
- replace div-backed attachShadow placeholder with a ShadowRoot backed by a document fragment
- add open/closed shadowRoot semantics, host/mode relationships, and duplicate attach protection
- add scoped query/serialization support on document fragments and shadow roots
- make supported event paths cross shadow root to host

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_shadow -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #174