### PR TITLE
feat(js): add ES module loader foundation

### DIFF
--- a/.agents/PRIORITY.md
+++ b/.agents/PRIORITY.md
@@ -48,8 +48,8 @@ Must be done in order — each phase builds on the previous.
 
 | # | Issue | Why this order |
 |---|---|---|
-| #244 | [JS] V8 migration audit and compatibility matrix (in progress by codex:gpt-5) | Foundation. Clarifies stale phase issues and current support gaps. |
-| #245 | [JS] ES module loader foundation | Depends on #244. Needs resolver, fetch, CSP, cache, and V8 module compile path. |
+| #244 ✓ | [JS] V8 migration audit and compatibility matrix | Foundation. Clarifies stale phase issues and current support gaps. |
+| #245 | [JS] ES module loader foundation (in progress by codex:gpt-5) | Depends on #244. Needs resolver, fetch, CSP, cache, and V8 module compile path. |
 | #246 | [JS] ES module graph linking and evaluation | Depends on #245. Needs module graph/link/evaluate before browser semantics. |
 | #247 | [JS] Browser ES module semantics | Depends on #246. Adds import.meta, dynamic import, nomodule, and script lifecycle behavior. |
 | #248 | [JS] Integrate ES modules with DOM mutation, style, and tick | Depends on #247. Modules must affect rendering and async work through the event loop. |

--- a/docs/js-v8-compatibility.md
+++ b/docs/js-v8-compatibility.md
@@ -37,9 +37,9 @@ Remaining work now belongs to `#243` and its leaf issues `#245` through `#249`.
 | URL / URLSearchParams / location | Partial | URL and location now resolve page and relative URLs; long-tail URL standard parity remains incomplete. |
 | localStorage/sessionStorage | Partial | Origin storage exists, but storage event/session behavior is not complete. |
 | Cookies / `document.cookie` | Missing or weak | Real JS-gated sites need a cookie jar and cookie semantics. Follow-up likely needed outside ES modules. |
-| Inline module scripts | Missing | Tracked by `#247`. |
-| External module scripts | Missing | Loader foundation tracked by `#245`; graph evaluation tracked by `#246`. |
-| Static imports | Missing | Tracked by `#246`. |
+| Inline module scripts | Partial | `#245` compiles inline module sources through V8 and caches by synthetic module URL. Browser lifecycle semantics remain `#247`. |
+| External module scripts | Partial | `#245` resolves, CSP-checks, fetches, compiles, and caches external module sources. Graph linking/evaluation remains `#246`. |
+| Static imports | Partial | `#245` reads V8 module requests during compile. Resolver/link/evaluate behavior remains `#246`. |
 | Dynamic `import()` | Missing | Tracked by `#247`. |
 | `import.meta.url` | Missing | Tracked by `#247`. |
 | Top-level await | Missing | Tracked by `#246`. |

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,10 +1,10 @@
+use markup5ever_rcdom;
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::time::Instant;
 use url::Url;
-use rayon::prelude::*;
-use markup5ever_rcdom;
 
-use crate::{dom, css, style, layout, render, js};
+use crate::{css, dom, js, layout, render, style};
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -120,7 +120,10 @@ pub fn page_to_api_response(page: &PageResult, base_url: &Url) -> ApiPageRespons
         .enumerate()
         .map(|(i, (rect, href))| {
             // Match link text by index (same DOM traversal order as collect_links).
-            let text = link_texts.get(i).map(|(_, t)| t.clone()).unwrap_or_default();
+            let text = link_texts
+                .get(i)
+                .map(|(_, t)| t.clone())
+                .unwrap_or_default();
             ApiElement {
                 id: format!("e{}", i),
                 element_type: "link".to_string(),
@@ -129,8 +132,16 @@ pub fn page_to_api_response(page: &PageResult, base_url: &Url) -> ApiPageRespons
                 rect: ApiRect {
                     x: if rect.x.is_finite() { rect.x } else { 0.0 },
                     y: if rect.y.is_finite() { rect.y } else { 0.0 },
-                    w: if rect.width.is_finite() { rect.width } else { 0.0 },
-                    h: if rect.height.is_finite() { rect.height } else { 0.0 },
+                    w: if rect.width.is_finite() {
+                        rect.width
+                    } else {
+                        0.0
+                    },
+                    h: if rect.height.is_finite() {
+                        rect.height
+                    } else {
+                        0.0
+                    },
                 },
             }
         })
@@ -152,8 +163,16 @@ pub fn page_to_api_response(page: &PageResult, base_url: &Url) -> ApiPageRespons
                 rect: ApiRect {
                     x: if rect.x.is_finite() { rect.x } else { 0.0 },
                     y: if rect.y.is_finite() { rect.y } else { 0.0 },
-                    w: if rect.width.is_finite() { rect.width } else { 0.0 },
-                    h: if rect.height.is_finite() { rect.height } else { 0.0 },
+                    w: if rect.width.is_finite() {
+                        rect.width
+                    } else {
+                        0.0
+                    },
+                    h: if rect.height.is_finite() {
+                        rect.height
+                    } else {
+                        0.0
+                    },
                 },
             }
         })
@@ -227,10 +246,29 @@ pub fn markdown_from_html(html: &str) -> String {
                 in_style = false;
             } else if !in_script && !in_style {
                 // Insert newline for block-level tags
-                if matches!(tag_lower, "p" | "br" | "/p" | "div" | "/div"
-                    | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
-                    | "/h1" | "/h2" | "/h3" | "/h4" | "/h5" | "/h6"
-                    | "li" | "/li" | "tr" | "/tr") {
+                if matches!(
+                    tag_lower,
+                    "p" | "br"
+                        | "/p"
+                        | "div"
+                        | "/div"
+                        | "h1"
+                        | "h2"
+                        | "h3"
+                        | "h4"
+                        | "h5"
+                        | "h6"
+                        | "/h1"
+                        | "/h2"
+                        | "/h3"
+                        | "/h4"
+                        | "/h5"
+                        | "/h6"
+                        | "li"
+                        | "/li"
+                        | "tr"
+                        | "/tr"
+                ) {
                     out.push('\n');
                 }
             }
@@ -349,7 +387,9 @@ pub fn extract_form_controls_from_html(html: &str) -> Vec<(String, String)> {
             } else if tag_lower_trimmed == "/script" {
                 in_script = false;
             } else if !in_script {
-                let (verb, _) = tag_lower_trimmed.split_once(' ').unwrap_or((tag_lower_trimmed, ""));
+                let (verb, _) = tag_lower_trimmed
+                    .split_once(' ')
+                    .unwrap_or((tag_lower_trimmed, ""));
                 if matches!(verb, "input" | "textarea" | "select") {
                     // Skip hidden inputs — they are excluded from the layout tree and
                     // must not be included here to keep the index-based zip in sync.
@@ -420,12 +460,14 @@ fn extract_attr(tag: &str, attr_name: &str) -> Option<String> {
             break 'outer;
         }
         tag_byte_offset = tag_off + tag_ch.len_utf8(); // default: past end of tag
-        // Consume the lowercased expansion of `tag_ch` from `lower`.
+                                                       // Consume the lowercased expansion of `tag_ch` from `lower`.
         for lc in tag_ch.to_lowercase() {
             if let Some((_, lc_from_lower)) = lower_chars.next() {
-                debug_assert_eq!(lc, lc_from_lower,
+                debug_assert_eq!(
+                    lc, lc_from_lower,
                     "to_lowercase mismatch: tag_ch={:?} expanded to {:?} but lower had {:?}",
-                    tag_ch, lc, lc_from_lower);
+                    tag_ch, lc, lc_from_lower
+                );
                 lower_consumed += lc.len_utf8();
             }
         }
@@ -448,7 +490,9 @@ fn extract_attr(tag: &str, attr_name: &str) -> Option<String> {
         Some(inner[..end].to_string())
     } else {
         // Unquoted value
-        let end = rest.find(|c: char| c.is_whitespace() || c == '>').unwrap_or(rest.len());
+        let end = rest
+            .find(|c: char| c.is_whitespace() || c == '>')
+            .unwrap_or(rest.len());
         Some(rest[..end].to_string())
     }
 }
@@ -479,7 +523,12 @@ pub fn collect_css_in_order(
     cache: &HashMap<String, String>,
     sources: &mut Vec<CssSource>,
 ) {
-    if let markup5ever_rcdom::NodeData::Element { ref name, ref attrs, .. } = handle.data {
+    if let markup5ever_rcdom::NodeData::Element {
+        ref name,
+        ref attrs,
+        ..
+    } = handle.data
+    {
         let tag = name.local.to_string();
         if tag == "style" {
             let mut inline = String::new();
@@ -580,8 +629,9 @@ pub fn process_html_with_cache(
         println!("  - CSS collect metadata: {:?}", start_collect.elapsed());
 
         // 2. Fetch all remote sources in parallel
-        let fetched_contents: Vec<(String, Option<String>)> =
-            sources.into_par_iter().map(|src| match src {
+        let fetched_contents: Vec<(String, Option<String>)> = sources
+            .into_par_iter()
+            .map(|src| match src {
                 CssSource::Inline(text) => (text, None),
                 CssSource::Remote(url) => {
                     let start_fetch = Instant::now();
@@ -600,7 +650,8 @@ pub fn process_html_with_cache(
                         }
                     }
                 }
-            }).collect();
+            })
+            .collect();
 
         // 3. Assemble and update cache
         let mut final_css = String::new();
@@ -774,10 +825,16 @@ pub fn process_html_with_cache(
     ))
 }
 
-fn collect_layout_metrics(layout_tree: &layout::LayoutBox, out: &mut HashMap<String, js::LayoutMetrics>) {
+fn collect_layout_metrics(
+    layout_tree: &layout::LayoutBox,
+    out: &mut HashMap<String, js::LayoutMetrics>,
+) {
     let mut stack = vec![layout_tree];
     while let Some(layout) = stack.pop() {
-        if matches!(layout.style_node.node.data, markup5ever_rcdom::NodeData::Element { .. }) {
+        if matches!(
+            layout.style_node.node.data,
+            markup5ever_rcdom::NodeData::Element { .. }
+        ) {
             out.insert(
                 js::node_path_key(&layout.style_node.node),
                 js::LayoutMetrics {
@@ -882,7 +939,8 @@ impl BrowserEngine {
         let (page, stylesheet) = result;
         self.last_stylesheet = Some(stylesheet);
         self.last_page = Some(page.clone());
-        self.js_runtime.set_layout_metrics(page.layout_metrics.clone());
+        self.js_runtime
+            .set_layout_metrics(page.layout_metrics.clone());
         self.refresh_after_image_loads(page, width)
     }
 
@@ -1061,7 +1119,10 @@ impl BrowserEngine {
     /// Return the raw HTML source of the last loaded page.
     /// Full DOM serialization is deferred to a follow-up issue.
     pub fn dom_tree(&self) -> String {
-        self.last_page.as_ref().map(|p| p.body.clone()).unwrap_or_default()
+        self.last_page
+            .as_ref()
+            .map(|p| p.body.clone())
+            .unwrap_or_default()
     }
 
     /// Return a summary of the last rendered layout.
@@ -1093,7 +1154,11 @@ impl BrowserEngine {
                 .iter()
                 .filter_map(|c| {
                     let name = c.name.trim().to_string();
-                    if name.is_empty() { None } else { Some(name) }
+                    if name.is_empty() {
+                        None
+                    } else {
+                        Some(name)
+                    }
                 })
                 .collect();
             (base_url, action, control_names)
@@ -1155,22 +1220,74 @@ impl BrowserEngine {
         let console = self.console_buffer.clone();
 
         drop_js_runtime_before_create(&mut self.js_runtime, || {
-            js::JsRuntime::new(Some(document), Some(base_url), policy, Some(metrics), console)
+            js::JsRuntime::new(
+                Some(document),
+                Some(base_url),
+                policy,
+                Some(metrics),
+                console,
+            )
         });
 
-        let scripts = js::extract_scripts_from_dom(&dom.document);
-        let allowed = self
-            .current_csp_policy
-            .as_ref()
-            .map(|p| p.allows_inline_script())
-            .unwrap_or(true);
-
-        if allowed {
-            for script in scripts {
-                self.js_runtime.execute(&script);
+        let scripts = js::extract_script_sources_from_dom(&dom.document, Some(&page.base_url));
+        for script in scripts {
+            match script {
+                js::ScriptSource::InlineClassic(script) => {
+                    let allowed = self
+                        .current_csp_policy
+                        .as_ref()
+                        .map(|p| p.allows_inline_script())
+                        .unwrap_or(true);
+                    if allowed {
+                        self.js_runtime.execute(&script);
+                    } else {
+                        println!("[CSP] Blocked inline script execution");
+                    }
+                }
+                js::ScriptSource::ExternalClassic(url) => {
+                    let allowed = self
+                        .current_csp_policy
+                        .as_ref()
+                        .map(|p| p.is_allowed("script-src", &url, Some(&page.base_url)))
+                        .unwrap_or(true);
+                    if !allowed {
+                        println!("[CSP] Blocked external script execution: {}", url);
+                        continue;
+                    }
+                    match reqwest::blocking::get(url.as_str()).and_then(|response| response.text())
+                    {
+                        Ok(script) => self.js_runtime.execute(&script),
+                        Err(err) => {
+                            println!("[JS] Failed to load external script {}: {}", url, err)
+                        }
+                    }
+                }
+                js::ScriptSource::InlineModule { url, source } => {
+                    let allowed = self
+                        .current_csp_policy
+                        .as_ref()
+                        .map(|p| p.allows_inline_script())
+                        .unwrap_or(true);
+                    if !allowed {
+                        println!("[CSP] Blocked inline module compilation: {}", url);
+                        continue;
+                    }
+                    let outcome = self.js_runtime.compile_module_source(url.clone(), source);
+                    if let Some(error) = outcome.error {
+                        println!("[JS] Failed to compile inline module {}: {}", url, error);
+                    }
+                }
+                js::ScriptSource::ExternalModule(url) => {
+                    let outcome =
+                        self.load_external_module_with(url.clone(), &page.base_url, |module_url| {
+                            reqwest::blocking::get(module_url.as_str())
+                                .and_then(|response| response.text())
+                        });
+                    if let Some(error) = outcome.error {
+                        println!("[JS] Failed to load external module {}: {}", url, error);
+                    }
+                }
             }
-        } else {
-            println!("[CSP] Blocked inline script execution");
         }
 
         let overrides = self.js_runtime.get_style_overrides();
@@ -1178,6 +1295,41 @@ impl BrowserEngine {
             for (id, props) in overrides {
                 self.js_style_overrides.entry(id).or_default().extend(props);
             }
+        }
+    }
+
+    pub fn load_external_module_with<F, E>(
+        &mut self,
+        url: Url,
+        page_base: &Url,
+        fetcher: F,
+    ) -> js::ModuleCompileOutcome
+    where
+        F: FnOnce(&Url) -> Result<String, E>,
+        E: ToString,
+    {
+        let allowed = self
+            .current_csp_policy
+            .as_ref()
+            .map(|p| p.is_allowed("script-src", &url, Some(page_base)))
+            .unwrap_or(true);
+        if !allowed {
+            return js::ModuleCompileOutcome {
+                url,
+                from_cache: false,
+                requests: Vec::new(),
+                error: Some("Blocked by script-src CSP".to_string()),
+            };
+        }
+
+        match fetcher(&url) {
+            Ok(source) => self.js_runtime.compile_module_source(url, source),
+            Err(err) => js::ModuleCompileOutcome {
+                url,
+                from_cache: false,
+                requests: Vec::new(),
+                error: Some(err.to_string()),
+            },
         }
     }
 
@@ -1203,12 +1355,16 @@ impl BrowserEngine {
     /// Advance the JS event loop by one tick.
     /// Returns `true` if a re-render is needed.
     pub fn tick_js(&mut self, timestamp: Option<f64>, deadline: Option<f64>) -> bool {
-        self.js_runtime.tick(Some(timestamp.unwrap_or(0.0)), deadline)
+        self.js_runtime
+            .tick(Some(timestamp.unwrap_or(0.0)), deadline)
     }
 }
 
 #[inline]
-fn drop_js_runtime_before_create(slot: &mut js::JsRuntime, factory: impl FnOnce() -> js::JsRuntime) {
+fn drop_js_runtime_before_create(
+    slot: &mut js::JsRuntime,
+    factory: impl FnOnce() -> js::JsRuntime,
+) {
     // SAFETY: We read the old value, drop it, then write a new value.
     // This satisfies V8's requirement that OwnedIsolate instances must be
     // dropped in reverse creation order. If we used normal assignment
@@ -1317,7 +1473,12 @@ fn run_engine_actor_with_engine(rx: mpsc::Receiver<EngineCmd>, eng: &mut Browser
                 let result = eng.navigate(&url, width);
                 let _ = reply.send(result);
             }
-            EngineCmd::ReRender { hovered_id, focused_id, width, reply } => {
+            EngineCmd::ReRender {
+                hovered_id,
+                focused_id,
+                width,
+                reply,
+            } => {
                 let result = eng.re_render(hovered_id.as_deref(), focused_id.as_deref(), width);
                 let _ = reply.send(result);
             }
@@ -1350,21 +1511,28 @@ fn run_engine_actor_with_engine(rx: mpsc::Receiver<EngineCmd>, eng: &mut Browser
                 let _ = reply.send(eng.computed_style(&selector));
             }
             EngineCmd::GetPage { reply } => {
-                let resp = eng.last_page.as_ref().map(|p| {
-                    page_to_api_response(p, &p.base_url.clone())
-                });
+                let resp = eng
+                    .last_page
+                    .as_ref()
+                    .map(|p| page_to_api_response(p, &p.base_url.clone()));
                 let _ = reply.send(resp);
             }
             EngineCmd::GetElements { reply } => {
-                let elems = eng.last_page.as_ref().map(|p| {
-                    page_to_api_response(p, &p.base_url.clone()).elements
-                }).unwrap_or_default();
+                let elems = eng
+                    .last_page
+                    .as_ref()
+                    .map(|p| page_to_api_response(p, &p.base_url.clone()).elements)
+                    .unwrap_or_default();
                 let _ = reply.send(elems);
             }
             EngineCmd::LoadImage { url, bytes } => {
                 eng.image_cache.insert(url, bytes);
             }
-            EngineCmd::Tick { timestamp, deadline, reply } => {
+            EngineCmd::Tick {
+                timestamp,
+                deadline,
+                reply,
+            } => {
                 let needs = eng.tick_js(Some(timestamp), deadline);
                 let overrides = eng.get_style_overrides();
                 for (id, props) in overrides {
@@ -1407,9 +1575,15 @@ impl EngineHandle {
     pub fn send_navigate(&self, url: String, width: f32) -> Result<PageResult, String> {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.tx
-            .send(EngineCmd::Navigate { url, width, reply: reply_tx })
+            .send(EngineCmd::Navigate {
+                url,
+                width,
+                reply: reply_tx,
+            })
             .map_err(|_| "engine disconnected".to_string())?;
-        reply_rx.recv().map_err(|_| "engine disconnected".to_string())?
+        reply_rx
+            .recv()
+            .map_err(|_| "engine disconnected".to_string())?
     }
 
     pub fn send_re_render(
@@ -1420,9 +1594,16 @@ impl EngineHandle {
     ) -> Result<PageResult, String> {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.tx
-            .send(EngineCmd::ReRender { hovered_id, focused_id, width, reply: reply_tx })
+            .send(EngineCmd::ReRender {
+                hovered_id,
+                focused_id,
+                width,
+                reply: reply_tx,
+            })
             .map_err(|_| "engine disconnected".to_string())?;
-        reply_rx.recv().map_err(|_| "engine disconnected".to_string())?
+        reply_rx
+            .recv()
+            .map_err(|_| "engine disconnected".to_string())?
     }
 
     pub fn send_get_page(&self) -> Option<ApiPageResponse> {
@@ -1445,7 +1626,11 @@ impl EngineHandle {
 
     pub fn send_get_elements(&self) -> Vec<ApiElement> {
         let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::GetElements { reply: reply_tx }).is_err() {
+        if self
+            .tx
+            .send(EngineCmd::GetElements { reply: reply_tx })
+            .is_err()
+        {
             return vec![];
         }
         reply_rx.recv().unwrap_or_default()
@@ -1453,7 +1638,15 @@ impl EngineHandle {
 
     pub fn send_click(&self, x: f32, y: f32) -> Vec<ClickResult> {
         let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::Click { x, y, reply: reply_tx }).is_err() {
+        if self
+            .tx
+            .send(EngineCmd::Click {
+                x,
+                y,
+                reply: reply_tx,
+            })
+            .is_err()
+        {
             return vec![];
         }
         reply_rx.recv().unwrap_or_default()
@@ -1461,7 +1654,14 @@ impl EngineHandle {
 
     pub fn send_evaluate_js(&self, script: String) -> String {
         let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::EvaluateJs { script, reply: reply_tx }).is_err() {
+        if self
+            .tx
+            .send(EngineCmd::EvaluateJs {
+                script,
+                reply: reply_tx,
+            })
+            .is_err()
+        {
             return String::new();
         }
         reply_rx.recv().unwrap_or_default()
@@ -1469,7 +1669,14 @@ impl EngineHandle {
 
     pub fn send_console_eval_result(&self, script: String) -> js::EvalOutcome {
         let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::EvaluateConsole { script, reply: reply_tx }).is_err() {
+        if self
+            .tx
+            .send(EngineCmd::EvaluateConsole {
+                script,
+                reply: reply_tx,
+            })
+            .is_err()
+        {
             return js::EvalOutcome {
                 result: None,
                 error: Some("engine disconnected".to_string()),
@@ -1480,13 +1687,19 @@ impl EngineHandle {
 
     pub fn send_screenshot(&self) -> Option<Vec<u8>> {
         let (reply_tx, reply_rx) = mpsc::channel();
-        self.tx.send(EngineCmd::Screenshot { reply: reply_tx }).ok()?;
+        self.tx
+            .send(EngineCmd::Screenshot { reply: reply_tx })
+            .ok()?;
         reply_rx.recv().ok()?
     }
 
     pub fn send_dom_tree(&self) -> String {
         let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::DomTree { reply: reply_tx }).is_err() {
+        if self
+            .tx
+            .send(EngineCmd::DomTree { reply: reply_tx })
+            .is_err()
+        {
             return String::new();
         }
         reply_rx.recv().unwrap_or_default()
@@ -1494,7 +1707,11 @@ impl EngineHandle {
 
     pub fn send_layout_tree(&self) -> String {
         let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::LayoutTree { reply: reply_tx }).is_err() {
+        if self
+            .tx
+            .send(EngineCmd::LayoutTree { reply: reply_tx })
+            .is_err()
+        {
             return String::new();
         }
         reply_rx.recv().unwrap_or_default()
@@ -1502,8 +1719,12 @@ impl EngineHandle {
 
     pub fn send_computed_style(&self, selector: String) -> HashMap<String, String> {
         let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx
-            .send(EngineCmd::ComputedStyle { selector, reply: reply_tx })
+        if self
+            .tx
+            .send(EngineCmd::ComputedStyle {
+                selector,
+                reply: reply_tx,
+            })
             .is_err()
         {
             return HashMap::new();
@@ -1513,7 +1734,15 @@ impl EngineHandle {
 
     pub fn send_tick(&self, timestamp: f64, deadline: Option<f64>) -> bool {
         let (reply_tx, reply_rx) = mpsc::channel();
-        if self.tx.send(EngineCmd::Tick { timestamp, deadline, reply: reply_tx }).is_err() {
+        if self
+            .tx
+            .send(EngineCmd::Tick {
+                timestamp,
+                deadline,
+                reply: reply_tx,
+            })
+            .is_err()
+        {
             return false;
         }
         reply_rx.recv().unwrap_or(false)
@@ -1586,43 +1815,96 @@ mod tests {
         assert!(engine.image_cache.is_empty());
     }
 
-// //     #[test]
-//     fn test_type_text_updates_focused_input_dom_state_and_events() {
-//         let mut engine = BrowserEngine::new();
-//         let base_url = Url::parse("https://example.com/").unwrap();
-//         let mut css_cache = HashMap::new();
-//         let (page, _) = process_html_with_cache(
-//             "<html><body><input id='field' value='a'><script>window.events=[]; var field = document.getElementById('field'); field.addEventListener('input', function(e) { window.events.push('input:' + e.data); }); field.addEventListener('change', function() { window.events.push('change'); });</script></body></html>",
-//             &base_url,
-//             &HashMap::new(),
-//             &mut css_cache,
-//             None,
-//             &HashMap::new(),
-//             None,
-//             None,
-//             None,
-//             800.0,
-//         )
-//         .unwrap();
-//         engine.init_js_for_page(&page);
-// 
-//         engine.js_runtime.set_focused_node_id(Some("field".to_string()));
-//         engine.type_text("bc");
-// 
-//         let value = engine.evaluate_js("document.getElementById('field').value");
-//         let events = engine.evaluate_js("window.events.join('|')");
-//         assert_eq!(value, "abc");
-//         assert_eq!(events, "input:bc|change");
-//     }
+    #[test]
+    fn test_external_module_fetch_compile_same_origin_and_cache() {
+        let mut engine = BrowserEngine::new();
+        let page_url = Url::parse("https://example.com/app/index.html").unwrap();
+        let module_url = Url::parse("https://example.com/app/main.js").unwrap();
+        let source = "import './dep.js'; export const value = 1;".to_string();
 
-// //     #[test]
-//     fn test_clear_console_empties_buffer() {
-//         let mut engine = BrowserEngine::new();
-//         engine.evaluate_js("console.log('hello')");
-//         assert_eq!(engine.console_entries().len(), 1);
-//         engine.clear_console();
-//         assert!(engine.console_entries().is_empty());
-//     }
+        let first = engine.load_external_module_with(module_url.clone(), &page_url, |url| {
+            assert_eq!(url, &module_url);
+            Ok::<String, String>(source.clone())
+        });
+        assert_eq!(first.error, None);
+        assert!(!first.from_cache);
+        assert_eq!(first.requests, vec!["./dep.js".to_string()]);
+        assert_eq!(engine.js_runtime.module_cache_len(), 1);
+
+        let second = engine.load_external_module_with(module_url.clone(), &page_url, |_url| {
+            Ok::<String, String>("export const value = 2;".to_string())
+        });
+        assert_eq!(second.error, None);
+        assert!(second.from_cache);
+        assert_eq!(engine.js_runtime.module_cache_len(), 1);
+    }
+
+    #[test]
+    fn test_external_module_fetch_compile_reports_fetch_error_without_panic() {
+        let mut engine = BrowserEngine::new();
+        let page_url = Url::parse("https://example.com/app/index.html").unwrap();
+        let module_url = Url::parse("https://example.com/app/missing.js").unwrap();
+
+        let outcome = engine.load_external_module_with(module_url, &page_url, |_url| {
+            Err::<String, String>("not found".to_string())
+        });
+
+        assert_eq!(outcome.error.as_deref(), Some("not found"));
+        assert_eq!(engine.js_runtime.module_cache_len(), 0);
+    }
+
+    #[test]
+    fn test_external_module_fetch_compile_respects_script_src_csp() {
+        let mut engine = BrowserEngine::new();
+        engine.current_csp_policy = Some(js::CspPolicy::parse("script-src 'self'"));
+        let page_url = Url::parse("https://example.com/app/index.html").unwrap();
+        let module_url = Url::parse("https://cdn.example.test/app/main.js").unwrap();
+
+        let outcome = engine.load_external_module_with(module_url, &page_url, |_url| {
+            Ok::<String, String>("export const value = 1;".to_string())
+        });
+
+        assert_eq!(outcome.error.as_deref(), Some("Blocked by script-src CSP"));
+        assert_eq!(engine.js_runtime.module_cache_len(), 0);
+    }
+
+    // //     #[test]
+    //     fn test_type_text_updates_focused_input_dom_state_and_events() {
+    //         let mut engine = BrowserEngine::new();
+    //         let base_url = Url::parse("https://example.com/").unwrap();
+    //         let mut css_cache = HashMap::new();
+    //         let (page, _) = process_html_with_cache(
+    //             "<html><body><input id='field' value='a'><script>window.events=[]; var field = document.getElementById('field'); field.addEventListener('input', function(e) { window.events.push('input:' + e.data); }); field.addEventListener('change', function() { window.events.push('change'); });</script></body></html>",
+    //             &base_url,
+    //             &HashMap::new(),
+    //             &mut css_cache,
+    //             None,
+    //             &HashMap::new(),
+    //             None,
+    //             None,
+    //             None,
+    //             800.0,
+    //         )
+    //         .unwrap();
+    //         engine.init_js_for_page(&page);
+    //
+    //         engine.js_runtime.set_focused_node_id(Some("field".to_string()));
+    //         engine.type_text("bc");
+    //
+    //         let value = engine.evaluate_js("document.getElementById('field').value");
+    //         let events = engine.evaluate_js("window.events.join('|')");
+    //         assert_eq!(value, "abc");
+    //         assert_eq!(events, "input:bc|change");
+    //     }
+
+    // //     #[test]
+    //     fn test_clear_console_empties_buffer() {
+    //         let mut engine = BrowserEngine::new();
+    //         engine.evaluate_js("console.log('hello')");
+    //         assert_eq!(engine.console_entries().len(), 1);
+    //         engine.clear_console();
+    //         assert!(engine.console_entries().is_empty());
+    //     }
 
     #[test]
     fn test_console_repl_returns_result_and_console_entries() {
@@ -1723,7 +2005,8 @@ mod tests {
 
     #[test]
     fn test_extract_form_controls_basic() {
-        let html = r#"<form><input name="user" type="text"><input name="pass" type="password"></form>"#;
+        let html =
+            r#"<form><input name="user" type="text"><input name="pass" type="password"></form>"#;
         let controls = extract_form_controls_from_html(html);
         assert_eq!(controls.len(), 2);
         assert_eq!(controls[0].0, "user");
@@ -1743,7 +2026,9 @@ mod tests {
 
     #[test]
     fn test_click_result_serde_navigate() {
-        let r = ClickResult::Navigate { url: "https://example.com".to_string() };
+        let r = ClickResult::Navigate {
+            url: "https://example.com".to_string(),
+        };
         let json = serde_json::to_string(&r).expect("serialize");
         assert!(json.contains("\"type\":\"Navigate\""));
         assert!(json.contains("\"url\":\"https://example.com\""));
@@ -1756,7 +2041,9 @@ mod tests {
 
     #[test]
     fn test_click_result_serde_focus() {
-        let r = ClickResult::FocusChanged { id: "search-input".to_string() };
+        let r = ClickResult::FocusChanged {
+            id: "search-input".to_string(),
+        };
         let json = serde_json::to_string(&r).expect("serialize");
         assert!(json.contains("\"type\":\"FocusChanged\""));
         assert!(json.contains("\"id\":\"search-input\""));
@@ -1772,7 +2059,10 @@ mod tests {
     #[test]
     fn test_extract_attr_basic() {
         let tag = r#"a href="https://example.com" class="link""#;
-        assert_eq!(extract_attr(tag, "href"), Some("https://example.com".to_string()));
+        assert_eq!(
+            extract_attr(tag, "href"),
+            Some("https://example.com".to_string())
+        );
     }
 
     #[test]
@@ -1993,33 +2283,33 @@ mod tests {
         assert_eq!(meta.controls[0].name, "q");
     }
 
-//     #[test]
-// //     fn test_submit_form_constructs_get_url_with_live_values() {
-//         let html = r#"<form action="/search" method="get"><input name="q" value="hello"></form>"#;
-//         let base = Url::parse("https://example.com").unwrap();
-//         let mut cache = HashMap::new();
-//         let (page, _) = process_html_with_cache(
-//             html,
-//             &base,
-//             &HashMap::new(),
-//             &mut cache,
-//             None,
-//             &HashMap::new(),
-//             None,
-//             None,
-//             None,
-//             800.0,
-//         )
-//         .unwrap();
-// 
-//         let mut engine = BrowserEngine::new();
-//         engine.init_js_for_page(&page);
-//         engine.last_page = Some(page);
-// 
-//         let url = engine.submit_form().expect("submit_form should return URL");
-//         assert!(url.starts_with("https://example.com/search?"));
-//         assert!(url.contains("q=hello"));
-//     }
+    //     #[test]
+    // //     fn test_submit_form_constructs_get_url_with_live_values() {
+    //         let html = r#"<form action="/search" method="get"><input name="q" value="hello"></form>"#;
+    //         let base = Url::parse("https://example.com").unwrap();
+    //         let mut cache = HashMap::new();
+    //         let (page, _) = process_html_with_cache(
+    //             html,
+    //             &base,
+    //             &HashMap::new(),
+    //             &mut cache,
+    //             None,
+    //             &HashMap::new(),
+    //             None,
+    //             None,
+    //             None,
+    //             800.0,
+    //         )
+    //         .unwrap();
+    //
+    //         let mut engine = BrowserEngine::new();
+    //         engine.init_js_for_page(&page);
+    //         engine.last_page = Some(page);
+    //
+    //         let url = engine.submit_form().expect("submit_form should return URL");
+    //         assert!(url.starts_with("https://example.com/search?"));
+    //         assert!(url.contains("q=hello"));
+    //     }
 
     #[test]
     fn test_submit_form_none_when_no_form() {
@@ -2045,38 +2335,41 @@ mod tests {
         assert!(engine.submit_form().is_none());
     }
 
-//     #[test]
-// //     fn test_submit_form_empty_action_uses_base_url() {
-//         let html = r#"<form><input name="q" value="rust"></form>"#;
-//         let base = Url::parse("https://example.com/page").unwrap();
-//         let mut cache = HashMap::new();
-//         let (page, _) = process_html_with_cache(
-//             html,
-//             &base,
-//             &HashMap::new(),
-//             &mut cache,
-//             None,
-//             &HashMap::new(),
-//             None,
-//             None,
-//             None,
-//             800.0,
-//         )
-//         .unwrap();
-// 
-//         let mut engine = BrowserEngine::new();
-//         engine.init_js_for_page(&page);
-//         engine.last_page = Some(page);
-// 
-//         let url = engine.submit_form().expect("should return URL");
-//         assert!(url.starts_with("https://example.com/page?"));
-//         assert!(url.contains("q=rust"));
-//     }
+    //     #[test]
+    // //     fn test_submit_form_empty_action_uses_base_url() {
+    //         let html = r#"<form><input name="q" value="rust"></form>"#;
+    //         let base = Url::parse("https://example.com/page").unwrap();
+    //         let mut cache = HashMap::new();
+    //         let (page, _) = process_html_with_cache(
+    //             html,
+    //             &base,
+    //             &HashMap::new(),
+    //             &mut cache,
+    //             None,
+    //             &HashMap::new(),
+    //             None,
+    //             None,
+    //             None,
+    //             800.0,
+    //         )
+    //         .unwrap();
+    //
+    //         let mut engine = BrowserEngine::new();
+    //         engine.init_js_for_page(&page);
+    //         engine.last_page = Some(page);
+    //
+    //         let url = engine.submit_form().expect("should return URL");
+    //         assert!(url.starts_with("https://example.com/page?"));
+    //         assert!(url.contains("q=rust"));
+    //     }
 
     #[test]
     fn test_resolve_url_http_passthrough() {
         assert_eq!(resolve_url("http://example.com"), "http://example.com");
-        assert_eq!(resolve_url("https://example.com/path"), "https://example.com/path");
+        assert_eq!(
+            resolve_url("https://example.com/path"),
+            "https://example.com/path"
+        );
     }
 
     #[test]

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,17 +1,16 @@
-use v8;
-use std::collections::{HashMap, HashSet, VecDeque};
-use markup5ever_rcdom::{NodeData, Handle};
+use crate::css::{parse_selector, AttributeMatch, Combinator, Selector};
+use lazy_static::lazy_static;
+use markup5ever_rcdom::{Handle, NodeData};
+use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
-use serde::{Serialize, Deserialize};
-use std::sync::Mutex;
-use std::rc::Rc;
-use lazy_static::lazy_static;
-use crate::css::{AttributeMatch, Combinator, Selector, parse_selector};
-
+use v8;
 
 lazy_static! {
     static ref GLOBAL_STORAGE: Mutex<OriginStorage> = Mutex::new(OriginStorage::load());
@@ -37,7 +36,10 @@ impl OriginStorage {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum SiblingDirection { Next, Previous }
+enum SiblingDirection {
+    Next,
+    Previous,
+}
 
 struct FetchHandlers {
     resolve: v8::Global<v8::Function>,
@@ -185,10 +187,12 @@ impl CspPolicy {
         let mut policy = Self::default();
         for directive in header.split(';') {
             let parts: Vec<&str> = directive.trim().split_whitespace().collect();
-            if parts.is_empty() { continue; }
+            if parts.is_empty() {
+                continue;
+            }
             let name = parts[0].to_lowercase();
             let sources: Vec<String> = parts[1..].iter().map(|s| s.to_string()).collect();
-            
+
             match name.as_str() {
                 "connect-src" => policy.connect_src = sources,
                 "script-src" => policy.script_src = sources,
@@ -205,32 +209,62 @@ impl CspPolicy {
             _ => return true,
         };
 
-        if sources.is_empty() { return true; }
+        if sources.is_empty() {
+            return true;
+        }
 
         for source in sources {
-            if source == "*" { return true; }
+            if source == "*" {
+                return true;
+            }
             if source == "'self'" {
                 if let Some(origin) = current_origin {
-                    if origin.origin() == url.origin() { return true; }
+                    if origin.origin() == url.origin() {
+                        return true;
+                    }
                 }
                 continue;
             }
             // Simple string prefix/origin match
-            if url.to_string().starts_with(source) { return true; }
+            if url.to_string().starts_with(source) {
+                return true;
+            }
         }
         false
     }
 
     pub fn allows_inline_script(&self) -> bool {
-        if self.script_src.is_empty() { return true; }
+        if self.script_src.is_empty() {
+            return true;
+        }
         self.script_src.iter().any(|s| s == "'unsafe-inline'")
     }
 }
 
 pub struct JsRuntime {
-    isolate: v8::OwnedIsolate,
     global_context: v8::Global<v8::Context>,
+    module_loader: ModuleLoader,
     task_receiver: std::sync::mpsc::Receiver<Box<dyn FnOnce() + Send>>,
+    isolate: v8::OwnedIsolate,
+}
+
+#[derive(Default)]
+pub struct ModuleLoader {
+    modules: HashMap<Url, ModuleRecord>,
+}
+
+#[derive(Clone, Debug)]
+struct ModuleRecord {
+    source: String,
+    requests: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModuleCompileOutcome {
+    pub url: Url,
+    pub from_cache: bool,
+    pub requests: Vec<String>,
+    pub error: Option<String>,
 }
 
 impl JsRuntime {
@@ -282,16 +316,24 @@ impl JsRuntime {
                     let url_init = CURRENT_ORIGIN.with(|origin| {
                         if let Some(ref url) = *origin.borrow() {
                             let href = url.to_string();
-                            format!(r#"(function() {{
-                                var _loc = __aura_create_location(JSON.parse({href_json:?}));
+                            let href_json =
+                                serde_json::to_string(&href).unwrap_or_else(|_| "\"\"".to_string());
+                            format!(
+                                r#"(function() {{
+                                var href = {href_json};
+                                var _loc = __aura_create_location(href);
                                 document.location = _loc;
-                                document.URL = {href_json:?};
-                                document.documentURI = {href_json:?};
-                                document.baseURI = {href_json:?};
+                                document.URL = href;
+                                document.documentURI = href;
+                                document.baseURI = href;
                                 window.location = _loc;
                                 location = _loc;
-                            }})();"#, href_json = serde_json::to_string(&href).unwrap_or_default())
-                        } else { String::new() }
+                            }})();"#,
+                                href_json = href_json
+                            )
+                        } else {
+                            String::new()
+                        }
                     });
                     if !url_init.is_empty() {
                         let src = v8::String::new(tc, &url_init).unwrap();
@@ -301,10 +343,15 @@ impl JsRuntime {
                     }
 
                     let script_allowed = CSP_POLICY.with(|p| {
-                        p.borrow().as_ref().map(|pol| pol.allows_inline_script()).unwrap_or(true)
+                        p.borrow()
+                            .as_ref()
+                            .map(|pol| pol.allows_inline_script())
+                            .unwrap_or(true)
                     });
-                    let flag_init = format!("window.__aura_inline_script_allowed = {};",
-                        if script_allowed { "true" } else { "false" });
+                    let flag_init = format!(
+                        "window.__aura_inline_script_allowed = {};",
+                        if script_allowed { "true" } else { "false" }
+                    );
                     let src = v8::String::new(tc, &flag_init).unwrap();
                     if let Some(script) = v8::Script::compile(tc, src, None) {
                         let _ = script.run(tc);
@@ -316,9 +363,10 @@ impl JsRuntime {
         }
 
         JsRuntime {
-            isolate,
             global_context,
+            module_loader: ModuleLoader::default(),
             task_receiver,
+            isolate,
         }
     }
 
@@ -328,7 +376,9 @@ impl JsRuntime {
 
     pub fn tick(&mut self, timestamp: Option<f64>, deadline_ms: Option<f64>) -> bool {
         let mut did_work = false;
-        if self.sync_focus() { did_work = true; }
+        if self.sync_focus() {
+            did_work = true;
+        }
 
         while let Ok(task) = self.task_receiver.try_recv() {
             MACRO_TASKS.with(|tasks| tasks.borrow_mut().push_back(task));
@@ -364,13 +414,22 @@ impl JsRuntime {
                     task(deadline);
                     self.run_pending_callbacks();
                     self.run_microtasks();
-                    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as f64;
-                    if now >= deadline { break; }
-                } else { break; }
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis() as f64;
+                    if now >= deadline {
+                        break;
+                    }
+                } else {
+                    break;
+                }
             }
         }
 
-        while let Some((callback, payload, is_resolve)) = FETCH_PENDING.with(|p| p.borrow_mut().pop_front()) {
+        while let Some((callback, payload, is_resolve)) =
+            FETCH_PENDING.with(|p| p.borrow_mut().pop_front())
+        {
             did_work = true;
             self.call_with_payload(callback, &payload, is_resolve);
             self.run_microtasks();
@@ -380,8 +439,11 @@ impl JsRuntime {
     }
 
     fn run_pending_callbacks(&mut self) {
-        let pending: Vec<(v8::Global<v8::Function>, Option<f64>)> = RUN_PENDING.with(|p| p.borrow_mut().drain(..).collect());
-        if pending.is_empty() { return; }
+        let pending: Vec<(v8::Global<v8::Function>, Option<f64>)> =
+            RUN_PENDING.with(|p| p.borrow_mut().drain(..).collect());
+        if pending.is_empty() {
+            return;
+        }
         let hs = std::pin::pin!(v8::HandleScope::new(&mut self.isolate));
         let hs = &mut hs.init();
         let local_context = v8::Local::new(hs, &self.global_context);
@@ -398,7 +460,12 @@ impl JsRuntime {
         }
     }
 
-    fn call_with_payload(&mut self, callback: v8::Global<v8::Function>, payload: &str, is_resolve: bool) {
+    fn call_with_payload(
+        &mut self,
+        callback: v8::Global<v8::Function>,
+        payload: &str,
+        is_resolve: bool,
+    ) {
         let hs = std::pin::pin!(v8::HandleScope::new(&mut self.isolate));
         let hs = &mut hs.init();
         let local_context = v8::Local::new(hs, &self.global_context);
@@ -433,14 +500,18 @@ impl JsRuntime {
             let local_context = v8::Local::new(hs, &self.global_context);
             let scope = &mut v8::ContextScope::new(hs, local_context);
             scope.perform_microtask_checkpoint();
-            if !micro_work_done { break; }
+            if !micro_work_done {
+                break;
+            }
         }
     }
 
     fn sync_focus(&mut self) -> bool {
         let old = PREVIOUS_FOCUSED_NODE.with(|f| (*f.borrow()).clone());
         let new = FOCUSED_NODE.with(|f| (*f.borrow()).clone());
-        if old == new { return false; }
+        if old == new {
+            return false;
+        }
         PREVIOUS_FOCUSED_NODE.with(|f| *f.borrow_mut() = new.clone());
         if let Some(ref old_id) = old {
             self.trigger_event(old_id, "blur");
@@ -457,10 +528,15 @@ impl JsRuntime {
         let native_id = DOM_ROOT.with(|root| {
             if let Some(ref r) = *root.borrow() {
                 find_element_by_id(r, target_id).map(register_node)
-            } else { None }
+            } else {
+                None
+            }
         });
         if let Some(nid) = native_id {
-            let code = format!("document.__trigger_event({}, '{}', {{ bubbles: true }})", nid, event_type);
+            let code = format!(
+                "document.__trigger_event({}, '{}', {{ bubbles: true }})",
+                nid, event_type
+            );
             self.execute(&code);
         }
     }
@@ -473,13 +549,6 @@ impl JsRuntime {
     }
 
     pub fn execute_with_result(&mut self, source: &str) -> EvalOutcome {
-        if source.contains("import.meta") || (source.contains("import ") && source.contains(" from ")) {
-            return EvalOutcome {
-                result: None,
-                error: Some("ES module syntax is not supported".to_string()),
-            };
-        }
-
         let hs = std::pin::pin!(v8::HandleScope::new(&mut self.isolate));
         let hs = &mut hs.init();
         let local_context = v8::Local::new(hs, &self.global_context);
@@ -530,10 +599,116 @@ impl JsRuntime {
                     } else {
                         value.to_string(tc).map(|s| s.to_rust_string_lossy(tc))
                     };
-                    EvalOutcome { result, error: None }
+                    EvalOutcome {
+                        result,
+                        error: None,
+                    }
                 }
             },
         }
+    }
+
+    pub fn resolve_module_specifier(&self, specifier: &str, referrer: &Url) -> Result<Url, String> {
+        referrer
+            .join(specifier)
+            .or_else(|_| Url::parse(specifier))
+            .map_err(|err| format!("Failed to resolve module specifier '{specifier}': {err}"))
+    }
+
+    pub fn compile_module_source(&mut self, url: Url, source: String) -> ModuleCompileOutcome {
+        if let Some(record) = self.module_loader.modules.get(&url) {
+            return ModuleCompileOutcome {
+                url,
+                from_cache: true,
+                requests: record.requests.clone(),
+                error: None,
+            };
+        }
+
+        match self.compile_v8_module(&url, &source) {
+            Ok(requests) => {
+                self.module_loader.modules.insert(
+                    url.clone(),
+                    ModuleRecord {
+                        source,
+                        requests: requests.clone(),
+                    },
+                );
+                ModuleCompileOutcome {
+                    url,
+                    from_cache: false,
+                    requests,
+                    error: None,
+                }
+            }
+            Err(error) => ModuleCompileOutcome {
+                url,
+                from_cache: false,
+                requests: Vec::new(),
+                error: Some(error),
+            },
+        }
+    }
+
+    pub fn module_cache_len(&self) -> usize {
+        self.module_loader.modules.len()
+    }
+
+    pub fn cached_module_urls(&self) -> Vec<Url> {
+        self.module_loader.modules.keys().cloned().collect()
+    }
+
+    pub fn cached_module_source(&self, url: &Url) -> Option<&str> {
+        self.module_loader
+            .modules
+            .get(url)
+            .map(|record| record.source.as_str())
+    }
+
+    fn compile_v8_module(&mut self, url: &Url, source: &str) -> Result<Vec<String>, String> {
+        let hs = std::pin::pin!(v8::HandleScope::new(&mut self.isolate));
+        let hs = &mut hs.init();
+        let local_context = v8::Local::new(hs, &self.global_context);
+        let scope = &mut v8::ContextScope::new(hs, local_context);
+        let tc = std::pin::pin!(v8::TryCatch::new(scope));
+        let tc = &mut tc.init();
+
+        let code = v8::String::new(tc, source)
+            .ok_or_else(|| "Failed to create V8 module source string".to_string())?;
+        let resource = v8::String::new(tc, url.as_str())
+            .ok_or_else(|| "Failed to create V8 module resource name".to_string())?;
+        let origin = v8::ScriptOrigin::new(
+            tc,
+            resource.into(),
+            0,
+            0,
+            false,
+            0,
+            None,
+            false,
+            false,
+            true,
+            None,
+        );
+        let mut source = v8::script_compiler::Source::new(code, Some(&origin));
+        let module = v8::script_compiler::compile_module(tc, &mut source).ok_or_else(|| {
+            tc.exception()
+                .and_then(|e| e.to_string(tc))
+                .map(|s| s.to_rust_string_lossy(tc))
+                .unwrap_or_else(|| "Unknown module compilation error".to_string())
+        })?;
+
+        let requests = module.get_module_requests();
+        let mut specifiers = Vec::new();
+        for i in 0..requests.length() {
+            if let Some(data) = requests.get(tc, i) {
+                if let Ok(request) = data.try_cast::<v8::ModuleRequest>() {
+                    let specifier = request.get_specifier();
+                    specifiers.push(specifier.to_rust_string_lossy(tc));
+                }
+            }
+        }
+        Ok(specifiers)
     }
 
     pub fn get_style_overrides(&mut self) -> HashMap<String, HashMap<String, String>> {
@@ -553,7 +728,9 @@ impl JsRuntime {
                         for entry in s_std.split("####") {
                             let parts: Vec<&str> = entry.splitn(3, "||||").collect();
                             if parts.len() == 3 && !parts[0].is_empty() {
-                                result.entry(parts[0].to_string()).or_insert_with(HashMap::new)
+                                result
+                                    .entry(parts[0].to_string())
+                                    .or_insert_with(HashMap::new)
                                     .insert(parts[1].to_string(), parts[2].to_string());
                             }
                         }
@@ -565,7 +742,9 @@ impl JsRuntime {
             let tc2 = std::pin::pin!(v8::TryCatch::new(scope));
             let tc2 = &mut tc2.init();
             let clear = v8::String::new(tc2, "__aura_style_log = [];").unwrap();
-            if let Some(script) = v8::Script::compile(tc2, clear, None) { let _ = script.run(tc2); }
+            if let Some(script) = v8::Script::compile(tc2, clear, None) {
+                let _ = script.run(tc2);
+            }
         }
         result
     }
@@ -579,46 +758,138 @@ impl JsRuntime {
     }
 }
 
-
-fn register_native_functions(scope: &mut v8::ContextScope<v8::HandleScope>, global: v8::Local<v8::Object>) {
+fn register_native_functions(
+    scope: &mut v8::ContextScope<v8::HandleScope>,
+    global: v8::Local<v8::Object>,
+) {
     let f = v8::Function::new(scope, console_log).unwrap();
-    global.set(scope, v8::String::new(scope, "log").unwrap().into(), f.into());
+    global.set(
+        scope,
+        v8::String::new(scope, "log").unwrap().into(),
+        f.into(),
+    );
     let f = v8::Function::new(scope, console_warn).unwrap();
-    global.set(scope, v8::String::new(scope, "warn").unwrap().into(), f.into());
+    global.set(
+        scope,
+        v8::String::new(scope, "warn").unwrap().into(),
+        f.into(),
+    );
     let f = v8::Function::new(scope, console_error).unwrap();
-    global.set(scope, v8::String::new(scope, "error").unwrap().into(), f.into());
+    global.set(
+        scope,
+        v8::String::new(scope, "error").unwrap().into(),
+        f.into(),
+    );
     let f = v8::Function::new(scope, console_info).unwrap();
-    global.set(scope, v8::String::new(scope, "info").unwrap().into(), f.into());
+    global.set(
+        scope,
+        v8::String::new(scope, "info").unwrap().into(),
+        f.into(),
+    );
     let f = v8::Function::new(scope, console_debug).unwrap();
-    global.set(scope, v8::String::new(scope, "debug").unwrap().into(), f.into());
+    global.set(
+        scope,
+        v8::String::new(scope, "debug").unwrap().into(),
+        f.into(),
+    );
 
-    register_fn(scope, global, "__aura_get_document_element", get_document_element_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_get_document_element",
+        get_document_element_cb,
+    );
     register_fn(scope, global, "__aura_get_head", get_head_cb);
     register_fn(scope, global, "__aura_get_body", get_body_cb);
-    register_fn(scope, global, "__aura_get_element_by_id", get_element_by_id_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_get_element_by_id",
+        get_element_by_id_cb,
+    );
     register_fn(scope, global, "__aura_query_selector", query_selector_cb);
-    register_fn(scope, global, "__aura_query_selector_all", query_selector_all_cb);
-    register_fn(scope, global, "__aura_get_elements_by_class", get_elements_by_class_cb);
-    register_fn(scope, global, "__aura_get_elements_by_tag", get_elements_by_tag_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_query_selector_all",
+        query_selector_all_cb,
+    );
+    register_fn(
+        scope,
+        global,
+        "__aura_get_elements_by_class",
+        get_elements_by_class_cb,
+    );
+    register_fn(
+        scope,
+        global,
+        "__aura_get_elements_by_tag",
+        get_elements_by_tag_cb,
+    );
     register_fn(scope, global, "__aura_get_parent_id", get_parent_id_cb);
-    register_fn(scope, global, "__aura_get_next_sibling_id", get_next_sibling_cb);
-    register_fn(scope, global, "__aura_get_previous_sibling_id", get_previous_sibling_cb);
-    register_fn(scope, global, "__aura_get_next_element_sibling_id", get_next_element_sibling_cb);
-    register_fn(scope, global, "__aura_get_previous_element_sibling_id", get_previous_element_sibling_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_get_next_sibling_id",
+        get_next_sibling_cb,
+    );
+    register_fn(
+        scope,
+        global,
+        "__aura_get_previous_sibling_id",
+        get_previous_sibling_cb,
+    );
+    register_fn(
+        scope,
+        global,
+        "__aura_get_next_element_sibling_id",
+        get_next_element_sibling_cb,
+    );
+    register_fn(
+        scope,
+        global,
+        "__aura_get_previous_element_sibling_id",
+        get_previous_element_sibling_cb,
+    );
     register_fn(scope, global, "__aura_get_inner_html", get_inner_html_cb);
     register_fn(scope, global, "__aura_get_outer_html", get_outer_html_cb);
     register_fn(scope, global, "__aura_set_inner_html", set_inner_html_cb);
-    register_fn(scope, global, "__aura_get_text_content", get_text_content_cb);
-    register_fn(scope, global, "__aura_set_text_content", set_text_content_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_get_text_content",
+        get_text_content_cb,
+    );
+    register_fn(
+        scope,
+        global,
+        "__aura_set_text_content",
+        set_text_content_cb,
+    );
     register_fn(scope, global, "__aura_get_attribute", get_attribute_cb);
     register_fn(scope, global, "__aura_set_attribute", set_attribute_cb);
     register_fn(scope, global, "__aura_get_attributes", get_attributes_cb);
     register_fn(scope, global, "__aura_has_attribute", has_attribute_cb);
-    register_fn(scope, global, "__aura_remove_attribute", remove_attribute_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_remove_attribute",
+        remove_attribute_cb,
+    );
     register_fn(scope, global, "__aura_create_element", create_element_cb);
-    register_fn(scope, global, "__aura_create_text_node", create_text_node_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_create_text_node",
+        create_text_node_cb,
+    );
     register_fn(scope, global, "__aura_create_comment", create_comment_cb);
-    register_fn(scope, global, "__aura_create_document_fragment", create_document_fragment_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_create_document_fragment",
+        create_document_fragment_cb,
+    );
     register_fn(scope, global, "__aura_append_child", append_child_cb);
     register_fn(scope, global, "__aura_remove_child", remove_child_cb);
     register_fn(scope, global, "__aura_insert_before", insert_before_cb);
@@ -628,13 +899,28 @@ fn register_native_functions(scope: &mut v8::ContextScope<v8::HandleScope>, glob
     register_fn(scope, global, "__aura_get_node_type", get_node_type_cb);
     register_fn(scope, global, "__aura_get_node_value", get_node_value_cb);
     register_fn(scope, global, "__aura_set_node_value", set_node_value_cb);
-    register_fn(scope, global, "__aura_get_layout_metrics", get_layout_metrics_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_get_layout_metrics",
+        get_layout_metrics_cb,
+    );
     register_fn(scope, global, "__aura_get_doctype_id", get_doctype_id_cb);
-    register_fn(scope, global, "__aura_get_doctype_info", get_doctype_info_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_get_doctype_info",
+        get_doctype_info_cb,
+    );
     register_fn(scope, global, "__aura_set_focus", set_focus_cb);
     register_fn(scope, global, "__aura_queue_task", queue_task_cb);
     register_fn(scope, global, "__aura_resolve_url", resolve_url_cb);
-    register_fn(scope, global, "__aura_can_execute_script_url", can_execute_script_url_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_can_execute_script_url",
+        can_execute_script_url_cb,
+    );
     register_fn(scope, global, "__aura_parse_url", parse_url_cb);
     register_fn(scope, global, "__aura_storage_get", storage_get_cb);
     register_fn(scope, global, "__aura_storage_set", storage_set_cb);
@@ -647,450 +933,1341 @@ fn register_native_functions(scope: &mut v8::ContextScope<v8::HandleScope>, glob
     register_fn(scope, global, "cancelIdleCallback", cic_cb);
 }
 
-fn console_log(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn console_log(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     console_impl(scope, args, ConsoleLevel::Log);
 }
-fn console_warn(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn console_warn(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     console_impl(scope, args, ConsoleLevel::Warn);
 }
-fn console_error(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn console_error(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     console_impl(scope, args, ConsoleLevel::Error);
 }
-fn console_info(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn console_info(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     console_impl(scope, args, ConsoleLevel::Info);
 }
-fn console_debug(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn console_debug(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     console_impl(scope, args, ConsoleLevel::Debug);
 }
 
-
-fn register_fn(scope: &mut v8::ContextScope<v8::HandleScope>, global: v8::Local<v8::Object>,
-    name: &str, cb: impl v8::MapFnTo<v8::FunctionCallback>,
+fn register_fn(
+    scope: &mut v8::ContextScope<v8::HandleScope>,
+    global: v8::Local<v8::Object>,
+    name: &str,
+    cb: impl v8::MapFnTo<v8::FunctionCallback>,
 ) {
     let f = v8::Function::new(scope, cb).unwrap();
     let key = v8::String::new(scope, name).unwrap();
     global.set(scope, key.into(), f.into());
 }
 
-
-fn get_element_by_id_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_element_by_id_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let id = args.get(0).to_rust_string_lossy(scope);
     let res = DOM_ROOT.with(|root| {
         if let Some(ref r) = *root.borrow() {
             find_element_by_id(r, &id).map(|h| {
-                let tag = if let NodeData::Element { ref name, .. } = h.data { name.local.to_string() } else { String::new() };
+                let tag = if let NodeData::Element { ref name, .. } = h.data {
+                    name.local.to_string()
+                } else {
+                    String::new()
+                };
                 (register_node(h), tag)
             })
-        } else { None }
+        } else {
+            None
+        }
     });
     if let Some((nid, tag)) = res {
         let obj = v8::Object::new(scope);
-        obj.set(scope, v8::String::new(scope, "nid").unwrap().into(), v8::Number::new(scope, nid as f64).into());
-        obj.set(scope, v8::String::new(scope, "tag").unwrap().into(), v8::String::new(scope, &tag).unwrap().into());
-        obj.set(scope, v8::String::new(scope, "kind").unwrap().into(), v8::String::new(scope, "element").unwrap().into());
+        obj.set(
+            scope,
+            v8::String::new(scope, "nid").unwrap().into(),
+            v8::Number::new(scope, nid as f64).into(),
+        );
+        obj.set(
+            scope,
+            v8::String::new(scope, "tag").unwrap().into(),
+            v8::String::new(scope, &tag).unwrap().into(),
+        );
+        obj.set(
+            scope,
+            v8::String::new(scope, "kind").unwrap().into(),
+            v8::String::new(scope, "element").unwrap().into(),
+        );
         rv.set(obj.into());
-    } else { rv.set_null(); }
+    } else {
+        rv.set_null();
+    }
 }
 
-fn get_document_element_cb(scope: &mut v8::PinScope, _a: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    let nid = DOM_ROOT.with(|root| root.borrow().as_ref().and_then(find_document_element).map(register_node));
-    if let Some(n) = nid { rv.set_uint32(n); } else { rv.set_null(); }
+fn get_document_element_cb(
+    scope: &mut v8::PinScope,
+    _a: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    let nid = DOM_ROOT.with(|root| {
+        root.borrow()
+            .as_ref()
+            .and_then(find_document_element)
+            .map(register_node)
+    });
+    if let Some(n) = nid {
+        rv.set_uint32(n);
+    } else {
+        rv.set_null();
+    }
 }
-fn get_head_cb(scope: &mut v8::PinScope, _a: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    let nid = DOM_ROOT.with(|root| root.borrow().as_ref().and_then(|d| find_document_surface_element(d, "head")).map(register_node));
-    if let Some(n) = nid { rv.set_uint32(n); } else { rv.set_null(); }
+fn get_head_cb(
+    scope: &mut v8::PinScope,
+    _a: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    let nid = DOM_ROOT.with(|root| {
+        root.borrow()
+            .as_ref()
+            .and_then(|d| find_document_surface_element(d, "head"))
+            .map(register_node)
+    });
+    if let Some(n) = nid {
+        rv.set_uint32(n);
+    } else {
+        rv.set_null();
+    }
 }
-fn get_body_cb(scope: &mut v8::PinScope, _a: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    let nid = DOM_ROOT.with(|root| root.borrow().as_ref().and_then(|d| find_document_surface_element(d, "body")).map(register_node));
-    if let Some(n) = nid { rv.set_uint32(n); } else { rv.set_null(); }
+fn get_body_cb(
+    scope: &mut v8::PinScope,
+    _a: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    let nid = DOM_ROOT.with(|root| {
+        root.borrow()
+            .as_ref()
+            .and_then(|d| find_document_surface_element(d, "body"))
+            .map(register_node)
+    });
+    if let Some(n) = nid {
+        rv.set_uint32(n);
+    } else {
+        rv.set_null();
+    }
 }
 
-fn query_selector_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn query_selector_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let root_nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let selector = args.get(1).to_rust_string_lossy(scope);
     let found = DOM_ROOT.with(|root| {
         if let Some(ref r) = *root.borrow() {
-            let search = if root_nid == 0 { r.clone() } else { NODE_REGISTRY.with(|reg| reg.borrow().get(&root_nid).cloned()).unwrap_or_else(|| r.clone()) };
+            let search = if root_nid == 0 {
+                r.clone()
+            } else {
+                NODE_REGISTRY
+                    .with(|reg| reg.borrow().get(&root_nid).cloned())
+                    .unwrap_or_else(|| r.clone())
+            };
             query_selector_first(&search, &selector, root_nid != 0)
-        } else { None }
+        } else {
+            None
+        }
     });
-    if let Some(h) = found { rv.set_uint32(register_node(h)); } else { rv.set_null(); }
+    if let Some(h) = found {
+        rv.set_uint32(register_node(h));
+    } else {
+        rv.set_null();
+    }
 }
 
-fn query_selector_all_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn query_selector_all_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let root_nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let selector = args.get(1).to_rust_string_lossy(scope);
     let nids = DOM_ROOT.with(|root| {
         if let Some(ref r) = *root.borrow() {
-            let search = if root_nid == 0 { r.clone() } else { NODE_REGISTRY.with(|reg| reg.borrow().get(&root_nid).cloned()).unwrap_or_else(|| r.clone()) };
+            let search = if root_nid == 0 {
+                r.clone()
+            } else {
+                NODE_REGISTRY
+                    .with(|reg| reg.borrow().get(&root_nid).cloned())
+                    .unwrap_or_else(|| r.clone())
+            };
             query_selector_all_nodes(&search, &selector, root_nid != 0)
-        } else { vec![] }
+        } else {
+            vec![]
+        }
     });
     let ids: Vec<u32> = nids.into_iter().map(register_node).collect();
-    let json = format!("[{}]", ids.iter().map(|n| n.to_string()).collect::<Vec<_>>().join(","));
+    let json = format!(
+        "[{}]",
+        ids.iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
     rv.set(v8::String::new(scope, &json).unwrap().into());
 }
 
-fn get_elements_by_class_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_elements_by_class_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let root_nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let cls = args.get(1).to_rust_string_lossy(scope);
     let nids = DOM_ROOT.with(|root| {
         if let Some(ref r) = *root.borrow() {
-            let search = if root_nid == 0 { r.clone() } else { NODE_REGISTRY.with(|reg| reg.borrow().get(&root_nid).cloned()).unwrap_or_else(|| r.clone()) };
+            let search = if root_nid == 0 {
+                r.clone()
+            } else {
+                NODE_REGISTRY
+                    .with(|reg| reg.borrow().get(&root_nid).cloned())
+                    .unwrap_or_else(|| r.clone())
+            };
             find_elements_by_class(&search, &cls, root_nid != 0)
-        } else { vec![] }
+        } else {
+            vec![]
+        }
     });
     let ids: Vec<u32> = nids.into_iter().map(register_node).collect();
-    let json = format!("[{}]", ids.iter().map(|n| n.to_string()).collect::<Vec<_>>().join(","));
+    let json = format!(
+        "[{}]",
+        ids.iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
     rv.set(v8::String::new(scope, &json).unwrap().into());
 }
 
-fn get_elements_by_tag_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_elements_by_tag_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let root_nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let tag = args.get(1).to_rust_string_lossy(scope).to_lowercase();
     let nids = DOM_ROOT.with(|root| {
         if let Some(ref r) = *root.borrow() {
-            let search = if root_nid == 0 { r.clone() } else { NODE_REGISTRY.with(|reg| reg.borrow().get(&root_nid).cloned()).unwrap_or_else(|| r.clone()) };
+            let search = if root_nid == 0 {
+                r.clone()
+            } else {
+                NODE_REGISTRY
+                    .with(|reg| reg.borrow().get(&root_nid).cloned())
+                    .unwrap_or_else(|| r.clone())
+            };
             find_elements_by_tag_name(&search, &tag, root_nid != 0)
-        } else { vec![] }
+        } else {
+            vec![]
+        }
     });
     let ids: Vec<u32> = nids.into_iter().map(register_node).collect();
-    let json = format!("[{}]", ids.iter().map(|n| n.to_string()).collect::<Vec<_>>().join(","));
+    let json = format!(
+        "[{}]",
+        ids.iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
     rv.set(v8::String::new(scope, &json).unwrap().into());
 }
 
-fn get_parent_id_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_parent_id_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let parent = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).and_then(|node| {
-        let pw = node.parent.take(); let p = pw.and_then(|w| w.upgrade());
-        if let Some(ref ph) = p { node.parent.set(Some(Rc::downgrade(ph))); } p
-    }));
-    if let Some(pn) = parent.map(register_node) { rv.set_uint32(pn); } else { rv.set_null(); }
+    let parent = NODE_REGISTRY.with(|reg| {
+        reg.borrow().get(&nid).and_then(|node| {
+            let pw = node.parent.take();
+            let p = pw.and_then(|w| w.upgrade());
+            if let Some(ref ph) = p {
+                node.parent.set(Some(Rc::downgrade(ph)));
+            }
+            p
+        })
+    });
+    if let Some(pn) = parent.map(register_node) {
+        rv.set_uint32(pn);
+    } else {
+        rv.set_null();
+    }
 }
-fn sib_res(scope: &mut v8::PinScope, rv: &mut v8::ReturnValue<v8::Value>, nid: u32, dir: SiblingDirection, el_only: bool) {
-    match get_sibling_id(nid, dir, el_only) { Some(sn) => rv.set_uint32(sn), None => rv.set_null() }
+fn sib_res(
+    scope: &mut v8::PinScope,
+    rv: &mut v8::ReturnValue<v8::Value>,
+    nid: u32,
+    dir: SiblingDirection,
+    el_only: bool,
+) {
+    match get_sibling_id(nid, dir, el_only) {
+        Some(sn) => rv.set_uint32(sn),
+        None => rv.set_null(),
+    }
 }
-fn get_next_sibling_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    sib_res(scope, &mut rv, args.get(0).uint32_value(scope).unwrap_or(0), SiblingDirection::Next, false);
+fn get_next_sibling_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    sib_res(
+        scope,
+        &mut rv,
+        args.get(0).uint32_value(scope).unwrap_or(0),
+        SiblingDirection::Next,
+        false,
+    );
 }
-fn get_previous_sibling_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    sib_res(scope, &mut rv, args.get(0).uint32_value(scope).unwrap_or(0), SiblingDirection::Previous, false);
+fn get_previous_sibling_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    sib_res(
+        scope,
+        &mut rv,
+        args.get(0).uint32_value(scope).unwrap_or(0),
+        SiblingDirection::Previous,
+        false,
+    );
 }
-fn get_next_element_sibling_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    sib_res(scope, &mut rv, args.get(0).uint32_value(scope).unwrap_or(0), SiblingDirection::Next, true);
+fn get_next_element_sibling_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    sib_res(
+        scope,
+        &mut rv,
+        args.get(0).uint32_value(scope).unwrap_or(0),
+        SiblingDirection::Next,
+        true,
+    );
 }
-fn get_previous_element_sibling_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    sib_res(scope, &mut rv, args.get(0).uint32_value(scope).unwrap_or(0), SiblingDirection::Previous, true);
+fn get_previous_element_sibling_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    sib_res(
+        scope,
+        &mut rv,
+        args.get(0).uint32_value(scope).unwrap_or(0),
+        SiblingDirection::Previous,
+        true,
+    );
 }
 
-fn get_inner_html_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_inner_html_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let html = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).map(|n| serialize_inner_html(n)).unwrap_or_default());
+    let html = NODE_REGISTRY.with(|reg| {
+        reg.borrow()
+            .get(&nid)
+            .map(|n| serialize_inner_html(n))
+            .unwrap_or_default()
+    });
     rv.set(v8::String::new(scope, &html).unwrap().into());
 }
-fn get_outer_html_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_outer_html_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let html = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).map(|n| { let mut o=String::new(); serialize_node(n, &mut o); o }).unwrap_or_default());
+    let html = NODE_REGISTRY.with(|reg| {
+        reg.borrow()
+            .get(&nid)
+            .map(|n| {
+                let mut o = String::new();
+                serialize_node(n, &mut o);
+                o
+            })
+            .unwrap_or_default()
+    });
     rv.set(v8::String::new(scope, &html).unwrap().into());
 }
-fn set_inner_html_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn set_inner_html_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let html = args.get(1).to_rust_string_lossy(scope);
     NODE_REGISTRY.with(|reg| {
         if let Some(node) = reg.borrow().get(&nid) {
-            let tag = if let NodeData::Element { ref name, .. } = node.data { name.local.to_string() } else { "div".to_string() };
+            let tag = if let NodeData::Element { ref name, .. } = node.data {
+                name.local.to_string()
+            } else {
+                "div".to_string()
+            };
             let frag = parse_html_fragment(&html, &tag);
             let mut ch = node.children.borrow_mut();
-            for c in ch.iter() { c.parent.set(None); } ch.clear();
-            for c in frag { c.parent.set(Some(Rc::downgrade(node))); ch.push(c); }
+            for c in ch.iter() {
+                c.parent.set(None);
+            }
+            ch.clear();
+            for c in frag {
+                c.parent.set(Some(Rc::downgrade(node)));
+                ch.push(c);
+            }
         }
     });
 }
-fn get_text_content_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_text_content_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let t = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).map(|n| match &n.data { NodeData::Comment{contents} => contents.to_string(), _ => collect_text_content(n) }).unwrap_or_default());
+    let t = NODE_REGISTRY.with(|reg| {
+        reg.borrow()
+            .get(&nid)
+            .map(|n| match &n.data {
+                NodeData::Comment { contents } => contents.to_string(),
+                _ => collect_text_content(n),
+            })
+            .unwrap_or_default()
+    });
     rv.set(v8::String::new(scope, &t).unwrap().into());
 }
-fn set_text_content_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn set_text_content_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let text = args.get(1).to_rust_string_lossy(scope);
     let node = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).cloned());
-    if let Some(node) = node { match &node.data {
-        NodeData::Text{contents} => { *contents.borrow_mut() = text.as_str().into(); }
-        NodeData::Comment{..} => {
-            use html5ever::tendril::StrTendril; use markup5ever_rcdom::Node;
-            replace_registered_node(nid, Node::new(NodeData::Comment{contents:StrTendril::from(text.as_str())}));
+    if let Some(node) = node {
+        match &node.data {
+            NodeData::Text { contents } => {
+                *contents.borrow_mut() = text.as_str().into();
+            }
+            NodeData::Comment { .. } => {
+                use html5ever::tendril::StrTendril;
+                use markup5ever_rcdom::Node;
+                replace_registered_node(
+                    nid,
+                    Node::new(NodeData::Comment {
+                        contents: StrTendril::from(text.as_str()),
+                    }),
+                );
+            }
+            _ => {
+                use html5ever::tendril::StrTendril;
+                use markup5ever_rcdom::Node;
+                let tn = Node::new(NodeData::Text {
+                    contents: std::cell::RefCell::new(StrTendril::from(text.as_str())),
+                });
+                tn.parent.set(Some(Rc::downgrade(&node)));
+                node.children.borrow_mut().clear();
+                node.children.borrow_mut().push(tn);
+            }
         }
-        _ => {
-            use html5ever::tendril::StrTendril; use markup5ever_rcdom::Node;
-            let tn = Node::new(NodeData::Text{contents:std::cell::RefCell::new(StrTendril::from(text.as_str()))});
-            tn.parent.set(Some(Rc::downgrade(&node))); node.children.borrow_mut().clear(); node.children.borrow_mut().push(tn);
-        }
-    }}
+    }
 }
 
-fn get_attribute_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_attribute_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let name = args.get(1).to_rust_string_lossy(scope);
-    let val = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).and_then(|n| {
-        if let NodeData::Element{ref attrs,..}=n.data { attrs.borrow().iter().find(|a|a.name.local.to_string()==name).map(|a|a.value.to_string()) } else {None}
-    }));
-    if let Some(v) = val { rv.set(v8::String::new(scope, &v).unwrap().into()); } else { rv.set_null(); }
+    let val = NODE_REGISTRY.with(|reg| {
+        reg.borrow().get(&nid).and_then(|n| {
+            if let NodeData::Element { ref attrs, .. } = n.data {
+                attrs
+                    .borrow()
+                    .iter()
+                    .find(|a| a.name.local.to_string() == name)
+                    .map(|a| a.value.to_string())
+            } else {
+                None
+            }
+        })
+    });
+    if let Some(v) = val {
+        rv.set(v8::String::new(scope, &v).unwrap().into());
+    } else {
+        rv.set_null();
+    }
 }
-fn set_attribute_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn set_attribute_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let name = args.get(1).to_rust_string_lossy(scope);
     let val = args.get(2).to_rust_string_lossy(scope);
-    NODE_REGISTRY.with(|reg| if let Some(n)=reg.borrow().get(&nid) { if let NodeData::Element{ref attrs,..}=n.data {
-        let mut a=attrs.borrow_mut(); let mut f=false;
-        for attr in a.iter_mut() { if attr.name.local.to_string()==name { attr.value=val.clone().into(); f=true; break; } }
-        if !f { use html5ever::{QualName,LocalName,ns,Attribute};
-            a.push(Attribute{name:QualName::new(None,ns!(html),LocalName::from(name)),value:val.into()}); }
-    }});
+    NODE_REGISTRY.with(|reg| {
+        if let Some(n) = reg.borrow().get(&nid) {
+            if let NodeData::Element { ref attrs, .. } = n.data {
+                let mut a = attrs.borrow_mut();
+                let mut f = false;
+                for attr in a.iter_mut() {
+                    if attr.name.local.to_string() == name {
+                        attr.value = val.clone().into();
+                        f = true;
+                        break;
+                    }
+                }
+                if !f {
+                    use html5ever::{ns, Attribute, LocalName, QualName};
+                    a.push(Attribute {
+                        name: QualName::new(None, ns!(html), LocalName::from(name)),
+                        value: val.into(),
+                    });
+                }
+            }
+        }
+    });
 }
-fn get_attributes_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_attributes_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let json = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).map(|n| {
-        if let NodeData::Element{ref attrs,..}=n.data { let items:Vec<String>=attrs.borrow().iter().map(|a|
-            format!("{{\"name\":{},\"value\":{}}}", serde_json::to_string(&a.name.local.to_string()).unwrap_or_default(), serde_json::to_string(&a.value.to_string()).unwrap_or_default())
-        ).collect(); format!("[{}]",items.join(",")) } else {"[]".to_string()}
-    }).unwrap_or_else(|| "[]".to_string()));
+    let json = NODE_REGISTRY.with(|reg| {
+        reg.borrow()
+            .get(&nid)
+            .map(|n| {
+                if let NodeData::Element { ref attrs, .. } = n.data {
+                    let items: Vec<String> = attrs
+                        .borrow()
+                        .iter()
+                        .map(|a| {
+                            format!(
+                                "{{\"name\":{},\"value\":{}}}",
+                                serde_json::to_string(&a.name.local.to_string())
+                                    .unwrap_or_default(),
+                                serde_json::to_string(&a.value.to_string()).unwrap_or_default()
+                            )
+                        })
+                        .collect();
+                    format!("[{}]", items.join(","))
+                } else {
+                    "[]".to_string()
+                }
+            })
+            .unwrap_or_else(|| "[]".to_string())
+    });
     rv.set(v8::String::new(scope, &json).unwrap().into());
 }
-fn has_attribute_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn has_attribute_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let name = args.get(1).to_rust_string_lossy(scope);
-    let f = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).map(|n| {
-        if let NodeData::Element{ref attrs,..}=n.data { attrs.borrow().iter().any(|a|a.name.local.to_string()==name) } else {false}
-    }).unwrap_or(false));
+    let f = NODE_REGISTRY.with(|reg| {
+        reg.borrow()
+            .get(&nid)
+            .map(|n| {
+                if let NodeData::Element { ref attrs, .. } = n.data {
+                    attrs
+                        .borrow()
+                        .iter()
+                        .any(|a| a.name.local.to_string() == name)
+                } else {
+                    false
+                }
+            })
+            .unwrap_or(false)
+    });
     rv.set_bool(f);
 }
-fn remove_attribute_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn remove_attribute_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
     let name = args.get(1).to_rust_string_lossy(scope);
-    NODE_REGISTRY.with(|reg| if let Some(n)=reg.borrow().get(&nid) { if let NodeData::Element{ref attrs,..}=n.data { attrs.borrow_mut().retain(|a|a.name.local.to_string()!=name); }});
+    NODE_REGISTRY.with(|reg| {
+        if let Some(n) = reg.borrow().get(&nid) {
+            if let NodeData::Element { ref attrs, .. } = n.data {
+                attrs
+                    .borrow_mut()
+                    .retain(|a| a.name.local.to_string() != name);
+            }
+        }
+    });
 }
 
-fn create_element_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn create_element_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let tag = args.get(0).to_rust_string_lossy(scope);
-    let tag = if tag.is_empty() { "div".to_string() } else { tag.to_lowercase() };
-    use html5ever::{QualName,LocalName,ns}; use markup5ever_rcdom::Node;
-    let n = Node::new(NodeData::Element{name:QualName::new(None,ns!(html),LocalName::from(tag)),attrs:std::cell::RefCell::new(vec![]),template_contents:std::cell::RefCell::new(None),mathml_annotation_xml_integration_point:false});
+    let tag = if tag.is_empty() {
+        "div".to_string()
+    } else {
+        tag.to_lowercase()
+    };
+    use html5ever::{ns, LocalName, QualName};
+    use markup5ever_rcdom::Node;
+    let n = Node::new(NodeData::Element {
+        name: QualName::new(None, ns!(html), LocalName::from(tag)),
+        attrs: std::cell::RefCell::new(vec![]),
+        template_contents: std::cell::RefCell::new(None),
+        mathml_annotation_xml_integration_point: false,
+    });
     rv.set_uint32(register_node(n));
 }
-fn create_text_node_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    use html5ever::tendril::StrTendril; use markup5ever_rcdom::Node;
-    rv.set_uint32(register_node(Node::new(NodeData::Text{contents:std::cell::RefCell::new(StrTendril::from(args.get(0).to_rust_string_lossy(scope).as_str()))})));
+fn create_text_node_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    use html5ever::tendril::StrTendril;
+    use markup5ever_rcdom::Node;
+    rv.set_uint32(register_node(Node::new(NodeData::Text {
+        contents: std::cell::RefCell::new(StrTendril::from(
+            args.get(0).to_rust_string_lossy(scope).as_str(),
+        )),
+    })));
 }
-fn create_comment_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    use html5ever::tendril::StrTendril; use markup5ever_rcdom::Node;
-    rv.set_uint32(register_node(Node::new(NodeData::Comment{contents:StrTendril::from(args.get(0).to_rust_string_lossy(scope).as_str())})));
+fn create_comment_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    use html5ever::tendril::StrTendril;
+    use markup5ever_rcdom::Node;
+    rv.set_uint32(register_node(Node::new(NodeData::Comment {
+        contents: StrTendril::from(args.get(0).to_rust_string_lossy(scope).as_str()),
+    })));
 }
-fn create_document_fragment_cb(scope: &mut v8::PinScope, _a: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    use markup5ever_rcdom::Node; let n = Node::new(NodeData::Document); let nid=register_node(n); mark_document_fragment_id(nid); rv.set_uint32(nid);
+fn create_document_fragment_cb(
+    scope: &mut v8::PinScope,
+    _a: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    use markup5ever_rcdom::Node;
+    let n = Node::new(NodeData::Document);
+    let nid = register_node(n);
+    mark_document_fragment_id(nid);
+    rv.set_uint32(nid);
 }
 
-fn append_child_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
-    let pn = args.get(0).uint32_value(scope).unwrap_or(0); let cn = args.get(1).uint32_value(scope).unwrap_or(0);
-    NODE_REGISTRY.with(|reg| { let reg=reg.borrow();
-        if let (Some(p),Some(c))=(reg.get(&pn),reg.get(&cn)) {
-            if is_document_fragment_id(cn) { append_fragment_children(p,c); }
-            else { detach_node_from_parent(c); c.parent.set(Some(Rc::downgrade(p))); p.children.borrow_mut().push(c.clone()); }
+fn append_child_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
+    let pn = args.get(0).uint32_value(scope).unwrap_or(0);
+    let cn = args.get(1).uint32_value(scope).unwrap_or(0);
+    NODE_REGISTRY.with(|reg| {
+        let reg = reg.borrow();
+        if let (Some(p), Some(c)) = (reg.get(&pn), reg.get(&cn)) {
+            if is_document_fragment_id(cn) {
+                append_fragment_children(p, c);
+            } else {
+                detach_node_from_parent(c);
+                c.parent.set(Some(Rc::downgrade(p)));
+                p.children.borrow_mut().push(c.clone());
+            }
         }
     });
 }
-fn remove_child_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
-    let pn = args.get(0).uint32_value(scope).unwrap_or(0); let cn = args.get(1).uint32_value(scope).unwrap_or(0);
-    NODE_REGISTRY.with(|reg| { let reg=reg.borrow();
-        if let (Some(p),Some(c))=(reg.get(&pn),reg.get(&cn)) { let cp=Rc::as_ptr(c) as usize; p.children.borrow_mut().retain(|x|Rc::as_ptr(x) as usize!=cp); c.parent.set(None); }
-    });
-}
-fn insert_before_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
-    let pn = args.get(0).uint32_value(scope).unwrap_or(0); let nn = args.get(1).uint32_value(scope).unwrap_or(0);
-    let rn: Option<u32> = if args.get(2).is_null() { None } else { Some(args.get(2).uint32_value(scope).unwrap_or(0)) };
-    NODE_REGISTRY.with(|reg| { let reg=reg.borrow();
-        if let (Some(p),Some(nc))=(reg.get(&pn),reg.get(&nn)) {
-            let pos = rn.and_then(|rv| reg.get(&rv).and_then(|refn| { let rp=Rc::as_ptr(refn) as usize; p.children.borrow().iter().position(|c|Rc::as_ptr(c) as usize==rp) }));
-            if is_document_fragment_id(nn) { insert_fragment_children(p,nc,pos); }
-            else { detach_node_from_parent(nc); nc.parent.set(Some(Rc::downgrade(p))); let mut ch=p.children.borrow_mut(); if let Some(pos)=pos { ch.insert(pos,nc.clone()); } else { ch.push(nc.clone()); } }
+fn remove_child_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
+    let pn = args.get(0).uint32_value(scope).unwrap_or(0);
+    let cn = args.get(1).uint32_value(scope).unwrap_or(0);
+    NODE_REGISTRY.with(|reg| {
+        let reg = reg.borrow();
+        if let (Some(p), Some(c)) = (reg.get(&pn), reg.get(&cn)) {
+            let cp = Rc::as_ptr(c) as usize;
+            p.children
+                .borrow_mut()
+                .retain(|x| Rc::as_ptr(x) as usize != cp);
+            c.parent.set(None);
         }
     });
 }
-fn remove_self_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn insert_before_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
+    let pn = args.get(0).uint32_value(scope).unwrap_or(0);
+    let nn = args.get(1).uint32_value(scope).unwrap_or(0);
+    let rn: Option<u32> = if args.get(2).is_null() {
+        None
+    } else {
+        Some(args.get(2).uint32_value(scope).unwrap_or(0))
+    };
+    NODE_REGISTRY.with(|reg| {
+        let reg = reg.borrow();
+        if let (Some(p), Some(nc)) = (reg.get(&pn), reg.get(&nn)) {
+            let pos = rn.and_then(|rv| {
+                reg.get(&rv).and_then(|refn| {
+                    let rp = Rc::as_ptr(refn) as usize;
+                    p.children
+                        .borrow()
+                        .iter()
+                        .position(|c| Rc::as_ptr(c) as usize == rp)
+                })
+            });
+            if is_document_fragment_id(nn) {
+                insert_fragment_children(p, nc, pos);
+            } else {
+                detach_node_from_parent(nc);
+                nc.parent.set(Some(Rc::downgrade(p)));
+                let mut ch = p.children.borrow_mut();
+                if let Some(pos) = pos {
+                    ch.insert(pos, nc.clone());
+                } else {
+                    ch.push(nc.clone());
+                }
+            }
+        }
+    });
+}
+fn remove_self_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    NODE_REGISTRY.with(|reg| { let reg=reg.borrow(); if let Some(n)=reg.get(&nid) { let np=Rc::as_ptr(n) as usize;
-        if let Some(pw)=n.parent.take() { if let Some(p)=pw.upgrade() { p.children.borrow_mut().retain(|c|Rc::as_ptr(c) as usize!=np); } } }
+    NODE_REGISTRY.with(|reg| {
+        let reg = reg.borrow();
+        if let Some(n) = reg.get(&nid) {
+            let np = Rc::as_ptr(n) as usize;
+            if let Some(pw) = n.parent.take() {
+                if let Some(p) = pw.upgrade() {
+                    p.children
+                        .borrow_mut()
+                        .retain(|c| Rc::as_ptr(c) as usize != np);
+                }
+            }
+        }
     });
 }
 
-fn get_children_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_children_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let ch = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).map(|n| n.children.borrow().iter().cloned().collect::<Vec<_>>()).unwrap_or_default());
-    let mut items=vec![];
-    for c in ch { let cn=register_node(c.clone()); match &c.data {
-        NodeData::Element{ref name,ref attrs,..} => { let tag=name.local.to_string(); let id=attrs.borrow().iter().find(|a|a.name.local.to_string()=="id").map(|a|a.value.to_string()).unwrap_or_default();
-            items.push(format!("{{\"nid\":{},\"tag\":\"{}\",\"id\":\"{}\",\"kind\":\"element\"}}",cn,tag,id)); }
-        NodeData::Text{..}=>items.push(format!("{{\"nid\":{},\"tag\":\"\",\"id\":\"\",\"kind\":\"text\"}}",cn)),
-        NodeData::Comment{..}=>items.push(format!("{{\"nid\":{},\"tag\":\"\",\"id\":\"\",\"kind\":\"comment\"}}",cn)),
-        NodeData::Doctype{ref name,..}=>items.push(format!("{{\"nid\":{},\"tag\":\"{}\",\"id\":\"\",\"kind\":\"doctype\"}}",cn,name)),
-        NodeData::Document=>items.push(format!("{{\"nid\":{},\"tag\":\"\",\"id\":\"\",\"kind\":\"fragment\"}}",cn)), _=>{}
-    }}
-    rv.set(v8::String::new(scope, &format!("[{}]",items.join(","))).unwrap().into());
+    let ch = NODE_REGISTRY.with(|reg| {
+        reg.borrow()
+            .get(&nid)
+            .map(|n| n.children.borrow().iter().cloned().collect::<Vec<_>>())
+            .unwrap_or_default()
+    });
+    let mut items = vec![];
+    for c in ch {
+        let cn = register_node(c.clone());
+        match &c.data {
+            NodeData::Element {
+                ref name,
+                ref attrs,
+                ..
+            } => {
+                let tag = name.local.to_string();
+                let id = attrs
+                    .borrow()
+                    .iter()
+                    .find(|a| a.name.local.to_string() == "id")
+                    .map(|a| a.value.to_string())
+                    .unwrap_or_default();
+                items.push(format!(
+                    "{{\"nid\":{},\"tag\":\"{}\",\"id\":\"{}\",\"kind\":\"element\"}}",
+                    cn, tag, id
+                ));
+            }
+            NodeData::Text { .. } => items.push(format!(
+                "{{\"nid\":{},\"tag\":\"\",\"id\":\"\",\"kind\":\"text\"}}",
+                cn
+            )),
+            NodeData::Comment { .. } => items.push(format!(
+                "{{\"nid\":{},\"tag\":\"\",\"id\":\"\",\"kind\":\"comment\"}}",
+                cn
+            )),
+            NodeData::Doctype { ref name, .. } => items.push(format!(
+                "{{\"nid\":{},\"tag\":\"{}\",\"id\":\"\",\"kind\":\"doctype\"}}",
+                cn, name
+            )),
+            NodeData::Document => items.push(format!(
+                "{{\"nid\":{},\"tag\":\"\",\"id\":\"\",\"kind\":\"fragment\"}}",
+                cn
+            )),
+            _ => {}
+        }
+    }
+    rv.set(
+        v8::String::new(scope, &format!("[{}]", items.join(",")))
+            .unwrap()
+            .into(),
+    );
 }
-fn get_node_info_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_node_info_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let info = NODE_REGISTRY.with(|reg| { let reg=reg.borrow(); if let Some(n)=reg.get(&nid) {
-        if is_document_fragment_id(nid) { return Some((String::new(),String::new(),String::new(),"fragment".to_string())); }
-        if let NodeData::Element{ref name,ref attrs,..}=n.data { let tag=name.local.to_string(); let ab=attrs.borrow();
-            let id=ab.iter().find(|a|a.name.local.to_string()=="id").map(|a|a.value.to_string()).unwrap_or_default();
-            let cls=ab.iter().find(|a|a.name.local.to_string()=="class").map(|a|a.value.to_string()).unwrap_or_default();
-            return Some((tag,id,cls,"element".to_string())); }
-        else if let NodeData::Text{..}=n.data { return Some((String::new(),String::new(),String::new(),"text".to_string())); }
-        else if let NodeData::Comment{..}=n.data { return Some((String::new(),String::new(),String::new(),"comment".to_string())); }
-        else if let NodeData::Doctype{ref name,..}=n.data { return Some((name.to_string(),String::new(),String::new(),"doctype".to_string())); }
-    } None });
-    if let Some((tag,id,cls,kind))=info { let o=v8::Object::new(scope);
-        o.set(scope, v8::String::new(scope,"tag").unwrap().into(), v8::String::new(scope,&tag).unwrap().into());
-        o.set(scope, v8::String::new(scope,"id").unwrap().into(), v8::String::new(scope,&id).unwrap().into());
-        o.set(scope, v8::String::new(scope,"class").unwrap().into(), v8::String::new(scope,&cls).unwrap().into());
-        o.set(scope, v8::String::new(scope,"kind").unwrap().into(), v8::String::new(scope,&kind).unwrap().into());
-        rv.set(o.into()); } else { rv.set_null(); }
+    let info = NODE_REGISTRY.with(|reg| {
+        let reg = reg.borrow();
+        if let Some(n) = reg.get(&nid) {
+            if is_document_fragment_id(nid) {
+                return Some((
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    "fragment".to_string(),
+                ));
+            }
+            if let NodeData::Element {
+                ref name,
+                ref attrs,
+                ..
+            } = n.data
+            {
+                let tag = name.local.to_string();
+                let ab = attrs.borrow();
+                let id = ab
+                    .iter()
+                    .find(|a| a.name.local.to_string() == "id")
+                    .map(|a| a.value.to_string())
+                    .unwrap_or_default();
+                let cls = ab
+                    .iter()
+                    .find(|a| a.name.local.to_string() == "class")
+                    .map(|a| a.value.to_string())
+                    .unwrap_or_default();
+                return Some((tag, id, cls, "element".to_string()));
+            } else if let NodeData::Text { .. } = n.data {
+                return Some((
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    "text".to_string(),
+                ));
+            } else if let NodeData::Comment { .. } = n.data {
+                return Some((
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    "comment".to_string(),
+                ));
+            } else if let NodeData::Doctype { ref name, .. } = n.data {
+                return Some((
+                    name.to_string(),
+                    String::new(),
+                    String::new(),
+                    "doctype".to_string(),
+                ));
+            }
+        }
+        None
+    });
+    if let Some((tag, id, cls, kind)) = info {
+        let o = v8::Object::new(scope);
+        o.set(
+            scope,
+            v8::String::new(scope, "tag").unwrap().into(),
+            v8::String::new(scope, &tag).unwrap().into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "id").unwrap().into(),
+            v8::String::new(scope, &id).unwrap().into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "class").unwrap().into(),
+            v8::String::new(scope, &cls).unwrap().into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "kind").unwrap().into(),
+            v8::String::new(scope, &kind).unwrap().into(),
+        );
+        rv.set(o.into());
+    } else {
+        rv.set_null();
+    }
 }
-fn get_node_type_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_node_type_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let nt = NODE_REGISTRY.with(|reg| { if is_document_fragment_id(nid) { 11 } else { reg.borrow().get(&nid).map(|n| match n.data { NodeData::Element{..}=>1,NodeData::Text{..}=>3,NodeData::Comment{..}=>8,NodeData::Doctype{..}=>10,NodeData::Document=>9,_=>0}).unwrap_or(0) }});
+    let nt = NODE_REGISTRY.with(|reg| {
+        if is_document_fragment_id(nid) {
+            11
+        } else {
+            reg.borrow()
+                .get(&nid)
+                .map(|n| match n.data {
+                    NodeData::Element { .. } => 1,
+                    NodeData::Text { .. } => 3,
+                    NodeData::Comment { .. } => 8,
+                    NodeData::Doctype { .. } => 10,
+                    NodeData::Document => 9,
+                    _ => 0,
+                })
+                .unwrap_or(0)
+        }
+    });
     rv.set_int32(nt);
 }
-fn get_node_value_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_node_value_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let v = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).and_then(|n| match &n.data { NodeData::Text{contents}=>Some(contents.borrow().to_string()), NodeData::Comment{contents}=>Some(contents.to_string()), _=>None }));
-    if let Some(s)=v { rv.set(v8::String::new(scope,&s).unwrap().into()); } else { rv.set_null(); }
+    let v = NODE_REGISTRY.with(|reg| {
+        reg.borrow().get(&nid).and_then(|n| match &n.data {
+            NodeData::Text { contents } => Some(contents.borrow().to_string()),
+            NodeData::Comment { contents } => Some(contents.to_string()),
+            _ => None,
+        })
+    });
+    if let Some(s) = v {
+        rv.set(v8::String::new(scope, &s).unwrap().into());
+    } else {
+        rv.set_null();
+    }
 }
-fn set_node_value_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn set_node_value_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     set_text_content_cb(scope, args, _rv);
 }
-fn get_layout_metrics_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_layout_metrics_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let m = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).and_then(|n| { let k=node_path_key(n); LAYOUT_METRICS.with(|lm| lm.borrow().get(&k).cloned()) }));
-    if let Some(metrics)=m { let o=v8::Object::new(scope);
-        o.set(scope, v8::String::new(scope,"x").unwrap().into(), v8::Number::new(scope,metrics.x as f64).into());
-        o.set(scope, v8::String::new(scope,"y").unwrap().into(), v8::Number::new(scope,metrics.y as f64).into());
-        o.set(scope, v8::String::new(scope,"width").unwrap().into(), v8::Number::new(scope,metrics.width as f64).into());
-        o.set(scope, v8::String::new(scope,"height").unwrap().into(), v8::Number::new(scope,metrics.height as f64).into());
-        o.set(scope, v8::String::new(scope,"top").unwrap().into(), v8::Number::new(scope,metrics.y as f64).into());
-        o.set(scope, v8::String::new(scope,"left").unwrap().into(), v8::Number::new(scope,metrics.x as f64).into());
-        o.set(scope, v8::String::new(scope,"right").unwrap().into(), v8::Number::new(scope,metrics.right() as f64).into());
-        o.set(scope, v8::String::new(scope,"bottom").unwrap().into(), v8::Number::new(scope,metrics.bottom() as f64).into());
-        rv.set(o.into()); } else { rv.set_null(); }
+    let m = NODE_REGISTRY.with(|reg| {
+        reg.borrow().get(&nid).and_then(|n| {
+            let k = node_path_key(n);
+            LAYOUT_METRICS.with(|lm| lm.borrow().get(&k).cloned())
+        })
+    });
+    if let Some(metrics) = m {
+        let o = v8::Object::new(scope);
+        o.set(
+            scope,
+            v8::String::new(scope, "x").unwrap().into(),
+            v8::Number::new(scope, metrics.x as f64).into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "y").unwrap().into(),
+            v8::Number::new(scope, metrics.y as f64).into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "width").unwrap().into(),
+            v8::Number::new(scope, metrics.width as f64).into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "height").unwrap().into(),
+            v8::Number::new(scope, metrics.height as f64).into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "top").unwrap().into(),
+            v8::Number::new(scope, metrics.y as f64).into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "left").unwrap().into(),
+            v8::Number::new(scope, metrics.x as f64).into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "right").unwrap().into(),
+            v8::Number::new(scope, metrics.right() as f64).into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "bottom").unwrap().into(),
+            v8::Number::new(scope, metrics.bottom() as f64).into(),
+        );
+        rv.set(o.into());
+    } else {
+        rv.set_null();
+    }
 }
-fn get_doctype_id_cb(scope: &mut v8::PinScope, _a: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
-    let nid = DOM_ROOT.with(|r| r.borrow().as_ref().and_then(find_document_doctype).map(register_node));
-    if let Some(n)=nid { rv.set_uint32(n); } else { rv.set_null(); }
+fn get_doctype_id_cb(
+    scope: &mut v8::PinScope,
+    _a: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    let nid = DOM_ROOT.with(|r| {
+        r.borrow()
+            .as_ref()
+            .and_then(find_document_doctype)
+            .map(register_node)
+    });
+    if let Some(n) = nid {
+        rv.set_uint32(n);
+    } else {
+        rv.set_null();
+    }
 }
-fn get_doctype_info_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn get_doctype_info_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let nid = args.get(0).uint32_value(scope).unwrap_or(0);
-    let info = NODE_REGISTRY.with(|reg| reg.borrow().get(&nid).and_then(|n| {
-        if let NodeData::Doctype{ref name,ref public_id,ref system_id}=n.data { Some((name.to_string(),public_id.to_string(),system_id.to_string())) } else {None}
-    }));
-    if let Some((name,pid,sid))=info { let o=v8::Object::new(scope);
-        o.set(scope, v8::String::new(scope,"name").unwrap().into(), v8::String::new(scope,&name).unwrap().into());
-        o.set(scope, v8::String::new(scope,"publicId").unwrap().into(), v8::String::new(scope,&pid).unwrap().into());
-        o.set(scope, v8::String::new(scope,"systemId").unwrap().into(), v8::String::new(scope,&sid).unwrap().into());
-        rv.set(o.into()); } else { rv.set_null(); }
+    let info = NODE_REGISTRY.with(|reg| {
+        reg.borrow().get(&nid).and_then(|n| {
+            if let NodeData::Doctype {
+                ref name,
+                ref public_id,
+                ref system_id,
+            } = n.data
+            {
+                Some((
+                    name.to_string(),
+                    public_id.to_string(),
+                    system_id.to_string(),
+                ))
+            } else {
+                None
+            }
+        })
+    });
+    if let Some((name, pid, sid)) = info {
+        let o = v8::Object::new(scope);
+        o.set(
+            scope,
+            v8::String::new(scope, "name").unwrap().into(),
+            v8::String::new(scope, &name).unwrap().into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "publicId").unwrap().into(),
+            v8::String::new(scope, &pid).unwrap().into(),
+        );
+        o.set(
+            scope,
+            v8::String::new(scope, "systemId").unwrap().into(),
+            v8::String::new(scope, &sid).unwrap().into(),
+        );
+        rv.set(o.into());
+    } else {
+        rv.set_null();
+    }
 }
-fn set_focus_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn set_focus_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let id = args.get(0).to_rust_string_lossy(scope);
-    if id.is_empty() { FOCUSED_NODE.with(|f| *f.borrow_mut() = None); } else { FOCUSED_NODE.with(|f| *f.borrow_mut() = Some(id)); }
+    if id.is_empty() {
+        FOCUSED_NODE.with(|f| *f.borrow_mut() = None);
+    } else {
+        FOCUSED_NODE.with(|f| *f.borrow_mut() = Some(id));
+    }
 }
-fn queue_task_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn queue_task_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let cb = args.get(0);
     if cb.is_function() {
         let cb_func: v8::Local<v8::Function> = unsafe { std::mem::transmute(cb) };
         let cb_global = v8::Global::new(scope, cb_func);
-        MACRO_TASKS.with(|tasks| tasks.borrow_mut().push_back(Box::new(move || {
-            RUN_PENDING.with(|p| p.borrow_mut().push((cb_global.clone(), None)));
-        })));
+        MACRO_TASKS.with(|tasks| {
+            tasks.borrow_mut().push_back(Box::new(move || {
+                RUN_PENDING.with(|p| p.borrow_mut().push((cb_global.clone(), None)));
+            }))
+        });
     }
 }
-fn resolve_url_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn resolve_url_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let input = args.get(0).to_rust_string_lossy(scope);
-    let base = args.get(1).to_rust_string_lossy(scope);
-    let resolved = if !base.is_empty() { Url::parse(&base).ok().and_then(|b|b.join(&input).ok()).or_else(||Url::parse(&input).ok()) } else { Url::parse(&input).ok() };
-    rv.set(v8::String::new(scope, &resolved.map(|u|u.to_string()).unwrap_or(input)).unwrap().into());
+    let base_arg = args.get(1);
+    let base = if base_arg.is_null() || base_arg.is_undefined() {
+        String::new()
+    } else {
+        base_arg.to_rust_string_lossy(scope)
+    };
+    let resolved = if !base.is_empty() {
+        Url::parse(&base)
+            .ok()
+            .and_then(|b| b.join(&input).ok())
+            .or_else(|| Url::parse(&input).ok())
+    } else {
+        Url::parse(&input).ok()
+    };
+    rv.set(
+        v8::String::new(scope, &resolved.map(|u| u.to_string()).unwrap_or(input))
+            .unwrap()
+            .into(),
+    );
 }
-fn can_execute_script_url_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn can_execute_script_url_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let url_str = args.get(0).to_rust_string_lossy(scope);
     let base_url = CURRENT_ORIGIN.with(|o| (*o.borrow()).clone());
-    let target = if let Some(ref b)=base_url { b.join(&url_str).unwrap_or_else(|_|Url::parse(&url_str).unwrap_or(b.clone())) } else { Url::parse(&url_str).unwrap_or_else(|_|Url::parse("about:blank").unwrap()) };
-    let allowed = CSP_POLICY.with(|p| p.borrow().as_ref().map(|pol|pol.is_allowed("script-src",&target,base_url.as_ref())).unwrap_or(true));
+    let target = if let Some(ref b) = base_url {
+        b.join(&url_str)
+            .unwrap_or_else(|_| Url::parse(&url_str).unwrap_or(b.clone()))
+    } else {
+        Url::parse(&url_str).unwrap_or_else(|_| Url::parse("about:blank").unwrap())
+    };
+    let allowed = CSP_POLICY.with(|p| {
+        p.borrow()
+            .as_ref()
+            .map(|pol| pol.is_allowed("script-src", &target, base_url.as_ref()))
+            .unwrap_or(true)
+    });
     rv.set_bool(allowed);
 }
-fn parse_url_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn parse_url_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let input = args.get(0).to_rust_string_lossy(scope);
-    let base = args.get(1).to_rust_string_lossy(scope);
+    let base_arg = args.get(1);
+    let base = if base_arg.is_null() || base_arg.is_undefined() {
+        String::new()
+    } else {
+        base_arg.to_rust_string_lossy(scope)
+    };
     let base = if base.is_empty() { None } else { Some(base) };
-    let parsed = if let Some(ref b)=base { Url::parse(b).ok().and_then(|bu|bu.join(&input).ok()) } else { Url::parse(&input).ok() };
-    if let Some(url)=parsed {
-        let o=v8::Object::new(scope);
-        let s = |k:&str,v:&str| { o.set(scope, v8::String::new(scope,k).unwrap().into(), v8::String::new(scope,v).unwrap().into()); };
-        s("href",&url.to_string()); s("hostname",url.host_str().unwrap_or(""));
-        s("pathname",url.path()); s("search",&url.query().map(|q|format!("?{}",q)).unwrap_or_default());
-        s("hash",&url.fragment().map(|f|format!("#{}",f)).unwrap_or_default());
-        s("protocol",&format!("{}:",url.scheme()));
-        s("host",&url.host_str().map(|h| if let Some(p)=url.port(){format!("{}:{}",h,p)}else{h.to_string()}).unwrap_or_default());
-        s("port",&url.port().map(|p|p.to_string()).unwrap_or_default());
-        s("origin",&url.origin().unicode_serialization());
-        rv.set(o.into()); } else { rv.set_null(); }
+    let parsed = if let Some(ref b) = base {
+        Url::parse(b).ok().and_then(|bu| bu.join(&input).ok())
+    } else {
+        Url::parse(&input).ok()
+    };
+    if let Some(url) = parsed {
+        let o = v8::Object::new(scope);
+        let s = |k: &str, v: &str| {
+            o.set(
+                scope,
+                v8::String::new(scope, k).unwrap().into(),
+                v8::String::new(scope, v).unwrap().into(),
+            );
+        };
+        s("href", &url.to_string());
+        s("hostname", url.host_str().unwrap_or(""));
+        s("pathname", url.path());
+        s(
+            "search",
+            &url.query().map(|q| format!("?{}", q)).unwrap_or_default(),
+        );
+        s(
+            "hash",
+            &url.fragment()
+                .map(|f| format!("#{}", f))
+                .unwrap_or_default(),
+        );
+        s("protocol", &format!("{}:", url.scheme()));
+        s(
+            "host",
+            &url.host_str()
+                .map(|h| {
+                    if let Some(p) = url.port() {
+                        format!("{}:{}", h, p)
+                    } else {
+                        h.to_string()
+                    }
+                })
+                .unwrap_or_default(),
+        );
+        s(
+            "port",
+            &url.port().map(|p| p.to_string()).unwrap_or_default(),
+        );
+        s("origin", &url.origin().unicode_serialization());
+        rv.set(o.into());
+    } else {
+        rv.set_null();
+    }
 }
-fn storage_get_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn storage_get_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let key = args.get(0).to_rust_string_lossy(scope);
-    let origin = CURRENT_ORIGIN.with(|o| o.borrow().as_ref().map(|u|u.origin().unicode_serialization()).unwrap_or_else(||"null".to_string()));
+    let origin = CURRENT_ORIGIN.with(|o| {
+        o.borrow()
+            .as_ref()
+            .map(|u| u.origin().unicode_serialization())
+            .unwrap_or_else(|| "null".to_string())
+    });
     let store = GLOBAL_STORAGE.lock().unwrap();
-    let val = store.data.get(&origin).and_then(|m|m.get(&key)).cloned().unwrap_or_else(||"null".to_string());
-    if val=="null" { rv.set_null(); } else { rv.set(v8::String::new(scope,&val).unwrap().into()); }
+    let val = store
+        .data
+        .get(&origin)
+        .and_then(|m| m.get(&key))
+        .cloned()
+        .unwrap_or_else(|| "null".to_string());
+    if val == "null" {
+        rv.set_null();
+    } else {
+        rv.set(v8::String::new(scope, &val).unwrap().into());
+    }
 }
-fn storage_set_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
-    let key = args.get(0).to_rust_string_lossy(scope); let value = args.get(1).to_rust_string_lossy(scope);
-    let origin = CURRENT_ORIGIN.with(|o| o.borrow().as_ref().map(|u|u.origin().unicode_serialization()).unwrap_or_else(||"null".to_string()));
-    let mut store = GLOBAL_STORAGE.lock().unwrap();
-    store.data.entry(origin).or_insert_with(HashMap::new).insert(key,value); store.save();
-}
-fn storage_remove_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn storage_set_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let key = args.get(0).to_rust_string_lossy(scope);
-    let origin = CURRENT_ORIGIN.with(|o| o.borrow().as_ref().map(|u|u.origin().unicode_serialization()).unwrap_or_else(||"null".to_string()));
+    let value = args.get(1).to_rust_string_lossy(scope);
+    let origin = CURRENT_ORIGIN.with(|o| {
+        o.borrow()
+            .as_ref()
+            .map(|u| u.origin().unicode_serialization())
+            .unwrap_or_else(|| "null".to_string())
+    });
     let mut store = GLOBAL_STORAGE.lock().unwrap();
-    if let Some(m)=store.data.get_mut(&origin) { m.remove(&key); store.save(); }
+    store
+        .data
+        .entry(origin)
+        .or_insert_with(HashMap::new)
+        .insert(key, value);
+    store.save();
 }
-fn storage_clear_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
-    let origin = CURRENT_ORIGIN.with(|o| o.borrow().as_ref().map(|u|u.origin().unicode_serialization()).unwrap_or_else(||"null".to_string()));
+fn storage_remove_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
+    let key = args.get(0).to_rust_string_lossy(scope);
+    let origin = CURRENT_ORIGIN.with(|o| {
+        o.borrow()
+            .as_ref()
+            .map(|u| u.origin().unicode_serialization())
+            .unwrap_or_else(|| "null".to_string())
+    });
     let mut store = GLOBAL_STORAGE.lock().unwrap();
-    if let Some(m)=store.data.get_mut(&origin) { m.clear(); store.save(); }
+    if let Some(m) = store.data.get_mut(&origin) {
+        m.remove(&key);
+        store.save();
+    }
 }
-fn fetch_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn storage_clear_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
+    let origin = CURRENT_ORIGIN.with(|o| {
+        o.borrow()
+            .as_ref()
+            .map(|u| u.origin().unicode_serialization())
+            .unwrap_or_else(|| "null".to_string())
+    });
+    let mut store = GLOBAL_STORAGE.lock().unwrap();
+    if let Some(m) = store.data.get_mut(&origin) {
+        m.clear();
+        store.save();
+    }
+}
+fn fetch_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let url_str = args.get(0).to_rust_string_lossy(scope);
     let method_str = args.get(1).to_rust_string_lossy(scope);
-    let method_str = if method_str.is_empty() { "GET".to_string() } else { method_str };
+    let method_str = if method_str.is_empty() {
+        "GET".to_string()
+    } else {
+        method_str
+    };
     let headers_json = args.get(2).to_rust_string_lossy(scope);
-    let headers_json = if headers_json.is_empty() { "{}".to_string() } else { headers_json };
+    let headers_json = if headers_json.is_empty() {
+        "{}".to_string()
+    } else {
+        headers_json
+    };
     let body = args.get(3).to_rust_string_lossy(scope);
     let resolve_val = args.get(4);
     let reject_val = args.get(5);
 
     let base_url = CURRENT_ORIGIN.with(|o| (*o.borrow()).clone());
     let target_url = if let Some(ref base) = base_url {
-        base.join(&url_str).unwrap_or_else(|_| Url::parse(&url_str).unwrap_or(base.clone()))
+        base.join(&url_str)
+            .unwrap_or_else(|_| Url::parse(&url_str).unwrap_or(base.clone()))
     } else {
         Url::parse(&url_str).unwrap_or_else(|_| Url::parse("about:blank").unwrap())
     };
 
     let allowed = CSP_POLICY.with(|p| {
-        p.borrow().as_ref().map(|pol| pol.is_allowed("connect-src", &target_url, base_url.as_ref())).unwrap_or(true)
+        p.borrow()
+            .as_ref()
+            .map(|pol| pol.is_allowed("connect-src", &target_url, base_url.as_ref()))
+            .unwrap_or(true)
     });
 
     if !allowed {
         if reject_val.is_function() {
             let rej: v8::Local<v8::Function> = unsafe { std::mem::transmute(reject_val) };
-            let msg = v8::String::new(scope, "CSP Error: connect-src directive blocked this request").unwrap();
+            let msg = v8::String::new(
+                scope,
+                "CSP Error: connect-src directive blocked this request",
+            )
+            .unwrap();
             let undef = v8::undefined(scope);
             let _ = rej.call(scope, undef.into(), &[msg.into()]);
         }
@@ -1107,10 +2284,13 @@ fn fetch_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: 
         let res: v8::Local<v8::Function> = unsafe { std::mem::transmute(resolve_val) };
         let rej: v8::Local<v8::Function> = unsafe { std::mem::transmute(reject_val) };
         FETCH_REGISTRY.with(|reg| {
-            reg.borrow_mut().insert(fetch_id, FetchHandlers {
-                resolve: v8::Global::new(scope, res),
-                reject: v8::Global::new(scope, rej),
-            });
+            reg.borrow_mut().insert(
+                fetch_id,
+                FetchHandlers {
+                    resolve: v8::Global::new(scope, res),
+                    reject: v8::Global::new(scope, rej),
+                },
+            );
         });
     }
 
@@ -1189,29 +2369,45 @@ fn fetch_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: 
     });
 }
 
-fn setTimeout_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn setTimeout_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let cb = args.get(0);
     if cb.is_function() {
         let cb_func: v8::Local<v8::Function> = unsafe { std::mem::transmute(cb) };
         let cb_global = v8::Global::new(scope, cb_func);
-        MACRO_TASKS.with(|tasks| tasks.borrow_mut().push_back(Box::new(move || {
-            RUN_PENDING.with(|p| p.borrow_mut().push((cb_global.clone(), None)));
-        })));
+        MACRO_TASKS.with(|tasks| {
+            tasks.borrow_mut().push_back(Box::new(move || {
+                RUN_PENDING.with(|p| p.borrow_mut().push((cb_global.clone(), None)));
+            }))
+        });
     }
 }
 
-fn raf_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn raf_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let cb = args.get(0);
     if cb.is_function() {
         let cb_func: v8::Local<v8::Function> = unsafe { std::mem::transmute(cb) };
         let cb_global = v8::Global::new(scope, cb_func);
-        RAF_TASKS.with(|tasks| tasks.borrow_mut().push_back(Box::new(move |timestamp| {
-            RUN_PENDING.with(|p| p.borrow_mut().push((cb_global.clone(), Some(timestamp))));
-        })));
+        RAF_TASKS.with(|tasks| {
+            tasks.borrow_mut().push_back(Box::new(move |timestamp| {
+                RUN_PENDING.with(|p| p.borrow_mut().push((cb_global.clone(), Some(timestamp))));
+            }))
+        });
     }
 }
 
-fn ric_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv: v8::ReturnValue<v8::Value>) {
+fn ric_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
     let cb = args.get(0);
     if cb.is_function() {
         let cb_func: v8::Local<v8::Function> = unsafe { std::mem::transmute(cb) };
@@ -1221,27 +2417,41 @@ fn ric_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, mut rv:
             *id_cell.borrow_mut() += 1;
             id
         });
-        IDLE_TASKS.with(|tasks| tasks.borrow_mut().push_back((id, Box::new(move |deadline| {
-            RUN_PENDING.with(|p| p.borrow_mut().push((cb_global.clone(), Some(deadline))));
-        }))));
+        IDLE_TASKS.with(|tasks| {
+            tasks.borrow_mut().push_back((
+                id,
+                Box::new(move |deadline| {
+                    RUN_PENDING.with(|p| p.borrow_mut().push((cb_global.clone(), Some(deadline))));
+                }),
+            ))
+        });
         rv.set_uint32(id);
     }
 }
 
-fn cic_cb(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue<v8::Value>) {
+fn cic_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
     let id = args.get(0).uint32_value(scope).unwrap_or(0);
     IDLE_TASKS.with(|tasks| tasks.borrow_mut().retain(|(tid, _)| *tid != id));
 }
 
-fn console_impl(scope: &mut v8::PinScope, args: v8::FunctionCallbackArguments, level: ConsoleLevel) {
+fn console_impl(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    level: ConsoleLevel,
+) {
     let mut output = String::new();
     for i in 0..args.length() {
-        if i > 0 { output.push(' '); }
+        if i > 0 {
+            output.push(' ');
+        }
         output.push_str(&args.get(i).to_rust_string_lossy(scope));
     }
     push_console_entry(level, output);
 }
-
 
 pub fn node_path_key(node: &Handle) -> String {
     let mut indices = Vec::new();
@@ -1273,23 +2483,112 @@ pub fn node_path_key(node: &Handle) -> String {
 }
 
 pub fn extract_scripts_from_dom(handle: &Handle) -> Vec<String> {
-    let mut scripts = Vec::new();
-    if let NodeData::Element { ref name, .. } = handle.data {
-        if name.local.to_string() == "script" {
-            let mut content = String::new();
-            for child in handle.children.borrow().iter() {
-                if let NodeData::Text { ref contents } = child.data {
-                    content.push_str(&contents.borrow());
+    extract_script_sources_from_dom(handle, None)
+        .into_iter()
+        .filter_map(|source| match source {
+            ScriptSource::InlineClassic(script) => Some(script),
+            ScriptSource::ExternalClassic(_)
+            | ScriptSource::InlineModule { .. }
+            | ScriptSource::ExternalModule(_) => None,
+        })
+        .collect()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ScriptSource {
+    InlineClassic(String),
+    ExternalClassic(Url),
+    InlineModule { url: Url, source: String },
+    ExternalModule(Url),
+}
+
+pub fn extract_script_sources_from_dom(
+    handle: &Handle,
+    base_url: Option<&Url>,
+) -> Vec<ScriptSource> {
+    fn walk(
+        handle: &Handle,
+        base_url: Option<&Url>,
+        scripts: &mut Vec<ScriptSource>,
+        inline_module_id: &mut usize,
+    ) {
+        if let NodeData::Element {
+            ref name,
+            ref attrs,
+            ..
+        } = handle.data
+        {
+            if name.local.to_string() == "script" {
+                let mut src = None;
+                let mut script_type = None;
+                for attr in attrs.borrow().iter() {
+                    let attr_name = attr.name.local.to_string();
+                    if attr_name == "src" {
+                        src = Some(attr.value.to_string());
+                    } else if attr_name == "type" {
+                        script_type = Some(attr.value.to_string().trim().to_lowercase());
+                    }
                 }
-            }
-            if !content.is_empty() {
-                scripts.push(content);
+
+                let is_module = matches!(script_type.as_deref(), Some("module"));
+                let is_classic = match script_type.as_deref() {
+                    None
+                    | Some("")
+                    | Some("text/javascript")
+                    | Some("application/javascript")
+                    | Some("classic") => true,
+                    _ => false,
+                };
+
+                if let Some(src) = src {
+                    if let Some(base) = base_url {
+                        if let Ok(url) = base.join(&src).or_else(|_| Url::parse(&src)) {
+                            if is_module {
+                                scripts.push(ScriptSource::ExternalModule(url));
+                            } else if is_classic {
+                                scripts.push(ScriptSource::ExternalClassic(url));
+                            }
+                        }
+                    }
+                } else {
+                    let mut content = String::new();
+                    for child in handle.children.borrow().iter() {
+                        if let NodeData::Text { ref contents } = child.data {
+                            content.push_str(&contents.borrow());
+                        }
+                    }
+                    if !content.is_empty() {
+                        if is_module {
+                            if let Some(base) = base_url {
+                                *inline_module_id += 1;
+                                let mut url = base.clone();
+                                url.set_fragment(Some(&format!(
+                                    "inline-module-{}",
+                                    inline_module_id
+                                )));
+                                scripts.push(ScriptSource::InlineModule {
+                                    url,
+                                    source: content,
+                                });
+                            }
+                        } else if is_classic {
+                            scripts.push(ScriptSource::InlineClassic(content));
+                        }
+                    }
+                }
+
+                return;
             }
         }
+
+        for child in handle.children.borrow().iter() {
+            walk(child, base_url, scripts, inline_module_id);
+        }
     }
-    for child in handle.children.borrow().iter() {
-        scripts.extend(extract_scripts_from_dom(child));
-    }
+
+    let mut scripts = Vec::new();
+    let mut inline_module_id = 0;
+    walk(handle, base_url, &mut scripts, &mut inline_module_id);
     scripts
 }
 
@@ -1301,6 +2600,17 @@ mod tests {
     fn make_runtime(html: &str) -> JsRuntime {
         let _dom = dom::parse_html(html);
         JsRuntime::new(None, None, None, None, new_console_buffer())
+    }
+
+    fn make_dom_runtime(html: &str, url: &str) -> JsRuntime {
+        let dom = dom::parse_html(html);
+        JsRuntime::new(
+            Some(dom.document.clone()),
+            Some(Url::parse(url).unwrap()),
+            None,
+            None,
+            new_console_buffer(),
+        )
     }
 
     #[test]
@@ -1326,16 +2636,125 @@ mod tests {
         assert_eq!(outcome.result.as_deref(), Some("{\"a\":1,\"b\":[2,3]}"));
         assert_eq!(outcome.error, None);
     }
+
+    #[test]
+    fn test_execute_with_result_does_not_prescan_import_text() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let outcome = rt.execute_with_result(r#""import value from './dep.js'""#);
+        assert_eq!(outcome.result.as_deref(), Some("import value from './dep.js'"));
+        assert_eq!(outcome.error, None);
+    }
+
+    #[test]
+    fn test_dom_runtime_initializes_location_and_url() {
+        let mut rt = make_dom_runtime(
+            "<html><body></body></html>",
+            "https://example.com/path/page.html",
+        );
+        let outcome = rt.execute_with_result(
+            r#"JSON.stringify({
+                href: location.href,
+                baseURI: document.baseURI,
+                resolved: new URL('/asset.js', location.href).href
+            })"#,
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(
+            outcome.result.as_deref(),
+            Some("{\"href\":\"https://example.com/path/page.html\",\"baseURI\":\"https://example.com/path/page.html\",\"resolved\":\"https://example.com/asset.js\"}")
+        );
+    }
+
+    #[test]
+    fn test_script_src_getter_resolves_relative_url() {
+        let mut rt = make_dom_runtime(
+            r#"<html><head><script src="/bundle.js"></script></head><body></body></html>"#,
+            "https://example.com/app/",
+        );
+        let outcome = rt.execute_with_result("document.scripts[0].src");
+        assert_eq!(outcome.error, None);
+        assert_eq!(
+            outcome.result.as_deref(),
+            Some("https://example.com/bundle.js")
+        );
+    }
+
+    #[test]
+    fn test_extract_script_sources_in_dom_order() {
+        let dom = dom::parse_html(
+            r#"<html><head>
+                <script>window.a = 1;</script>
+                <script src="/bundle.js"></script>
+                <script type="module" src="/module.js"></script>
+            </head></html>"#,
+        );
+        let base = Url::parse("https://example.com/app/").unwrap();
+        let sources = extract_script_sources_from_dom(&dom.document, Some(&base));
+        assert_eq!(
+            sources,
+            vec![
+                ScriptSource::InlineClassic("window.a = 1;".to_string()),
+                ScriptSource::ExternalClassic(Url::parse("https://example.com/bundle.js").unwrap()),
+                ScriptSource::ExternalModule(Url::parse("https://example.com/module.js").unwrap()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compile_module_source_caches_by_url() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let url = Url::parse("https://example.com/app/module.js").unwrap();
+
+        let first = rt.compile_module_source(
+            url.clone(),
+            "import value from './dep.js'; export const answer = value;".to_string(),
+        );
+        assert_eq!(first.error, None);
+        assert!(!first.from_cache);
+        assert_eq!(first.requests, vec!["./dep.js".to_string()]);
+        assert_eq!(rt.module_cache_len(), 1);
+
+        let second = rt.compile_module_source(url.clone(), "export const answer = 42;".to_string());
+        assert_eq!(second.error, None);
+        assert!(second.from_cache);
+        assert_eq!(second.requests, vec!["./dep.js".to_string()]);
+        assert_eq!(
+            rt.cached_module_source(&url),
+            Some("import value from './dep.js'; export const answer = value;")
+        );
+        assert_eq!(rt.module_cache_len(), 1);
+    }
+
+    #[test]
+    fn test_compile_module_source_reports_error_without_cache() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        let url = Url::parse("https://example.com/app/bad.js").unwrap();
+        let outcome = rt.compile_module_source(url, "export const = ;".to_string());
+        assert!(outcome.error.is_some());
+        assert_eq!(rt.module_cache_len(), 0);
+    }
+
+    #[test]
+    fn test_resolve_module_specifier_uses_referrer() {
+        let rt = make_runtime("<html><body></body></html>");
+        let referrer = Url::parse("https://example.com/app/modules/main.js").unwrap();
+        let resolved = rt.resolve_module_specifier("./dep.js", &referrer).unwrap();
+        assert_eq!(resolved.as_str(), "https://example.com/app/modules/dep.js");
+    }
 }
 
 // ── DOM Helper Functions ──────────────────────────────────────────────────────
 
 fn find_element_by_tag(root: &Handle, tag: &str) -> Option<Handle> {
     if let NodeData::Element { ref name, .. } = root.data {
-        if name.local.to_string() == tag { return Some(root.clone()); }
+        if name.local.to_string() == tag {
+            return Some(root.clone());
+        }
     }
     for child in root.children.borrow().iter() {
-        if let Some(found) = find_element_by_tag(child, tag) { return Some(found); }
+        if let Some(found) = find_element_by_tag(child, tag) {
+            return Some(found);
+        }
     }
     None
 }
@@ -1343,7 +2762,9 @@ fn find_element_by_tag(root: &Handle, tag: &str) -> Option<Handle> {
 fn find_direct_child_element_by_tag(root: &Handle, tag: &str) -> Option<Handle> {
     for child in root.children.borrow().iter() {
         if let NodeData::Element { ref name, .. } = child.data {
-            if name.local.to_string() == tag { return Some(child.clone()); }
+            if name.local.to_string() == tag {
+                return Some(child.clone());
+            }
         }
     }
     None
@@ -1366,14 +2787,18 @@ fn find_element_by_id(root: &Handle, id: &str) -> Option<Handle> {
         }
     }
     for child in root.children.borrow().iter() {
-        if let Some(found) = find_element_by_id(child, id) { return Some(found); }
+        if let Some(found) = find_element_by_id(child, id) {
+            return Some(found);
+        }
     }
     None
 }
 
 fn find_document_doctype(root: &Handle) -> Option<Handle> {
     for child in root.children.borrow().iter() {
-        if let NodeData::Doctype { .. } = child.data { return Some(child.clone()); }
+        if let NodeData::Doctype { .. } = child.data {
+            return Some(child.clone());
+        }
     }
     None
 }
@@ -1395,12 +2820,22 @@ fn register_node(handle: Handle) -> u32 {
 
 fn replace_registered_node(id: u32, new_handle: Handle) {
     let parent = NODE_REGISTRY.with(|reg| {
-        reg.borrow().get(&id).and_then(|node| node.parent.take().and_then(|weak| weak.upgrade()))
+        reg.borrow()
+            .get(&id)
+            .and_then(|node| node.parent.take().and_then(|weak| weak.upgrade()))
     });
     if let Some(ref parent_handle) = parent {
-        let old_ptr = NODE_REGISTRY.with(|reg| reg.borrow().get(&id).map(|node| Rc::as_ptr(node) as usize).unwrap_or(0));
+        let old_ptr = NODE_REGISTRY.with(|reg| {
+            reg.borrow()
+                .get(&id)
+                .map(|node| Rc::as_ptr(node) as usize)
+                .unwrap_or(0)
+        });
         let mut children = parent_handle.children.borrow_mut();
-        if let Some(pos) = children.iter().position(|child| Rc::as_ptr(child) as usize == old_ptr) {
+        if let Some(pos) = children
+            .iter()
+            .position(|child| Rc::as_ptr(child) as usize == old_ptr)
+        {
             new_handle.parent.set(Some(Rc::downgrade(parent_handle)));
             children[pos] = new_handle.clone();
         }
@@ -1408,7 +2843,9 @@ fn replace_registered_node(id: u32, new_handle: Handle) {
     NODE_REGISTRY.with(|reg| {
         if let Some(old_handle) = reg.borrow_mut().insert(id, new_handle.clone()) {
             let old_ptr = Rc::as_ptr(&old_handle) as usize;
-            REVERSE_NODE_REGISTRY.with(|reverse| { reverse.borrow_mut().remove(&old_ptr); });
+            REVERSE_NODE_REGISTRY.with(|reverse| {
+                reverse.borrow_mut().remove(&old_ptr);
+            });
         }
     });
     let new_ptr = Rc::as_ptr(&new_handle) as usize;
@@ -1416,7 +2853,9 @@ fn replace_registered_node(id: u32, new_handle: Handle) {
 }
 
 fn mark_document_fragment_id(id: u32) {
-    DOCUMENT_FRAGMENT_NODE_IDS.with(|ids| { ids.borrow_mut().insert(id); });
+    DOCUMENT_FRAGMENT_NODE_IDS.with(|ids| {
+        ids.borrow_mut().insert(id);
+    });
 }
 
 fn is_document_fragment_id(id: u32) -> bool {
@@ -1428,7 +2867,10 @@ fn detach_node_from_parent(node: &Handle) {
     let parent_weak = node.parent.take();
     if let Some(parent_weak) = parent_weak {
         if let Some(parent) = parent_weak.upgrade() {
-            parent.children.borrow_mut().retain(|c| Rc::as_ptr(c) as usize != node_ptr);
+            parent
+                .children
+                .borrow_mut()
+                .retain(|c| Rc::as_ptr(c) as usize != node_ptr);
         }
     }
 }
@@ -1447,17 +2889,23 @@ fn get_sibling_id(nid: u32, direction: SiblingDirection, elements_only: bool) ->
     let parent = get_parent_handle(&node)?;
     let node_ptr = Rc::as_ptr(&node) as usize;
     let children: Vec<Handle> = parent.children.borrow().iter().cloned().collect();
-    let index = children.iter().position(|child| Rc::as_ptr(child) as usize == node_ptr)?;
+    let index = children
+        .iter()
+        .position(|child| Rc::as_ptr(child) as usize == node_ptr)?;
     match direction {
         SiblingDirection::Next => {
             for sibling in children.iter().skip(index + 1) {
-                if elements_only && !matches!(sibling.data, NodeData::Element { .. }) { continue; }
+                if elements_only && !matches!(sibling.data, NodeData::Element { .. }) {
+                    continue;
+                }
                 return Some(register_node(sibling.clone()));
             }
         }
         SiblingDirection::Previous => {
             for sibling in children[..index].iter().rev() {
-                if elements_only && !matches!(sibling.data, NodeData::Element { .. }) { continue; }
+                if elements_only && !matches!(sibling.data, NodeData::Element { .. }) {
+                    continue;
+                }
                 return Some(register_node(sibling.clone()));
             }
         }
@@ -1490,12 +2938,18 @@ fn insert_fragment_children(parent: &Handle, fragment: &Handle, insert_pos: Opti
 fn parse_html_fragment(html: &str, ctx_tag: &str) -> Vec<Handle> {
     use html5ever::parse_fragment;
     use html5ever::tendril::TendrilSink;
-    use html5ever::{QualName, LocalName, ns};
+    use html5ever::{ns, LocalName, QualName};
     let ctx_name = QualName::new(None, ns!(html), LocalName::from(ctx_tag));
     let dom = parse_fragment(
         markup5ever_rcdom::RcDom::default(),
-        Default::default(), ctx_name, vec![], false,
-    ).from_utf8().read_from(&mut html.as_bytes()).unwrap();
+        Default::default(),
+        ctx_name,
+        vec![],
+        false,
+    )
+    .from_utf8()
+    .read_from(&mut html.as_bytes())
+    .unwrap();
     steal_fragment_children(&dom.document)
 }
 
@@ -1503,7 +2957,9 @@ fn steal_fragment_children(doc: &Handle) -> Vec<Handle> {
     for child in doc.children.borrow().iter() {
         if let NodeData::Element { .. } = child.data {
             let children: Vec<Handle> = child.children.borrow_mut().drain(..).collect();
-            for c in &children { c.parent.set(None); }
+            for c in &children {
+                c.parent.set(None);
+            }
             return children;
         }
     }
@@ -1520,9 +2976,14 @@ fn serialize_inner_html(node: &Handle) -> String {
 
 fn serialize_node(node: &Handle, out: &mut String) {
     match &node.data {
-        NodeData::Element { ref name, ref attrs, .. } => {
+        NodeData::Element {
+            ref name,
+            ref attrs,
+            ..
+        } => {
             let tag = name.local.to_string();
-            out.push('<'); out.push_str(&tag);
+            out.push('<');
+            out.push_str(&tag);
             for attr in attrs.borrow().iter() {
                 out.push(' ');
                 out.push_str(&attr.name.local.to_string());
@@ -1531,37 +2992,62 @@ fn serialize_node(node: &Handle, out: &mut String) {
                 out.push('"');
             }
             out.push('>');
-            for child in node.children.borrow().iter() { serialize_node(child, out); }
-            out.push_str("</"); out.push_str(&tag); out.push('>');
+            for child in node.children.borrow().iter() {
+                serialize_node(child, out);
+            }
+            out.push_str("</");
+            out.push_str(&tag);
+            out.push('>');
         }
         NodeData::Text { ref contents } => {
             out.push_str(&html_escape(&contents.borrow()));
         }
         NodeData::Comment { ref contents } => {
-            out.push_str("<!--"); out.push_str(contents); out.push_str("-->");
+            out.push_str("<!--");
+            out.push_str(contents);
+            out.push_str("-->");
         }
-        NodeData::Doctype { ref name, ref public_id, ref system_id } => {
-            out.push_str("<!DOCTYPE "); out.push_str(name);
-            if !public_id.is_empty() { out.push_str(" PUBLIC \""); out.push_str(public_id); out.push('"');
-                if !system_id.is_empty() { out.push_str(" \""); out.push_str(system_id); out.push('"'); }
+        NodeData::Doctype {
+            ref name,
+            ref public_id,
+            ref system_id,
+        } => {
+            out.push_str("<!DOCTYPE ");
+            out.push_str(name);
+            if !public_id.is_empty() {
+                out.push_str(" PUBLIC \"");
+                out.push_str(public_id);
+                out.push('"');
+                if !system_id.is_empty() {
+                    out.push_str(" \"");
+                    out.push_str(system_id);
+                    out.push('"');
+                }
             }
             out.push('>');
         }
         NodeData::Document => {
-            for child in node.children.borrow().iter() { serialize_node(child, out); }
+            for child in node.children.borrow().iter() {
+                serialize_node(child, out);
+            }
         }
         _ => {}
     }
 }
 
 fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&quot;")
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
 }
 
 fn collect_text_content(node: &Handle) -> String {
     let mut text = String::new();
     match &node.data {
-        NodeData::Text { ref contents } => { text.push_str(&contents.borrow()); }
+        NodeData::Text { ref contents } => {
+            text.push_str(&contents.borrow());
+        }
         _ => {
             for child in node.children.borrow().iter() {
                 text.push_str(&collect_text_content(child));
@@ -1570,8 +3056,6 @@ fn collect_text_content(node: &Handle) -> String {
     }
     text
 }
-
-
 
 fn split_selector_groups(selector: &str) -> Vec<&str> {
     let mut groups = Vec::new();
@@ -1583,64 +3067,131 @@ fn split_selector_groups(selector: &str) -> Vec<&str> {
             ']' | ')' => depth -= 1,
             ',' if depth == 0 => {
                 let part = selector[start..idx].trim();
-                if !part.is_empty() { groups.push(part); }
+                if !part.is_empty() {
+                    groups.push(part);
+                }
                 start = idx + ch.len_utf8();
             }
             _ => {}
         }
     }
     let tail = selector[start..].trim();
-    if !tail.is_empty() { groups.push(tail); }
+    if !tail.is_empty() {
+        groups.push(tail);
+    }
     groups
 }
 
 fn selector_is_supported_for_dom_queries(selector: &Selector) -> bool {
-    if selector.pseudo_class.is_some() || selector.pseudo_element.is_some() { return false; }
-    selector.ancestor.as_deref().map(selector_is_supported_for_dom_queries).unwrap_or(true)
+    if selector.pseudo_class.is_some() || selector.pseudo_element.is_some() {
+        return false;
+    }
+    selector
+        .ancestor
+        .as_deref()
+        .map(selector_is_supported_for_dom_queries)
+        .unwrap_or(true)
 }
 
 fn selector_subject_matches_handle(node: &Handle, selector: &Selector) -> bool {
-    let NodeData::Element { ref name, ref attrs, .. } = node.data else { return false; };
-    let has_constraint = selector.tag.is_some() || selector.id.is_some() || !selector.class.is_empty() || !selector.attributes.is_empty();
-    if !has_constraint { return false; }
+    let NodeData::Element {
+        ref name,
+        ref attrs,
+        ..
+    } = node.data
+    else {
+        return false;
+    };
+    let has_constraint = selector.tag.is_some()
+        || selector.id.is_some()
+        || !selector.class.is_empty()
+        || !selector.attributes.is_empty();
+    if !has_constraint {
+        return false;
+    }
     let tag = name.local.to_string().to_lowercase();
-    if let Some(ref required_tag) = selector.tag { if tag != required_tag.to_lowercase() { return false; } }
+    if let Some(ref required_tag) = selector.tag {
+        if tag != required_tag.to_lowercase() {
+            return false;
+        }
+    }
     let attrs_ref = attrs.borrow();
-    let id_val = attrs_ref.iter().find(|a| a.name.local.to_string() == "id").map(|a| a.value.to_string());
-    if let Some(ref required_id) = selector.id { if id_val.as_deref() != Some(required_id.as_str()) { return false; } }
-    let class_val = attrs_ref.iter().find(|a| a.name.local.to_string() == "class").map(|a| a.value.to_string()).unwrap_or_default();
+    let id_val = attrs_ref
+        .iter()
+        .find(|a| a.name.local.to_string() == "id")
+        .map(|a| a.value.to_string());
+    if let Some(ref required_id) = selector.id {
+        if id_val.as_deref() != Some(required_id.as_str()) {
+            return false;
+        }
+    }
+    let class_val = attrs_ref
+        .iter()
+        .find(|a| a.name.local.to_string() == "class")
+        .map(|a| a.value.to_string())
+        .unwrap_or_default();
     let classes: Vec<&str> = class_val.split_whitespace().collect();
-    for required_class in &selector.class { if !classes.contains(&required_class.as_str()) { return false; } }
+    for required_class in &selector.class {
+        if !classes.contains(&required_class.as_str()) {
+            return false;
+        }
+    }
     for attr_sel in &selector.attributes {
         let matched = attrs_ref.iter().any(|attr| {
-            if attr.name.local.to_string() != attr_sel.name { return false; }
-            match &attr_sel.value { AttributeMatch::Exists => true, AttributeMatch::Equals(expected) => attr.value.to_string() == *expected }
+            if attr.name.local.to_string() != attr_sel.name {
+                return false;
+            }
+            match &attr_sel.value {
+                AttributeMatch::Exists => true,
+                AttributeMatch::Equals(expected) => attr.value.to_string() == *expected,
+            }
         });
-        if !matched { return false; }
+        if !matched {
+            return false;
+        }
     }
     true
 }
 
 fn previous_element_siblings(node: &Handle) -> Vec<Handle> {
-    let Some(parent) = get_parent_handle(node) else { return Vec::new(); };
+    let Some(parent) = get_parent_handle(node) else {
+        return Vec::new();
+    };
     let node_ptr = Rc::as_ptr(node) as usize;
     let mut siblings = Vec::new();
     for child in parent.children.borrow().iter() {
-        if Rc::as_ptr(child) as usize == node_ptr { break; }
-        if matches!(child.data, NodeData::Element { .. }) { siblings.push(child.clone()); }
+        if Rc::as_ptr(child) as usize == node_ptr {
+            break;
+        }
+        if matches!(child.data, NodeData::Element { .. }) {
+            siblings.push(child.clone());
+        }
     }
     siblings
 }
 
 fn selector_matches_parsed_handle(node: &Handle, selector: &Selector) -> bool {
-    if !selector_is_supported_for_dom_queries(selector) || !selector_subject_matches_handle(node, selector) { return false; }
-    let Some(ref ancestor_sel) = selector.ancestor else { return true; };
-    let combinator = selector.combinator.as_ref().unwrap_or(&Combinator::Descendant);
+    if !selector_is_supported_for_dom_queries(selector)
+        || !selector_subject_matches_handle(node, selector)
+    {
+        return false;
+    }
+    let Some(ref ancestor_sel) = selector.ancestor else {
+        return true;
+    };
+    let combinator = selector
+        .combinator
+        .as_ref()
+        .unwrap_or(&Combinator::Descendant);
     match combinator {
         Combinator::Descendant => {
             let mut current = get_parent_handle(node);
             while let Some(parent) = current {
-                if matches!(parent.data, NodeData::Element { .. }) && selector_matches_parsed_handle(&parent, ancestor_sel) { return true; }
+                if matches!(parent.data, NodeData::Element { .. })
+                    && selector_matches_parsed_handle(&parent, ancestor_sel)
+                {
+                    return true;
+                }
                 current = get_parent_handle(&parent);
             }
             false
@@ -1649,30 +3200,47 @@ fn selector_matches_parsed_handle(node: &Handle, selector: &Selector) -> bool {
             .filter(|parent| matches!(parent.data, NodeData::Element { .. }))
             .map(|parent| selector_matches_parsed_handle(&parent, ancestor_sel))
             .unwrap_or(false),
-        Combinator::NextSibling => previous_element_siblings(node).into_iter().rev().next()
-            .map(|sibling| selector_matches_parsed_handle(&sibling, ancestor_sel)).unwrap_or(false),
-        Combinator::SubsequentSibling => previous_element_siblings(node).into_iter().rev()
+        Combinator::NextSibling => previous_element_siblings(node)
+            .into_iter()
+            .rev()
+            .next()
+            .map(|sibling| selector_matches_parsed_handle(&sibling, ancestor_sel))
+            .unwrap_or(false),
+        Combinator::SubsequentSibling => previous_element_siblings(node)
+            .into_iter()
+            .rev()
             .any(|sibling| selector_matches_parsed_handle(&sibling, ancestor_sel)),
     }
 }
 
 fn selector_matches_handle(node: &Handle, selector: &str) -> bool {
     let groups = split_selector_groups(selector);
-    if groups.is_empty() { return false; }
-    groups.into_iter().any(|group| { let parsed = parse_selector(group); selector_matches_parsed_handle(node, &parsed) })
+    if groups.is_empty() {
+        return false;
+    }
+    groups.into_iter().any(|group| {
+        let parsed = parse_selector(group);
+        selector_matches_parsed_handle(node, &parsed)
+    })
 }
 
 fn query_selector_first(root: &Handle, selector: &str, skip_root: bool) -> Option<Handle> {
-    if !skip_root && selector_matches_handle(root, selector) { return Some(root.clone()); }
+    if !skip_root && selector_matches_handle(root, selector) {
+        return Some(root.clone());
+    }
     for child in root.children.borrow().iter() {
-        if let Some(found) = query_selector_first(child, selector, false) { return Some(found); }
+        if let Some(found) = query_selector_first(child, selector, false) {
+            return Some(found);
+        }
     }
     None
 }
 
 fn query_selector_all_nodes(root: &Handle, selector: &str, skip_root: bool) -> Vec<Handle> {
     let mut results = Vec::new();
-    if !skip_root && selector_matches_handle(root, selector) { results.push(root.clone()); }
+    if !skip_root && selector_matches_handle(root, selector) {
+        results.push(root.clone());
+    }
     for child in root.children.borrow().iter() {
         results.append(&mut query_selector_all_nodes(child, selector, false));
     }
@@ -1683,8 +3251,15 @@ fn find_elements_by_class(root: &Handle, cls: &str, skip_root: bool) -> Vec<Hand
     let mut results = Vec::new();
     if !skip_root {
         if let NodeData::Element { ref attrs, .. } = root.data {
-            let class_val = attrs.borrow().iter().find(|a| a.name.local.to_string() == "class").map(|a| a.value.to_string()).unwrap_or_default();
-            if class_val.split_whitespace().any(|c| c == cls) { results.push(root.clone()); }
+            let class_val = attrs
+                .borrow()
+                .iter()
+                .find(|a| a.name.local.to_string() == "class")
+                .map(|a| a.value.to_string())
+                .unwrap_or_default();
+            if class_val.split_whitespace().any(|c| c == cls) {
+                results.push(root.clone());
+            }
         }
     }
     for child in root.children.borrow().iter() {
@@ -1697,7 +3272,9 @@ fn find_elements_by_tag_name(root: &Handle, tag: &str, skip_root: bool) -> Vec<H
     let mut results = Vec::new();
     if !skip_root {
         if let NodeData::Element { ref name, .. } = root.data {
-            if tag == "*" || name.local.to_string().to_lowercase() == tag { results.push(root.clone()); }
+            if tag == "*" || name.local.to_string().to_lowercase() == tag {
+                results.push(root.clone());
+            }
         }
     }
     for child in root.children.borrow().iter() {

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -54,6 +54,19 @@ function __aura_apply_location_href(href) {
     return true;
 }
 
+function __aura_resolve_url_attribute(value) {
+    var raw = String(value || '');
+    if (!raw) return '';
+    if (typeof __aura_resolve_url === 'function') {
+        return __aura_resolve_url(raw, location.href || document.baseURI || '');
+    }
+    try {
+        return new URL(raw, location.href || document.baseURI || undefined).href;
+    } catch (e) {
+        return raw;
+    }
+}
+
 // -- Node Registry (Ensures stable objects for events) -----------------------
 var __node_registry = new Map();
 
@@ -1626,9 +1639,9 @@ class Element extends Node {
         if (v) this.setAttribute('disabled', 'disabled');
         else this.removeAttribute('disabled');
     }
-    get href() { return __aura_get_attribute(this._id, 'href') || ''; }
+    get href() { return __aura_resolve_url_attribute(__aura_get_attribute(this._id, 'href') || ''); }
     set href(v) { __aura_set_attribute(this._id, 'href', String(v)); }
-    get src() { return __aura_get_attribute(this._id, 'src') || ''; }
+    get src() { return __aura_resolve_url_attribute(__aura_get_attribute(this._id, 'src') || ''); }
     set src(v) { __aura_set_attribute(this._id, 'src', String(v)); }
     get type() { return __aura_get_attribute(this._id, 'type') || ''; }
     set type(v) { __aura_set_attribute(this._id, 'type', String(v)); }
@@ -3408,6 +3421,8 @@ class URL {
         this._updateHref();
     }
     get hash() { return this._hash; }
+    set origin(value) { this._origin = String(value || ''); }
+    get origin() { return this._origin; }
     get searchParams() {
         if (!this._searchParams) {
             this._searchParams = new URLSearchParams(this.search, query => {
@@ -3555,7 +3570,7 @@ class HTMLImageElement extends Element {
         this.onload = null;
         this.onerror = null;
     }
-    get src() { return __aura_get_attribute(this._id, 'src') || ''; }
+    get src() { return __aura_resolve_url_attribute(__aura_get_attribute(this._id, 'src') || ''); }
     set src(v) {
         __aura_set_attribute(this._id, 'src', String(v));
         // Fire onload asynchronously since we can't actually load images
@@ -3600,13 +3615,13 @@ class HTMLButtonElement extends HTMLElement {}
 window.HTMLButtonElement = HTMLButtonElement;
 
 class HTMLAnchorElement extends HTMLElement {
-    get href() { return __aura_get_attribute(this._id, 'href') || ''; }
+    get href() { return __aura_resolve_url_attribute(__aura_get_attribute(this._id, 'href') || ''); }
     set href(v) { __aura_set_attribute(this._id, 'href', String(v)); }
 }
 window.HTMLAnchorElement = HTMLAnchorElement;
 
 class HTMLScriptElement extends HTMLElement {
-    get src() { return __aura_get_attribute(this._id, 'src') || ''; }
+    get src() { return __aura_resolve_url_attribute(__aura_get_attribute(this._id, 'src') || ''); }
     set src(v) { __aura_set_attribute(this._id, 'src', String(v)); }
     get type() { return __aura_get_attribute(this._id, 'type') || ''; }
     set type(v) { __aura_set_attribute(this._id, 'type', String(v)); }


### PR DESCRIPTION
## Summary
- add a V8-backed ES module compile path with a URL-keyed module cache and request extraction
- classify classic vs module scripts, resolve script URLs against the page URL, and fetch/CSP-check external modules through BrowserEngine
- update JS compatibility docs and add coverage for module compile cache, fetch errors, CSP blocking, and specifier resolution

Closes #245

## Verification
- cargo check --all-targets
- cargo test --lib -- --test-threads=2
- cargo build --bins
- browser-cli-reviewer: daemon health ok, navigated https://yunseong.dev and https://google.com, screenshot captured at /tmp/browser-review-245.png