### PR TITLE
feat(js): implement XMLHttpRequest

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -3941,6 +3941,46 @@ mod tests {
     }
 
     #[test]
+    fn test_xml_http_request_state_headers_and_abort() {
+        let url = url::Url::parse("https://example.com/app/index.html").unwrap();
+        let dom = crate::dom::parse_html("<html><body></body></html>");
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url), None, None, new_console_buffer());
+
+        let result = eval(&mut rt, r#"
+            (function() {
+                var xhr = new XMLHttpRequest();
+                var events = [];
+                xhr.onreadystatechange = function() { events.push('rs:' + xhr.readyState); };
+                xhr.onabort = function() { events.push('abort'); };
+                xhr.onloadend = function() { events.push('end'); };
+                xhr.open('post', '../api', true);
+                xhr.setRequestHeader('X-Test', 'one');
+                xhr.setRequestHeader('x-test', 'two');
+                var opened = [
+                    xhr.readyState,
+                    xhr._method,
+                    xhr._url,
+                    xhr._headers.get('x-test'),
+                    XMLHttpRequest.DONE
+                ].join(',');
+
+                xhr._responseHeaders = new Headers({ 'Content-Type': 'text/plain' });
+                xhr._changeReadyState(xhr.HEADERS_RECEIVED);
+                var responseHeader = xhr.getResponseHeader('content-type');
+                var allHeaders = xhr.getAllResponseHeaders().indexOf('content-type: text/plain') >= 0;
+                xhr.abort();
+
+                return [opened, responseHeader, allHeaders, events.join('|'), xhr.status, xhr.responseText].join('||');
+            })()
+        "#);
+
+        assert_eq!(
+            result,
+            "1,POST,https://example.com/api,one, two,4||text/plain||true||rs:1|rs:2|rs:4|abort|end||0||"
+        );
+    }
+
+    #[test]
     fn test_match_media_returns_object() {
         let mut rt = make_runtime("<html><body></body></html>");
         let result = eval(&mut rt, "(function() { var mm = window.matchMedia('(max-width: 800px)'); return typeof mm.matches; })()");

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -2204,10 +2204,15 @@ window.getComputedStyle = function(el, pseudoElt) {
     });
 };
 
-// -- XMLHttpRequest stub -----------------------------------------------------
+// -- XMLHttpRequest ----------------------------------------------------------
 class XMLHttpRequest extends EventTarget {
     constructor() {
         super();
+        this.UNSENT = 0;
+        this.OPENED = 1;
+        this.HEADERS_RECEIVED = 2;
+        this.LOADING = 3;
+        this.DONE = 4;
         this.readyState = 0;
         this.status = 0;
         this.statusText = '';
@@ -2222,37 +2227,131 @@ class XMLHttpRequest extends EventTarget {
         this.ontimeout = null;
         this.onprogress = null;
         this.onabort = null;
+        this.onloadend = null;
+        this.onloadstart = null;
         this._method = '';
         this._url = '';
-        this._headers = {};
+        this._headers = new Headers();
+        this._responseHeaders = new Headers();
+        this._async = true;
+        this._sent = false;
+        this._aborted = false;
     }
-    open(method, url, async) {
-        this._method = method;
-        this._url = url;
+    _fire(type) {
+        let event = new Event(type);
+        this.dispatchEvent(event);
+    }
+    _changeReadyState(state) {
+        this.readyState = state;
+        this._fire('readystatechange');
+    }
+    open(method, url, async = true, user, password) {
+        this._method = String(method || 'GET').toUpperCase();
+        try {
+            this._url = new URL(String(url), location.href || document.baseURI || 'about:blank').href;
+        } catch (e) {
+            this._url = String(url);
+        }
+        this._async = async !== false;
+        this._headers = new Headers();
+        this._responseHeaders = new Headers();
+        this._sent = false;
+        this._aborted = false;
+        this.status = 0;
+        this.statusText = '';
+        this.responseText = '';
+        this.response = null;
         this.readyState = 1;
+        this._fire('readystatechange');
     }
     send(body) {
-        // Stub: fire error asynchronously
-        var self = this;
-        setTimeout(function() {
-            self.readyState = 4;
-            self.status = 0;
-            if (typeof self.onerror === 'function') self.onerror(new Event('error'));
-            if (typeof self.onreadystatechange === 'function') self.onreadystatechange();
-        }, 0);
+        if (this.readyState !== this.OPENED || this._sent) {
+            throw new Error('XMLHttpRequest is not open');
+        }
+        if (!this._async) {
+            throw new Error('Synchronous XMLHttpRequest is not supported');
+        }
+
+        this._sent = true;
+        this._aborted = false;
+        this._fire('loadstart');
+
+        fetch(this._url, {
+            method: this._method,
+            headers: this._headers,
+            body: body === undefined || body === null ? undefined : body,
+            credentials: this.withCredentials ? 'include' : 'same-origin'
+        }).then(response => {
+            if (this._aborted) return;
+            this.status = response.status;
+            this.statusText = response.statusText;
+            this.responseURL = response.url || this._url;
+            this._responseHeaders = new Headers(response.headers);
+            this._changeReadyState(this.HEADERS_RECEIVED);
+            this._changeReadyState(this.LOADING);
+            return response.text();
+        }).then(text => {
+            if (this._aborted || text === undefined) return;
+            this.responseText = String(text);
+            if (this.responseType === '' || this.responseType === 'text') {
+                this.response = this.responseText;
+            } else if (this.responseType === 'json') {
+                try { this.response = this.responseText ? JSON.parse(this.responseText) : null; }
+                catch (e) { this.response = null; }
+            } else {
+                this.response = this.responseText;
+            }
+            this._changeReadyState(this.DONE);
+            this._fire('load');
+            this._fire('loadend');
+        }).catch(error => {
+            if (this._aborted) return;
+            this.status = 0;
+            this.statusText = '';
+            this.responseText = '';
+            this.response = null;
+            this._changeReadyState(this.DONE);
+            this._fire('error');
+            this._fire('loadend');
+        });
     }
     setRequestHeader(name, value) {
-        this._headers[name] = value;
+        if (this.readyState !== this.OPENED || this._sent) {
+            throw new Error('XMLHttpRequest is not open');
+        }
+        this._headers.append(name, value);
     }
-    getResponseHeader(name) { return null; }
-    getAllResponseHeaders() { return ''; }
+    getResponseHeader(name) {
+        if (this.readyState < this.HEADERS_RECEIVED) return null;
+        return this._responseHeaders.get(name);
+    }
+    getAllResponseHeaders() {
+        if (this.readyState < this.HEADERS_RECEIVED) return '';
+        return Array.from(this._responseHeaders)
+            .map(pair => pair[0] + ': ' + pair[1] + '\r\n')
+            .join('');
+    }
     abort() {
-        this.readyState = 0;
-        if (typeof this.onabort === 'function') this.onabort(new Event('abort'));
+        this._aborted = true;
+        this._sent = false;
+        this.status = 0;
+        this.statusText = '';
+        this.responseText = '';
+        this.response = null;
+        if (this.readyState !== this.UNSENT && this.readyState !== this.DONE) {
+            this._changeReadyState(this.DONE);
+        }
+        this._fire('abort');
+        this._fire('loadend');
     }
     overrideMimeType() {}
 }
 window.XMLHttpRequest = XMLHttpRequest;
+XMLHttpRequest.UNSENT = 0;
+XMLHttpRequest.OPENED = 1;
+XMLHttpRequest.HEADERS_RECEIVED = 2;
+XMLHttpRequest.LOADING = 3;
+XMLHttpRequest.DONE = 4;
 
 // -- window.matchMedia -------------------------------------------------------
 window.matchMedia = function(query) {


### PR DESCRIPTION
## Summary
- replace the XHR error stub with an async fetch-backed state machine
- support open, send, request headers, response headers, readyState transitions, abort, and load/error/loadend events
- expose XHR constants on instances and constructor

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_xml_http_request -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #178