### PR TITLE
feat(js): define dynamic script loading

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -583,6 +583,26 @@ impl JsRuntime {
         });
         context.register_global_callable(js_string!("__aura_resolve_url"), 2, resolve_url).unwrap();
 
+        // Register native __aura_can_execute_script_url
+        let can_execute_script_url = NativeFunction::from_copy_closure(|_this, args, _context| {
+            let url_str = args.get(0).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
+            let base_url = CURRENT_ORIGIN.with(|o| (*o.borrow()).clone());
+            let target_url = if let Some(base) = base_url.as_ref() {
+                base.join(&url_str).unwrap_or_else(|_| Url::parse(&url_str).unwrap_or(base.clone()))
+            } else {
+                Url::parse(&url_str).unwrap_or_else(|_| Url::parse("about:blank").unwrap())
+            };
+            let allowed = CSP_POLICY.with(|p| {
+                if let Some(ref policy) = *p.borrow() {
+                    policy.is_allowed("script-src", &target_url, base_url.as_ref())
+                } else {
+                    true
+                }
+            });
+            Ok(JsValue::from(allowed))
+        });
+        context.register_global_callable(js_string!("__aura_can_execute_script_url"), 1, can_execute_script_url).unwrap();
+
         // Register native __aura_fetch
         let aura_fetch = NativeFunction::from_copy_closure(|_this, args, _context| {
             let url_str = args.get(0).and_then(|v| v.as_string()).map(|s| s.to_std_string_escaped()).unwrap_or_default();
@@ -1427,6 +1447,18 @@ impl JsRuntime {
                 println!("[JS Bootstrap] URL init error: {:?}", e);
             }
         }
+
+        let script_allowed = CSP_POLICY.with(|p| {
+            p.borrow()
+                .as_ref()
+                .map(|policy| policy.allows_inline_script())
+                .unwrap_or(true)
+        });
+        let script_allowed_init = format!(
+            "window.__aura_inline_script_allowed = {};",
+            if script_allowed { "true" } else { "false" }
+        );
+        let _ = context.eval(Source::from_bytes(script_allowed_init.as_bytes()));
 
         Self { context, task_receiver }
     }
@@ -4343,6 +4375,69 @@ mod tests {
             result,
             "one, two|x-test,content-type|https://example.com/api|POST|application/json|include|{\"ok\":true}|201|true|application/json|yes|function|false|true"
         );
+    }
+
+    #[test]
+    fn test_dynamic_inline_script_executes_and_fires_load() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let result = eval(&mut rt, r#"
+            (function() {
+                window.dynamicScriptValue = 0;
+                window.dynamicScriptEvents = [];
+                var script = document.createElement('script');
+                script.text = 'window.dynamicScriptValue = 42;';
+                script.addEventListener('load', function() { window.dynamicScriptEvents.push('load'); });
+                script.addEventListener('error', function() { window.dynamicScriptEvents.push('error'); });
+                document.body.appendChild(script);
+                return window.dynamicScriptValue;
+            })()
+        "#);
+        assert_eq!(result, "42");
+
+        rt.tick(None, None);
+        let events = eval(&mut rt, "window.dynamicScriptEvents.join(',')");
+        assert_eq!(events, "load");
+    }
+
+    #[test]
+    fn test_dynamic_script_csp_and_module_decision() {
+        let dom = crate::dom::parse_html("<html><body></body></html>");
+        let csp = CspPolicy {
+            script_src: vec!["'self'".to_string()],
+            connect_src: vec![],
+        };
+        let mut rt = JsRuntime::new(Some(dom.document), Some(url::Url::parse("https://example.com/").unwrap()), Some(csp), None, new_console_buffer());
+
+        let result = eval(&mut rt, r#"
+            (function() {
+                window.blockedDynamicValue = 0;
+                window.dynamicScriptEvents = [];
+                var inline = document.createElement('script');
+                inline.text = 'window.blockedDynamicValue = 99;';
+                inline.addEventListener('error', function() { window.dynamicScriptEvents.push('inline-error'); });
+                document.body.appendChild(inline);
+
+                var moduleScript = document.createElement('script');
+                moduleScript.type = 'module';
+                moduleScript.text = 'window.blockedDynamicValue = 100;';
+                moduleScript.addEventListener('error', function() { window.dynamicScriptEvents.push('module-error:' + moduleScript._auraModuleUnsupported); });
+                document.body.appendChild(moduleScript);
+
+                return [
+                    window.blockedDynamicValue,
+                    window.__aura_inline_script_allowed,
+                    typeof __aura_can_execute_script_url,
+                    __aura_can_execute_script_url('/app.js'),
+                    __aura_can_execute_script_url('https://cdn.example.net/app.js')
+                ].join('|');
+            })()
+        "#);
+
+        assert_eq!(result, "0|false|function|true|false");
+        rt.tick(None, None);
+        rt.tick(None, None);
+        let events = eval(&mut rt, "window.dynamicScriptEvents.join(',')");
+        assert_eq!(events, "inline-error,module-error:true");
     }
 
     #[test]

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -1075,6 +1075,7 @@ class Node extends EventTarget {
             __aura_append_child(this._id, child._id);
             if (oldParent && oldParent !== this) __aura_child_list_mutation(oldParent, [], [child], oldPrevious, oldNext);
             if (added.length > 0) __aura_child_list_mutation(this, added, [], previous, null);
+            added.forEach(__aura_maybe_run_script);
         }
         return child;
     }
@@ -1098,6 +1099,7 @@ class Node extends EventTarget {
             __aura_insert_before(this._id, newChild._id, refChild ? refChild._id : null);
             if (oldParent && oldParent !== this) __aura_child_list_mutation(oldParent, [], [newChild], oldPrevious, oldNext);
             if (added.length > 0) __aura_child_list_mutation(this, added, [], previous, next);
+            added.forEach(__aura_maybe_run_script);
         }
         return newChild;
     }
@@ -2236,6 +2238,7 @@ window.__aura_environmentNotes = {
     ],
     viewport: 'Fixed 800x600 CSS pixel viewport in the current headless runtime.'
 };
+window.__aura_inline_script_allowed = true;
 
 // -- history -----------------------------------------------------------------
 window.history = {
@@ -2916,6 +2919,65 @@ window.fetch = function(input, init) {
     });
 };
 
+function __aura_script_type(script) {
+    return (script.getAttribute('type') || '').trim().toLowerCase();
+}
+
+function __aura_script_fire(script, type) {
+    __aura_queue_task(() => script.dispatchEvent(new Event(type)));
+}
+
+function __aura_execute_classic_script(script, code) {
+    try {
+        (0, eval)(String(code || ''));
+        __aura_script_fire(script, 'load');
+    } catch (e) {
+        console.error('Script execution error: ' + e);
+        __aura_script_fire(script, 'error');
+    }
+}
+
+function __aura_maybe_run_script(node) {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE || String(node.tagName || '').toLowerCase() !== 'script') return;
+    let script = node;
+    if (script._alreadyStarted) return;
+    script._alreadyStarted = true;
+
+    let type = __aura_script_type(script);
+    if (type && type !== 'text/javascript' && type !== 'application/javascript' && type !== 'classic') {
+        script._auraModuleUnsupported = type === 'module';
+        console.warn(type === 'module'
+            ? 'Module scripts are not supported yet; dynamic module script signaled error.'
+            : 'Unsupported script type skipped: ' + type);
+        __aura_script_fire(script, 'error');
+        return;
+    }
+
+    let src = script.src;
+    if (src) {
+        if (typeof __aura_can_execute_script_url === 'function' && !__aura_can_execute_script_url(src)) {
+            console.warn('CSP blocked dynamic script: ' + src);
+            __aura_script_fire(script, 'error');
+            return;
+        }
+        fetch(src)
+            .then(response => response.ok ? response.text() : Promise.reject(new Error('HTTP ' + response.status)))
+            .then(code => __aura_execute_classic_script(script, code))
+            .catch(error => {
+                console.error('Script load error: ' + error);
+                __aura_script_fire(script, 'error');
+            });
+        return;
+    }
+
+    if (!window.__aura_inline_script_allowed) {
+        console.warn('CSP blocked inline dynamic script');
+        __aura_script_fire(script, 'error');
+        return;
+    }
+    __aura_execute_classic_script(script, script.text || script.textContent || '');
+}
+
 // -- MutationObserver --------------------------------------------------------
 class MutationObserver {
     constructor(callback) {
@@ -3546,9 +3608,21 @@ window.HTMLAnchorElement = HTMLAnchorElement;
 class HTMLScriptElement extends HTMLElement {
     get src() { return __aura_get_attribute(this._id, 'src') || ''; }
     set src(v) { __aura_set_attribute(this._id, 'src', String(v)); }
+    get type() { return __aura_get_attribute(this._id, 'type') || ''; }
+    set type(v) { __aura_set_attribute(this._id, 'type', String(v)); }
+    get text() { return this.textContent; }
+    set text(v) { this.textContent = String(v); }
     get async() { return __aura_has_attribute(this._id, 'async'); }
     set async(v) { if (v) __aura_set_attribute(this._id, 'async', ''); else __aura_remove_attribute(this._id, 'async'); }
     get defer() { return __aura_has_attribute(this._id, 'defer'); }
+    set defer(v) { if (v) __aura_set_attribute(this._id, 'defer', ''); else __aura_remove_attribute(this._id, 'defer'); }
+    get noModule() { return __aura_has_attribute(this._id, 'nomodule'); }
+    set noModule(v) { if (v) __aura_set_attribute(this._id, 'nomodule', ''); else __aura_remove_attribute(this._id, 'nomodule'); }
+    get crossOrigin() { return __aura_get_attribute(this._id, 'crossorigin'); }
+    set crossOrigin(v) {
+        if (v === null || v === undefined) __aura_remove_attribute(this._id, 'crossorigin');
+        else __aura_set_attribute(this._id, 'crossorigin', String(v));
+    }
 }
 window.HTMLScriptElement = HTMLScriptElement;
 


### PR DESCRIPTION
## Summary
- execute dynamically inserted classic inline scripts and signal load/error events
- add external dynamic classic script path through fetch plus CSP script-src checks
- expose script element text/type/defer/noModule/crossOrigin helpers
- make module scripts an explicit unsupported path that signals error for a future split

## Tests
- node --check src/js_bootstrap.js
- cargo test -q test_dynamic_ -- --nocapture
- cargo build --bins
- browser-cli-reviewer: health, navigate https://yunseong.dev, navigate https://google.com

Closes #184