### PR TITLE
feat(js): add history traversal events

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -3750,6 +3750,40 @@ mod tests {
     }
 
     #[test]
+    fn test_history_back_forward_go_dispatches_navigation_events() {
+        let url = url::Url::parse("https://example.com/start#zero").unwrap();
+        let dom = crate::dom::parse_html("<html><body></body></html>");
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
+
+        let result = eval(&mut rt, r#"
+            (function() {
+                var events = [];
+                window.addEventListener('popstate', function(e) {
+                    events.push('pop:' + JSON.stringify(e.state));
+                });
+                window.addEventListener('hashchange', function(e) {
+                    events.push('hash:' + e.oldURL + '>' + e.newURL);
+                });
+                history.pushState({page: 1}, '', '/one#same');
+                history.pushState({page: 2}, '', '/two#next');
+                history.back();
+                var afterBack = [location.pathname, location.hash, JSON.stringify(history.state)].join('|');
+                history.forward();
+                var afterForward = [location.pathname, location.hash, JSON.stringify(history.state)].join('|');
+                history.go(-2);
+                var afterGo = [location.pathname, location.hash, history.state === null].join('|');
+                history.go(99);
+                return [afterBack, afterForward, afterGo, events.join(';'), history.length].join('||');
+            })()
+        "#);
+
+        assert_eq!(
+            result,
+            "/one|#same|{\"page\":1}||/two|#next|{\"page\":2}||/start|#zero|true||pop:{\"page\":1};hash:https://example.com/two#next>https://example.com/one#same;pop:{\"page\":2};hash:https://example.com/one#same>https://example.com/two#next;pop:null;hash:https://example.com/two#next>https://example.com/start#zero||3"
+        );
+    }
+
+    #[test]
     fn test_new_url_relative_resolution() {
         let mut rt = make_runtime("<html><body></body></html>");
         // Relative path '/x' against base with port

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -1952,8 +1952,31 @@ window.history = {
     length: 1,
     state: null,
     _entries: [location.href],
+    _states: [null],
     _index: 0,
+    _ensureCurrentEntry: function() {
+        if (this._entries.length === 1 && this._index === 0 && this._entries[0] !== location.href) {
+            this._entries[0] = location.href;
+        }
+    },
+    _dispatchNavigationEvents: function(oldURL, oldHash, newURL, newHash) {
+        window.dispatchEvent(new PopStateEvent('popstate', { state: this.state }));
+        if (oldHash !== newHash) {
+            window.dispatchEvent(new HashChangeEvent('hashchange', { oldURL, newURL }));
+        }
+    },
+    _traverseTo: function(index) {
+        this._ensureCurrentEntry();
+        if (index < 0 || index >= this._entries.length || index === this._index) return;
+        let oldURL = location.href;
+        let oldHash = location.hash;
+        this._index = index;
+        this.state = this._states[this._index];
+        __aura_apply_location_href(this._entries[this._index]);
+        this._dispatchNavigationEvents(oldURL, oldHash, location.href, location.hash);
+    },
     pushState: function(state, title, url) {
+        this._ensureCurrentEntry();
         this.state = state;
         var nextHref = location.href;
         if (url !== undefined && url !== null) {
@@ -1965,11 +1988,14 @@ window.history = {
             __aura_apply_location_href(nextHref);
         }
         this._entries = this._entries.slice(0, this._index + 1);
+        this._states = this._states.slice(0, this._index + 1);
         this._entries.push(nextHref);
+        this._states.push(state);
         this._index = this._entries.length - 1;
         this.length = this._entries.length;
     },
     replaceState: function(state, title, url) {
+        this._ensureCurrentEntry();
         this.state = state;
         if (url !== undefined && url !== null) {
             var resolved;
@@ -1982,10 +2008,16 @@ window.history = {
                 this._entries[this._index] = location.href;
             }
         }
+        this._states[this._index] = state;
     },
-    back: function() {},
-    forward: function() {},
-    go: function() {},
+    back: function() { this.go(-1); },
+    forward: function() { this.go(1); },
+    go: function(delta) {
+        let step = delta === undefined ? 0 : Number(delta);
+        if (!Number.isFinite(step)) step = 0;
+        if (step === 0) return;
+        this._traverseTo(this._index + Math.trunc(step));
+    },
 };
 
 // -- performance -------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add state-backed history entries for traversal
- implement history.back, history.forward, and history.go
- dispatch popstate and hashchange during supported traversal
- keep location/history state coherent

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_history_ -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #181