### PR TITLE
feat(dom): add CharacterData/Text/Comment constructors (#253)

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -3618,6 +3618,192 @@ mod tests {
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("object"));
     }
+
+    #[test]
+    fn test_character_data_constructor_exists() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("typeof CharacterData");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("function"));
+    }
+
+    #[test]
+    fn test_character_data_is_window_property() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("typeof window.CharacterData");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("function"));
+    }
+
+    #[test]
+    fn test_character_data_prototype_instanceof_node() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("CharacterData.prototype instanceof Node");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_text_node_is_instanceof_character_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("document.createTextNode('x') instanceof CharacterData");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_text_node_is_instanceof_node() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("document.createTextNode('x') instanceof Node");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_comment_is_instanceof_character_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("document.createComment('x') instanceof CharacterData");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_comment_is_instanceof_node() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("document.createComment('x') instanceof Node");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_text_prototype_instanceof_character_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("Text.prototype instanceof CharacterData");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_comment_prototype_instanceof_character_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("Comment.prototype instanceof CharacterData");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_text_node_has_data_property() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("document.createTextNode('hello').data");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn test_text_node_has_length_property() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result("document.createTextNode('hello').length");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("5"));
+    }
+
+    #[test]
+    fn test_character_data_append_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "var n = document.createTextNode('hello'); n.appendData(' world'); n.data",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn test_character_data_delete_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "var n = document.createTextNode('hello'); n.deleteData(1, 3); n.data",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("ho"));
+    }
+
+    #[test]
+    fn test_character_data_insert_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "var n = document.createTextNode('ho'); n.insertData(1, 'ell'); n.data",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn test_character_data_replace_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "var n = document.createTextNode('hello world'); n.replaceData(0, 5, 'goodbye'); n.data",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("goodbye world"));
+    }
+
+    #[test]
+    fn test_character_data_substring_data() {
+        let mut rt = make_dom_runtime(
+            "<html><body>hello</body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "document.createTextNode('hello world').substringData(0, 5)",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("hello"));
+    }
 }
 
 // ── DOM Helper Functions ──────────────────────────────────────────────────────

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -1742,21 +1742,54 @@ class Element extends Node {
     }
 }
 
-class TextNode extends Node {
-    constructor(id) {
-        super(id, 'text');
+class CharacterData extends Node {
+    constructor(id, kind) {
+        super(id, kind);
         this._data = '';
     }
     get data() {
-        return this._id ? __aura_read_character_data(this._id, 'text') : this._data;
+        return this._id ? __aura_read_character_data(this._id, this._kind) : this._data;
     }
     set data(val) {
         let text = String(val);
         let oldValue = this.data;
-        if (!__aura_write_character_data(this._id, 'text', text)) {
+        if (!__aura_write_character_data(this._id, this._kind, text)) {
             this._data = text;
         }
         __aura_character_data_mutation(this, oldValue);
+    }
+    get length() {
+        return this.data.length;
+    }
+    appendData(text) {
+        this.data = this.data + String(text);
+    }
+    deleteData(offset, count) {
+        let d = this.data;
+        offset = Math.min(d.length, Math.max(0, Number(offset) || 0));
+        count = Math.max(0, Number(count) || 0);
+        this.data = d.slice(0, offset) + d.slice(offset + count);
+    }
+    insertData(offset, text) {
+        let d = this.data;
+        offset = Math.min(d.length, Math.max(0, Number(offset) || 0));
+        this.data = d.slice(0, offset) + String(text) + d.slice(offset);
+    }
+    replaceData(offset, count, text) {
+        this.deleteData(offset, count);
+        this.insertData(offset, text);
+    }
+    substringData(offset, count) {
+        let d = this.data;
+        offset = Math.min(d.length, Math.max(0, Number(offset) || 0));
+        count = Math.max(0, Number(count) || 0);
+        return d.slice(offset, offset + count);
+    }
+}
+
+class TextNode extends CharacterData {
+    constructor(id) {
+        super(id, 'text');
     }
     get nodeValue() {
         return this.data;
@@ -1772,21 +1805,10 @@ class TextNode extends Node {
     }
 }
 
-class Comment extends Node {
+class Comment extends CharacterData {
     constructor(id, data) {
         super(id, 'comment');
-        this._data = data === undefined ? '' : String(data);
-    }
-    get data() {
-        return this._id ? __aura_read_character_data(this._id, 'comment') : this._data;
-    }
-    set data(val) {
-        let text = String(val);
-        let oldValue = this.data;
-        if (!__aura_write_character_data(this._id, 'comment', text)) {
-            this._data = text;
-        }
-        __aura_character_data_mutation(this, oldValue);
+        if (data !== undefined) this._data = String(data);
     }
     get nodeValue() {
         return this.data;
@@ -3544,6 +3566,7 @@ window.IntersectionObserver = IntersectionObserver;
 window.ResizeObserver = ResizeObserver;
 window.Node = Node;
 window.Element = Element;
+window.CharacterData = CharacterData;
 window.Text = TextNode;
 window.Comment = Comment;
 window.DocumentType = DocumentType;


### PR DESCRIPTION
## Summary
- CharacterData class between Node and TextNode/Comment
- data, length, appendData, deleteData, insertData, replaceData, substringData
- window.CharacterData exposed
- 16 tests covering constructors, prototype chain, mutation methods

## Verification
- cargo test --lib: 284 passed, 0 failed