### PR TITLE
feat(js): module script load/error lifecycle events (#263)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1231,6 +1231,7 @@ impl BrowserEngine {
 
         let scripts = js::extract_script_sources_from_dom(&dom.document, Some(&page.base_url));
         let mut root_module_urls: Vec<Url> = Vec::new();
+        let mut module_script_targets: Vec<(Url, u32)> = Vec::new();
 
         for script in scripts {
             match script {
@@ -1264,7 +1265,7 @@ impl BrowserEngine {
                         }
                     }
                 }
-                js::ScriptSource::InlineModule { url, source } => {
+                js::ScriptSource::InlineModule { url, source, node_id } => {
                     let allowed = self
                         .current_csp_policy
                         .as_ref()
@@ -1278,11 +1279,13 @@ impl BrowserEngine {
                     if let Some(error) = outcome.error {
                         println!("[JS] Failed to compile inline module {}: {}", url, error);
                         js::push_console_entry(js::ConsoleLevel::Error, format!("Failed to compile inline module {url}: {error}"));
+                        module_script_targets.push((url, node_id));
                     } else {
-                        root_module_urls.push(url);
+                        root_module_urls.push(url.clone());
+                        module_script_targets.push((url, node_id));
                     }
                 }
-                js::ScriptSource::ExternalModule(url) => {
+                js::ScriptSource::ExternalModule { url, node_id } => {
                     let outcome =
                         self.load_external_module_with(url.clone(), &page.base_url, |module_url| {
                             reqwest::blocking::get(module_url.as_str())
@@ -1291,8 +1294,10 @@ impl BrowserEngine {
                     if let Some(error) = outcome.error {
                         println!("[JS] Failed to load external module {}: {}", url, error);
                         js::push_console_entry(js::ConsoleLevel::Error, format!("Failed to load external module {url}: {error}"));
+                        module_script_targets.push((url, node_id));
                     } else {
-                        root_module_urls.push(url);
+                        root_module_urls.push(url.clone());
+                        module_script_targets.push((url, node_id));
                     }
                 }
             }
@@ -1304,10 +1309,24 @@ impl BrowserEngine {
         if !root_module_urls.is_empty() {
             let eval_result = self.js_runtime.evaluate_module_graph(&root_module_urls);
             if let Err(errors) = eval_result {
+                let failed_urls: Vec<&str> = errors
+                    .iter()
+                    .filter_map(|e| e.split(": ").next())
+                    .collect();
                 for error in &errors {
                     println!("[JS] Module evaluation error: {error}");
                     js::push_console_entry(js::ConsoleLevel::Error, error.clone());
                 }
+                for (url, node_id) in &module_script_targets {
+                    if failed_urls.iter().any(|f| url.as_str() == *f) {
+                        self.js_runtime
+                            .trigger_event_on_node_id(*node_id, "error");
+                    }
+                }
+            }
+            for (_, node_id) in &module_script_targets {
+                self.js_runtime
+                    .trigger_event_on_node_id(*node_id, "load");
             }
         }
 

--- a/src/js.rs
+++ b/src/js.rs
@@ -764,6 +764,14 @@ impl JsRuntime {
         }
     }
 
+    pub fn trigger_event_on_node_id(&mut self, node_id: u32, event_type: &str) {
+        let code = format!(
+            "document.__trigger_event({}, '{}', {{ bubbles: true }})",
+            node_id, event_type
+        );
+        self.execute(&code);
+    }
+
     pub fn execute(&mut self, source: &str) {
         let outcome = self.execute_with_result(source);
         if let Some(error) = outcome.error {
@@ -2965,7 +2973,7 @@ pub fn extract_scripts_from_dom(handle: &Handle) -> Vec<String> {
             ScriptSource::InlineClassic(script) => Some(script),
             ScriptSource::ExternalClassic(_)
             | ScriptSource::InlineModule { .. }
-            | ScriptSource::ExternalModule(_) => None,
+            | ScriptSource::ExternalModule { .. } => None,
         })
         .collect()
 }
@@ -2974,8 +2982,8 @@ pub fn extract_scripts_from_dom(handle: &Handle) -> Vec<String> {
 pub enum ScriptSource {
     InlineClassic(String),
     ExternalClassic(Url),
-    InlineModule { url: Url, source: String },
-    ExternalModule(Url),
+    InlineModule { url: Url, source: String, node_id: u32 },
+    ExternalModule { url: Url, node_id: u32 },
 }
 
 pub fn extract_script_sources_from_dom(
@@ -3027,7 +3035,8 @@ pub fn extract_script_sources_from_dom(
                     if let Some(base) = base_url {
                         if let Ok(url) = base.join(&src).or_else(|_| Url::parse(&src)) {
                             if is_module {
-                                scripts.push(ScriptSource::ExternalModule(url));
+                                let node_id = register_node(handle.clone());
+                                scripts.push(ScriptSource::ExternalModule { url, node_id });
                             } else if is_classic {
                                 scripts.push(ScriptSource::ExternalClassic(url));
                             }
@@ -3049,9 +3058,11 @@ pub fn extract_script_sources_from_dom(
                                     "inline-module-{}",
                                     inline_module_id
                                 )));
+                                let node_id = register_node(handle.clone());
                                 scripts.push(ScriptSource::InlineModule {
                                     url,
                                     source: content,
+                                    node_id,
                                 });
                             }
                         } else if is_classic {
@@ -3173,14 +3184,10 @@ mod tests {
         );
         let base = Url::parse("https://example.com/app/").unwrap();
         let sources = extract_script_sources_from_dom(&dom.document, Some(&base));
-        assert_eq!(
-            sources,
-            vec![
-                ScriptSource::InlineClassic("window.a = 1;".to_string()),
-                ScriptSource::ExternalClassic(Url::parse("https://example.com/bundle.js").unwrap()),
-                ScriptSource::ExternalModule(Url::parse("https://example.com/module.js").unwrap()),
-            ]
-        );
+        assert_eq!(sources.len(), 3);
+        assert!(matches!(&sources[0], ScriptSource::InlineClassic(s) if s == "window.a = 1;"));
+        assert!(matches!(&sources[1], ScriptSource::ExternalClassic(url) if url.as_str() == "https://example.com/bundle.js"));
+        assert!(matches!(&sources[2], ScriptSource::ExternalModule { url, node_id: _ } if url.as_str() == "https://example.com/module.js"));
     }
 
     #[test]
@@ -3191,12 +3198,8 @@ mod tests {
             r#"<html><head><script type="module" src="/m.js"></script></head></html>"#,
         );
         let module_sources = extract_script_sources_from_dom(&module_dom.document, Some(&base));
-        assert_eq!(
-            module_sources,
-            vec![ScriptSource::ExternalModule(
-                Url::parse("https://example.com/m.js").unwrap()
-            )]
-        );
+        assert_eq!(module_sources.len(), 1);
+        assert!(matches!(&module_sources[0], ScriptSource::ExternalModule { url, .. } if url.as_str() == "https://example.com/m.js"));
 
         let nomodule_dom = dom::parse_html(r#"<html><head><script nomodule>window.x=1</script></head></html>"#);
         let nomodule_sources = extract_script_sources_from_dom(&nomodule_dom.document, Some(&base));


### PR DESCRIPTION
## Summary
- `trigger_event_on_node_id()` for direct DOM event dispatch on script elements
- `ScriptSource` module variants carry DOM `node_id` for element tracking
- Engine tracks `module_script_targets` and fires `load`/`error` events after eval

## Verification
- `cargo test --lib`: 252 passed, 0 failed