### PR TITLE
feat(js): add document cookie jar

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -3809,13 +3809,63 @@ mod tests {
     }
 
     #[test]
-    fn test_document_cookie_empty_string() {
-        let mut rt = make_runtime("<html><body></body></html>");
-        let cookie = eval(&mut rt, "document.cookie");
-        assert_eq!(cookie, "", "Expected empty cookie string");
-        // Writing should not throw
-        let ok = eval(&mut rt, "(function() { try { document.cookie = 'test=1'; return 'ok'; } catch(e) { return 'err'; } })()");
-        assert_eq!(ok, "ok");
+    fn test_document_cookie_get_set_and_replace() {
+        let url = url::Url::parse("https://example.com/app/page.html").unwrap();
+        let dom = crate::dom::parse_html("<html><body></body></html>");
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
+
+        let result = eval(&mut rt, r#"
+            (function() {
+                document.cookie = 'theme=light';
+                document.cookie = 'session=abc; Path=/app';
+                var first = document.cookie;
+                document.cookie = 'theme=dark';
+                return [
+                    navigator.cookieEnabled,
+                    first,
+                    document.cookie
+                ].join('|');
+            })()
+        "#);
+
+        assert_eq!(
+            result,
+            "true|theme=light; session=abc|session=abc; theme=dark"
+        );
+    }
+
+    #[test]
+    fn test_document_cookie_scope_and_expiry_semantics() {
+        let url = url::Url::parse("https://sub.example.com/app/page.html").unwrap();
+        let dom = crate::dom::parse_html("<html><body></body></html>");
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
+
+        let result = eval(&mut rt, r#"
+            (function() {
+                document.cookie = 'root=1; Domain=example.com; Path=/';
+                document.cookie = 'app=1; Path=/app';
+                document.cookie = 'other=1; Path=/other';
+                document.cookie = 'bad=1; Domain=evil.example; Path=/';
+                document.cookie = 'secure=1; Secure; Path=/';
+                var before = document.cookie;
+
+                location.pathname = '/other/index.html';
+                var otherPath = document.cookie;
+
+                document.cookie = 'root=gone; Domain=example.com; Path=/; Max-Age=0';
+                var afterDelete = document.cookie;
+
+                location.protocol = 'http:';
+                var afterHttp = document.cookie;
+
+                return [before, otherPath, afterDelete, afterHttp].join('|');
+            })()
+        "#);
+
+        assert_eq!(
+            result,
+            "root=1; app=1; secure=1|root=1; other=1; secure=1|other=1; secure=1|other=1"
+        );
     }
 
     #[test]

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -1906,7 +1906,7 @@ var navigator = {
     language: 'en-US',
     languages: ['en-US', 'en'],
     platform: 'Linux x86_64',
-    cookieEnabled: false,
+    cookieEnabled: true,
     onLine: true,
     hardwareConcurrency: 4,
     maxTouchPoints: 0,
@@ -2040,10 +2040,138 @@ window.performance = {
     timeOrigin: Date.now(),
 };
 
-// -- document.cookie (stub, read-only empty string) --------------------------
+// -- document.cookie ----------------------------------------------------------
+var __aura_cookie_jar = [];
+
+function __aura_cookie_hostname() {
+    return (location.hostname || '').toLowerCase();
+}
+
+function __aura_cookie_pathname() {
+    return location.pathname || '/';
+}
+
+function __aura_cookie_default_path() {
+    let path = __aura_cookie_pathname();
+    if (!path || path[0] !== '/') return '/';
+    let lastSlash = path.lastIndexOf('/');
+    if (lastSlash <= 0) return '/';
+    return path.slice(0, lastSlash);
+}
+
+function __aura_cookie_domain_match(host, domain, hostOnly) {
+    host = String(host || '').toLowerCase();
+    domain = String(domain || '').toLowerCase();
+    if (hostOnly) return host === domain;
+    return host === domain || host.endsWith('.' + domain);
+}
+
+function __aura_cookie_path_match(requestPath, cookiePath) {
+    requestPath = requestPath || '/';
+    cookiePath = cookiePath || '/';
+    if (requestPath === cookiePath) return true;
+    if (!requestPath.startsWith(cookiePath)) return false;
+    return cookiePath.endsWith('/') || requestPath[cookiePath.length] === '/';
+}
+
+function __aura_cookie_is_expired(cookie, now) {
+    return cookie.expires !== null && cookie.expires <= now;
+}
+
+function __aura_cookie_prune() {
+    let now = Date.now();
+    __aura_cookie_jar = __aura_cookie_jar.filter(cookie => !__aura_cookie_is_expired(cookie, now));
+}
+
+function __aura_cookie_visible(cookie) {
+    return !cookie.httpOnly
+        && (!cookie.secure || location.protocol === 'https:')
+        && __aura_cookie_domain_match(__aura_cookie_hostname(), cookie.domain, cookie.hostOnly)
+        && __aura_cookie_path_match(__aura_cookie_pathname(), cookie.path);
+}
+
+function __aura_cookie_parse_expiry(value) {
+    let time = Date.parse(value);
+    return Number.isNaN(time) ? null : time;
+}
+
 Object.defineProperty(document, 'cookie', {
-    get: function() { return ''; },
-    set: function(val) { /* stub: ignore cookie writes */ },
+    get: function() {
+        __aura_cookie_prune();
+        return __aura_cookie_jar
+            .filter(__aura_cookie_visible)
+            .map(cookie => cookie.name + '=' + cookie.value)
+            .join('; ');
+    },
+    set: function(val) {
+        let input = String(val == null ? '' : val);
+        let parts = input.split(';');
+        let pair = parts.shift();
+        if (!pair) return;
+
+        let eq = pair.indexOf('=');
+        if (eq <= 0) return;
+
+        let name = pair.slice(0, eq).trim();
+        if (!name || /[\x00-\x20\x7f()<>@,;:\\"\/\[\]?={}]/.test(name)) return;
+
+        let host = __aura_cookie_hostname();
+        if (!host) return;
+
+        let value = pair.slice(eq + 1).trim();
+        let cookie = {
+            name: name,
+            value: value,
+            domain: host,
+            hostOnly: true,
+            path: __aura_cookie_default_path(),
+            expires: null,
+            secure: false,
+            sameSite: '',
+            httpOnly: false,
+        };
+
+        for (let attr of parts) {
+            let trimmed = attr.trim();
+            if (!trimmed) continue;
+            let attrEq = trimmed.indexOf('=');
+            let attrName = (attrEq >= 0 ? trimmed.slice(0, attrEq) : trimmed).trim().toLowerCase();
+            let attrValue = attrEq >= 0 ? trimmed.slice(attrEq + 1).trim() : '';
+
+            if (attrName === 'domain') {
+                let domain = attrValue.toLowerCase().replace(/^\./, '');
+                if (domain && __aura_cookie_domain_match(host, domain, false)) {
+                    cookie.domain = domain;
+                    cookie.hostOnly = false;
+                } else {
+                    return;
+                }
+            } else if (attrName === 'path') {
+                cookie.path = attrValue && attrValue[0] === '/' ? attrValue : '/';
+            } else if (attrName === 'expires') {
+                let expires = __aura_cookie_parse_expiry(attrValue);
+                if (expires !== null) cookie.expires = expires;
+            } else if (attrName === 'max-age') {
+                let seconds = Number(attrValue);
+                if (Number.isFinite(seconds)) cookie.expires = Date.now() + Math.trunc(seconds) * 1000;
+            } else if (attrName === 'secure') {
+                cookie.secure = true;
+            } else if (attrName === 'samesite') {
+                cookie.sameSite = attrValue;
+            }
+        }
+
+        __aura_cookie_jar = __aura_cookie_jar.filter(existing =>
+            !(existing.name === cookie.name
+                && existing.domain === cookie.domain
+                && existing.path === cookie.path
+                && existing.hostOnly === cookie.hostOnly)
+        );
+
+        if (!__aura_cookie_is_expired(cookie, Date.now())) {
+            __aura_cookie_jar.push(cookie);
+        }
+    },
     configurable: true,
 });
 


### PR DESCRIPTION
## Summary
- replace the empty document.cookie stub with an in-memory cookie jar
- support cookie set/get, replacement, path/domain/secure visibility, expiry, and Max-Age deletion
- expose navigator.cookieEnabled as true

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_document_cookie -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #179