### PR TITLE
feat(js): complete fetch api surface

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -586,8 +586,11 @@ impl JsRuntime {
         // Register native __aura_fetch
         let aura_fetch = NativeFunction::from_copy_closure(|_this, args, _context| {
             let url_str = args.get(0).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
-            let resolve = args.get(1).cloned().unwrap_or(JsValue::undefined());
-            let reject = args.get(2).cloned().unwrap_or(JsValue::undefined());
+            let method_str = args.get(1).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_else(|| "GET".to_string());
+            let headers_json = args.get(2).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_else(|| "{}".to_string());
+            let body = args.get(3).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let resolve = args.get(4).cloned().unwrap_or(JsValue::undefined());
+            let reject = args.get(5).cloned().unwrap_or(JsValue::undefined());
 
             let base_url = CURRENT_ORIGIN.with(|o| (*o.borrow()).clone());
             let target_url = if let Some(base) = base_url.as_ref() {
@@ -628,14 +631,29 @@ impl JsRuntime {
 
                     std::thread::spawn(move || {
                         let client = reqwest::blocking::Client::new();
-                        let mut req = client.get(target_url.clone());
+                        let method = reqwest::Method::from_bytes(method_str.as_bytes()).unwrap_or(reqwest::Method::GET);
+                        let mut req = client.request(method.clone(), target_url.clone());
                         if is_cross_origin {
                             req = req.header("Origin", origin_str.clone());
+                        }
+                        if let Ok(headers) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&headers_json) {
+                            for (name, value) in headers {
+                                if let Some(value_str) = value.as_str() {
+                                    req = req.header(name.as_str(), value_str);
+                                }
+                            }
+                        }
+                        if method != reqwest::Method::GET && method != reqwest::Method::HEAD && !body.is_empty() {
+                            req = req.body(body.clone());
                         }
 
                         let res = req.send();
                         match res {
                             Ok(response) => {
+                                let response_url = response.url().to_string();
+                                let status = response.status().as_u16();
+                                let status_text = response.status().canonical_reason().unwrap_or("").to_string();
+
                                 // CORS Check
                                 if is_cross_origin {
                                     let acao = response.headers().get("access-control-allow-origin")
@@ -658,26 +676,32 @@ impl JsRuntime {
                                     }
                                 }
 
+                                let mut headers = serde_json::Map::new();
+                                for (name, value) in response.headers().iter() {
+                                    if let Ok(value_str) = value.to_str() {
+                                        headers.insert(name.as_str().to_string(), serde_json::Value::String(value_str.to_string()));
+                                    }
+                                }
                                 let body = response.text().unwrap_or_default();
+                                let payload = serde_json::json!({
+                                    "url": response_url,
+                                    "status": status,
+                                    "statusText": status_text,
+                                    "ok": (200..=299).contains(&status),
+                                    "headers": headers,
+                                    "body": body,
+                                    "type": "basic",
+                                    "redirected": false
+                                });
+                                let payload_js = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
                                 let _ = sender_clone.send(Box::new(move |ctx| {
                                     let (resolve, _) = FETCH_REGISTRY.with(|reg| reg.borrow_mut().remove(&fetch_id).unwrap());
-                                    FETCH_BODY_REGISTRY.with(|reg| reg.borrow_mut().insert(fetch_id, body));
                                     
                                     if let Some(obj) = resolve.as_object() {
-                                        let res_obj_val = ctx.eval(Source::from_bytes(b"({})")).unwrap();
-                                        let res_obj = res_obj_val.as_object().unwrap();
-                                        
-                                        let text_fn = NativeFunction::from_copy_closure(move |_, _, _| {
-                                            let body = FETCH_BODY_REGISTRY.with(|reg| reg.borrow_mut().remove(&fetch_id).unwrap_or_default());
-                                            Ok(JsValue::from(js_string!(body)))
-                                        });
-                                        
-                                        ctx.register_global_callable(js_string!("__aura_temp_text"), 0, text_fn).unwrap();
-                                        let text_fn_obj = ctx.eval(Source::from_bytes(b"__aura_temp_text")).unwrap();
-                                        let _ = ctx.eval(Source::from_bytes(b"delete globalThis.__aura_temp_text"));
-                                        
-                                        res_obj.set(js_string!("text"), text_fn_obj, false, ctx).unwrap();
-                                        let _ = obj.call(&JsValue::undefined(), &[res_obj_val], ctx);
+                                        let script = format!("__aura_make_fetch_response({})", payload_js);
+                                        if let Ok(res_obj_val) = ctx.eval(Source::from_bytes(script.as_bytes())) {
+                                            let _ = obj.call(&JsValue::undefined(), &[res_obj_val], ctx);
+                                        }
                                     }
                                 }));
                             }
@@ -696,7 +720,7 @@ impl JsRuntime {
             });
             Ok(JsValue::undefined())
         });
-        context.register_global_callable(js_string!("__aura_fetch"), 3, aura_fetch).unwrap();
+        context.register_global_callable(js_string!("__aura_fetch"), 6, aura_fetch).unwrap();
 
         // ── DOM Query APIs ────────────────────────────────────────────────────
 
@@ -4134,6 +4158,61 @@ mod tests {
         let mut rt = make_runtime("<html><body></body></html>");
         let result = eval(&mut rt, "(function() { var ctrl = new AbortController(); ctrl.abort(); return ctrl.signal.aborted ? 'aborted' : 'not'; })()");
         assert_eq!(result, "aborted");
+    }
+
+    #[test]
+    fn test_fetch_headers_request_response_surface() {
+        let url = url::Url::parse("https://example.com/app/index.html").unwrap();
+        let dom = crate::dom::parse_html("<html><body></body></html>");
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
+
+        let result = eval(&mut rt, r#"
+            (function() {
+                var headers = new Headers([['X-Test', 'one']]);
+                headers.append('x-test', 'two');
+                headers.set('Content-Type', 'application/json');
+
+                var request = new Request('/api', {
+                    method: 'post',
+                    headers: headers,
+                    body: JSON.stringify({ok: true}),
+                    credentials: 'include'
+                });
+                var requestClone = request.clone();
+
+                var response = Response.json({ok: true}, { status: 201, headers: { 'X-Reply': 'yes' } });
+                var responseClone = response.clone();
+
+                var getBodyRejected = false;
+                try {
+                    new Request('/bad', { method: 'GET', body: 'nope' });
+                } catch (e) {
+                    getBodyRejected = true;
+                }
+
+                return [
+                    headers.get('X-TEST'),
+                    Array.from(headers.keys()).join(','),
+                    request.url,
+                    request.method,
+                    request.headers.get('content-type'),
+                    request.credentials,
+                    requestClone._body,
+                    response.status,
+                    response.ok,
+                    response.headers.get('content-type'),
+                    response.headers.get('x-reply'),
+                    typeof response.text().then,
+                    responseClone.bodyUsed,
+                    getBodyRejected
+                ].join('|');
+            })()
+        "#);
+
+        assert_eq!(
+            result,
+            "one, two|x-test,content-type|https://example.com/api|POST|application/json|include|{\"ok\":true}|201|true|application/json|yes|function|false|true"
+        );
     }
 
     #[test]

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -2319,9 +2319,209 @@ window.setInterval = function(fn, delay) {
 window.clearInterval = function() {};
 
 // -- fetch() -----------------------------------------------------------------
-window.fetch = function(url) {
+class Headers {
+    constructor(init) {
+        this._headers = [];
+        if (init instanceof Headers) {
+            init.forEach((value, name) => this.append(name, value));
+        } else if (Array.isArray(init)) {
+            init.forEach(pair => this.append(pair[0], pair[1]));
+        } else if (init && typeof init === 'object') {
+            Object.keys(init).forEach(name => this.append(name, init[name]));
+        }
+    }
+    _normalizeName(name) {
+        let normalized = String(name).toLowerCase();
+        if (!normalized || /[\x00-\x20\x7f()<>@,;:\\"\/\[\]?={}]/.test(normalized)) {
+            throw new TypeError('Invalid header name');
+        }
+        return normalized;
+    }
+    _normalizeValue(value) {
+        return String(value).trim();
+    }
+    append(name, value) {
+        name = this._normalizeName(name);
+        value = this._normalizeValue(value);
+        let existing = this._headers.find(header => header[0] === name);
+        if (existing) existing[1] += ', ' + value;
+        else this._headers.push([name, value]);
+    }
+    delete(name) {
+        name = this._normalizeName(name);
+        this._headers = this._headers.filter(header => header[0] !== name);
+    }
+    get(name) {
+        name = this._normalizeName(name);
+        let header = this._headers.find(header => header[0] === name);
+        return header ? header[1] : null;
+    }
+    has(name) {
+        name = this._normalizeName(name);
+        return this._headers.some(header => header[0] === name);
+    }
+    set(name, value) {
+        name = this._normalizeName(name);
+        value = this._normalizeValue(value);
+        this.delete(name);
+        this._headers.push([name, value]);
+    }
+    forEach(callback, thisArg) {
+        this._headers.forEach(header => callback.call(thisArg, header[1], header[0], this));
+    }
+    keys() { return this._headers.map(header => header[0])[Symbol.iterator](); }
+    values() { return this._headers.map(header => header[1])[Symbol.iterator](); }
+    entries() { return this._headers.map(header => [header[0], header[1]])[Symbol.iterator](); }
+    [Symbol.iterator]() { return this.entries(); }
+}
+window.Headers = Headers;
+
+function __aura_body_to_string(body) {
+    if (body === undefined || body === null) return '';
+    if (body instanceof URLSearchParams) return body.toString();
+    if (body instanceof Blob) return body._text || '';
+    if (body instanceof FormData) {
+        let params = new URLSearchParams();
+        body.forEach((value, name) => params.append(name, value));
+        return params.toString();
+    }
+    return String(body);
+}
+
+function __aura_encode_headers(headers) {
+    let out = {};
+    headers.forEach((value, name) => { out[name] = value; });
+    return JSON.stringify(out);
+}
+
+function __aura_consumable_body(target, body) {
+    target._body = body === undefined || body === null ? '' : String(body);
+    target.bodyUsed = false;
+    target._consumeBody = function() {
+        if (this.bodyUsed) return Promise.reject(new TypeError('Body has already been used'));
+        this.bodyUsed = true;
+        return Promise.resolve(this._body);
+    };
+    target.text = function() { return this._consumeBody(); };
+    target.json = function() { return this._consumeBody().then(text => JSON.parse(text)); };
+    target.arrayBuffer = function() {
+        return this._consumeBody().then(text => {
+            let buffer = new ArrayBuffer(text.length);
+            let view = new Uint8Array(buffer);
+            for (let i = 0; i < text.length; i++) view[i] = text.charCodeAt(i) & 0xff;
+            return buffer;
+        });
+    };
+    target.blob = function() { return this._consumeBody().then(text => new Blob([text])); };
+}
+
+class Request {
+    constructor(input, init = {}) {
+        if (input instanceof Request) {
+            this.url = input.url;
+            this.method = input.method;
+            this.headers = new Headers(input.headers);
+            this.credentials = input.credentials;
+            this.mode = input.mode;
+            this.cache = input.cache;
+            this.redirect = input.redirect;
+            this.referrer = input.referrer;
+            __aura_consumable_body(this, init.body !== undefined ? __aura_body_to_string(init.body) : input._body);
+        } else {
+            this.url = new URL(String(input), location.href).href;
+            this.method = 'GET';
+            this.headers = new Headers();
+            this.credentials = 'same-origin';
+            this.mode = 'cors';
+            this.cache = 'default';
+            this.redirect = 'follow';
+            this.referrer = 'about:client';
+            __aura_consumable_body(this, '');
+        }
+
+        if (init.method !== undefined) this.method = String(init.method).toUpperCase();
+        if (init.headers !== undefined) this.headers = new Headers(init.headers);
+        if (init.credentials !== undefined) this.credentials = String(init.credentials);
+        if (init.mode !== undefined) this.mode = String(init.mode);
+        if (init.cache !== undefined) this.cache = String(init.cache);
+        if (init.redirect !== undefined) this.redirect = String(init.redirect);
+        if (init.referrer !== undefined) this.referrer = String(init.referrer);
+        if (init.body !== undefined) __aura_consumable_body(this, __aura_body_to_string(init.body));
+
+        if ((this.method === 'GET' || this.method === 'HEAD') && this._body) {
+            throw new TypeError('Request with GET/HEAD method cannot have body');
+        }
+    }
+    clone() {
+        if (this.bodyUsed) throw new TypeError('Body has already been used');
+        return new Request(this);
+    }
+}
+window.Request = Request;
+
+class Response {
+    constructor(body = null, init = {}) {
+        this.status = init.status === undefined ? 200 : Number(init.status);
+        this.statusText = init.statusText === undefined ? '' : String(init.statusText);
+        this.headers = new Headers(init.headers);
+        this.url = init.url || '';
+        this.type = init.type || 'basic';
+        this.redirected = !!init.redirected;
+        this.ok = this.status >= 200 && this.status <= 299;
+        __aura_consumable_body(this, __aura_body_to_string(body));
+    }
+    clone() {
+        if (this.bodyUsed) throw new TypeError('Body has already been used');
+        return new Response(this._body, {
+            status: this.status,
+            statusText: this.statusText,
+            headers: this.headers,
+            url: this.url,
+            type: this.type,
+            redirected: this.redirected,
+        });
+    }
+    static json(data, init = {}) {
+        let headers = new Headers(init.headers);
+        if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+        return new Response(JSON.stringify(data), Object.assign({}, init, { headers }));
+    }
+    static redirect(url, status = 302) {
+        return new Response(null, { status, headers: { location: new URL(String(url), location.href).href } });
+    }
+    static error() {
+        return new Response(null, { status: 0, statusText: '', type: 'error' });
+    }
+}
+window.Response = Response;
+
+function __aura_make_fetch_response(data) {
+    return new Response(data.body || '', {
+        status: data.status || 0,
+        statusText: data.statusText || '',
+        headers: data.headers || {},
+        url: data.url || '',
+        type: data.type || 'basic',
+        redirected: !!data.redirected,
+    });
+}
+
+window.fetch = function(input, init) {
+    let request;
+    try {
+        request = new Request(input, init || {});
+    } catch (e) {
+        return Promise.reject(e);
+    }
     return new Promise((resolve, reject) => {
-        __aura_fetch(url, resolve, reject);
+        __aura_fetch(
+            request.url,
+            request.method,
+            __aura_encode_headers(request.headers),
+            request._body,
+            resolve,
+            reject
+        );
     });
 };
 


### PR DESCRIPTION
## Summary
- add browser-like Headers, Request, and Response classes
- add body readers, cloning, Response helpers, and fetch init normalization
- extend the native fetch bridge with method, headers, body, status, URL, and response headers

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_fetch_headers_request_response_surface -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #177