### PR TITLE
docs(workflow): add issue-to-PR process

### DIFF
--- a/.agents/docs/development-workflow.md
+++ b/.agents/docs/development-workflow.md
@@ -1,0 +1,69 @@
+# Development Workflow
+
+Use this workflow for non-trivial issue work.
+
+## Required Sequence
+
+1. Create or select a GitHub issue.
+   - Prefer an existing issue when it already covers the work.
+   - Create a new issue when the blocker is narrower than the existing roadmap item.
+   - Capture observed behavior, expected behavior, scope, and validation commands.
+
+2. Create the branch.
+   - Format:
+
+```text
+<tag>/<issue-number>
+```
+
+   - Examples:
+
+```text
+fix/279
+feat/257
+docs/279
+refactor/270
+test/278
+```
+
+   - `<tag>` should match the main work type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `build`, or `ci`.
+   - `<issue-number>` must be the GitHub issue number without `#`.
+   - Keep branch names short. Put details in the issue, plan, commit message, and PR body.
+   - One issue should usually map to one branch.
+
+3. Write the plan.
+   - Use the project-local `writing-plan` skill.
+   - Store issue-linked plans under `.plan/issues/`.
+   - The plan must include goal, non-goals, context, checklist, validation, risks, rollback, and open questions.
+
+4. Run plan review.
+   - Use the project-local `multi-model-plan-review` skill before implementation.
+   - Apply must-fix feedback to the plan before coding.
+   - Record rejected feedback with a short reason when useful.
+
+5. Develop.
+   - Keep edits scoped to the issue and plan.
+   - Prefer existing project patterns over new abstractions.
+   - Run targeted tests as the implementation progresses.
+   - Keep long browser/daemon/site checks wrapped in `timeout`.
+
+6. Run pair review.
+   - Use the project-local `pair-review` skill before final validation.
+   - Focus review on YAGNI, DRY, maintainability, scope control, correctness, and validation gaps.
+   - Fix must-fix findings before PR.
+
+7. Validate and open PR.
+   - Run build/tests relevant to touched scope.
+   - Run `browser-cli-reviewer` before PR creation for browser implementation changes.
+   - Push the branch and open a PR linked to the issue.
+   - PR body should include issue link, summary, validation, and remaining risks.
+
+## Local Skills
+
+Project-local copies of the workflow skills live in `./.agents/skills/`:
+
+- `writing-plan`
+- `multi-model-plan-review`
+- `pair-review`
+
+Prefer these project-local copies for this repository so workflow behavior stays stable even if user-level skills change.

--- a/.agents/skills/multi-model-plan-review/SKILL.md
+++ b/.agents/skills/multi-model-plan-review/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: multi-model-plan-review
+description: >
+  Multi-model plan review protocol. Use before non-trivial implementation when
+  the user asks for plan review, peer plan review, fast/medium/heavy review, or
+  wants ambiguity and overengineering checked before coding. Runs fast and
+  medium first-pass reviews, then a heavy second-pass verification, then folds
+  findings back into the plan.
+---
+
+# Multi-Model Plan Review
+
+Use this skill before non-trivial implementation when plan quality matters.
+
+## Goal
+
+Improve plans before code:
+- fast reviewer catches ambiguity and missing decisions
+- medium reviewer catches overengineering, YAGNI, weak boundaries, and DRY risk
+- heavy reviewer verifies the revised plan and tradeoffs
+- primary agent reflects accepted findings into the final plan
+
+## Protocol
+
+1. Build the review packet.
+   - Task goal and acceptance criteria
+   - Current plan
+   - Relevant files, modules, APIs, schemas, or diffs
+   - Constraints, risk points, and validation strategy
+2. First pass: run fast and medium reviews.
+   - Prefer parallel execution when subagents are available.
+   - Fast review: ambiguity, missing details, unclear validation.
+   - Medium review: overengineering, YAGNI, DRY, maintainability.
+3. Revise the plan.
+   - Apply all `must-fix` findings.
+   - Apply useful `should-fix` findings.
+   - Keep rejected suggestions in a short "Rejected feedback" note with reasons.
+4. Second pass: run heavy review.
+   - Give it the original task, original plan, first-pass findings, and revised plan.
+   - It checks whether the revised plan is implementable and appropriately scoped.
+5. Finalize.
+   - If heavy review passes, use the revised plan for implementation.
+   - If heavy review fails, update the plan and repeat heavy review once.
+   - If it still fails, stop and report the blocker.
+
+## Model Roles
+
+- **fast**: cheap, sharp ambiguity pass. Prefer concise output.
+- **medium**: code-quality critic. Prefer concrete simplification suggestions.
+- **heavy**: final gate. Prefer deeper reasoning and tradeoff validation.
+
+Do not hard-code model names. Use the available model or subagent tier that best matches each role.
+
+## Prompt Templates
+
+### Fast First Pass
+
+```text
+Review this implementation plan as the fast reviewer.
+
+Focus only on ambiguity, missing decisions, hidden assumptions, unclear ownership,
+edge cases, and validation gaps.
+
+Return FAST REVIEW: PASS or FAST REVIEW: NONPASS.
+For NONPASS, list must-fix/should-fix/question findings with concrete plan changes.
+```
+
+### Medium First Pass
+
+```text
+Review this implementation plan as the medium reviewer.
+
+Focus only on overengineering, YAGNI, speculative abstractions, unnecessary
+module splits, DRY risks, coupling, and maintainability.
+
+Return MEDIUM REVIEW: PASS or MEDIUM REVIEW: NONPASS.
+For NONPASS, list must-fix/should-fix/question findings with concrete plan changes.
+```
+
+### Heavy Second Pass
+
+```text
+Review this implementation plan as the heavy reviewer.
+
+You receive the original task, original plan, fast findings, medium findings,
+and revised plan. Verify that the revised plan reflects the right feedback,
+rejects bad feedback for clear reasons, solves the task, and has a credible
+validation strategy.
+
+Return HEAVY REVIEW: PASS or HEAVY REVIEW: NONPASS.
+For NONPASS, list only blockers with concrete plan changes.
+```
+
+## Rules
+
+- The primary agent owns the final plan.
+- Treat vague plans as failures.
+- Do not add abstractions only to satisfy DRY.
+- Do not expand scope during review.
+- Prefer explicit, localized, testable implementation steps.
+- Heavy review is the final gate before implementation.

--- a/.agents/skills/multi-model-plan-review/agents/openai.yaml
+++ b/.agents/skills/multi-model-plan-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Multi-Model Plan Review"
+  short_description: "Fast, medium, and heavy plan review protocol"
+  default_prompt: "Use $multi-model-plan-review to review my implementation plan with fast, medium, and heavy passes before coding."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/pair-review/SKILL.md
+++ b/.agents/skills/pair-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pair-review
+description: >
+  Pair review protocol with a critic subagent. Use when the user asks for pair
+  review, peer review, critic review, or a code quality pass focused on YAGNI,
+  DRY, maintainability, scope control, and implementation tradeoffs during
+  planning or coding.
+---
+
+# Pair Review
+
+Use this skill to add an independent critic subagent to non-trivial planning or implementation work.
+
+## Goal
+
+Catch design drift early:
+- YAGNI violations: speculative features, unused abstractions, premature generalization
+- DRY violations: meaningful duplication, copy-pasted logic, split-brain behavior
+- Code quality risks: unclear boundaries, hidden state, deep nesting, weak names, hard-to-test code
+- Scope creep: changes not required by the task
+- Validation gaps: missing edge cases, weak tests, unverified behavior
+
+## Protocol
+
+1. Define the review target.
+   - Include the user goal, plan, changed files or diff, constraints, and validation strategy.
+   - Keep the packet small enough that the critic can inspect the relevant code independently.
+2. Spawn the `pair-review-critic` subagent.
+   - Ask it to read the relevant files before judging.
+   - Ask for `VERDICT: PASS` or `VERDICT: NONPASS`.
+3. Apply the critic feedback deliberately.
+   - Fix must-fix issues.
+   - Accept or reject should-fix issues with a concrete reason.
+   - Do not expand scope only because the critic suggested a larger redesign.
+4. Repeat only when needed.
+   - Repeat after must-fix changes on complex or risky work.
+   - Skip repeat review for small wording or formatting fixes.
+
+## Review Timing
+
+- **Plan review**: before code when the approach has architectural tradeoffs.
+- **Mid-implementation review**: when a helper, module boundary, or abstraction is forming.
+- **Diff review**: after code changes, before final validation or PR.
+
+## Critic Prompt Template
+
+```text
+Use the pair-review-critic role.
+
+TASK:
+<user goal and acceptance criteria>
+
+PLAN:
+<current plan or implementation approach>
+
+CHANGED FILES / DIFF:
+<file list, relevant diff, or paths to read>
+
+CONSTRAINTS:
+<architecture rules, project style, tests already run, known tradeoffs>
+
+Focus on YAGNI, DRY, code quality, maintainability, scope control, and validation gaps.
+Return VERDICT: PASS or VERDICT: NONPASS. Cite file:line for concrete issues.
+```
+
+## Rules
+
+- The primary agent owns the implementation and final judgment.
+- The critic is adversarial about quality but not about taste.
+- Block only on correctness, maintainability risk, scope creep, or missing validation.
+- Do not block on style preferences without a concrete maintainability or correctness impact.
+- Prefer the smallest change that preserves clarity and long-term maintainability.

--- a/.agents/skills/pair-review/agents/openai.yaml
+++ b/.agents/skills/pair-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Pair Review"
+  short_description: "Critic subagent protocol for code quality review"
+  default_prompt: "Use $pair-review to run a critic subagent pass focused on YAGNI, DRY, and maintainability."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/writing-plan/SKILL.md
+++ b/.agents/skills/writing-plan/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: writing-plan
+description: Generate a work plan markdown file under .plan/general/ or .plan/issues/ with strict naming conventions. Use when asked to "write a plan" or when starting any non-trivial change. Optionally links plans to GitHub issues.
+---
+
+# writing-plan Skill
+
+## Trigger conditions
+Use this skill when:
+- The user asks for a plan / planning / 작업 플랜 / 실행 계획.
+- You are about to implement a non-trivial change and there is no plan file yet.
+- You are preparing a PR and need a PR-reviewable plan.
+
+## Inputs (ask if missing)
+- **title** (required): Short human-readable title for the plan.
+- **github_issue** (optional): GitHub issue reference as `123`, `#123`, or an issue URL.
+
+## Output rules (MUST)
+
+- **Date format:** `YYYY-MM-DD` (must appear in filename and inside file body).
+- **Slug generation:**
+  - **Translate non-English titles to English summary for the slug.** (e.g., "가격 캐시 추가" -> "add-price-cache")
+  - Lowercase everything.
+  - Replace spaces/underscores with `-`.
+  - Remove special characters.
+  - Collapse repeated `-` and trim leading/trailing `-`.
+  - Keep reasonably short (<= 50 chars).
+
+### General plan (No GitHub issue)
+1. **Ensure directory:** `.plan/general/`
+2. **Check collision:**
+   - Target: `.plan/general/<YYYY-MM-DD>-<slug>.md`
+   - If target exists, append suffix: `-2`, `-3`, etc. (e.g., `...-slug-2.md`)
+3. **Create File:** `.plan/general/<YYYY-MM-DD>-<slug>.md`
+
+### GitHub issue plan (GitHub issue provided)
+1. **Normalize issue number:**
+   - `123` → `123`
+   - `#123` → `123`
+   - GitHub issue URL → extract the issue number
+2. **Validate issue number:** Must contain digits only after normalization.
+3. **Optional check:** If `gh` is available and repo context exists, run `gh issue view <number>` to verify the issue. If verification fails due to auth, sandbox, or network issues, continue with the normalized number unless the user explicitly asked for verification.
+4. **Ensure directory:** `.plan/issues/`
+5. **Check collision:**
+   - Target: `.plan/issues/<YYYY-MM-DD>-issue-<number>-<slug>.md`
+   - If target exists, append suffix: `-2`, `-3`, etc. (e.g., `...-slug-2.md`)
+6. **Create File:** `.plan/issues/<YYYY-MM-DD>-issue-<number>-<slug>.md`
+
+## Plan content (MUST)
+1. **Load template:** Read `assets/PLAN_TEMPLATE.md`.
+2. **Replace placeholders:**
+   - `{{DATE}}` → Current date (YYYY-MM-DD)
+   - `{{TITLE}}` → User provided title (Keep original language here)
+   - `{{GITHUB_ISSUE_OR_NONE}}` → GitHub issue reference (e.g., `#123`) or string "None"
+3. **Fill sections:** Do not delete headers. Add initial thoughts if context is available.
+
+## Return format (in chat)
+After creating the plan file, respond with:
+- **Created file path** (clickable if possible)
+- **3–5 bullet summary** of the plan goal
+- **Open questions** (if any context is missing)

--- a/.agents/skills/writing-plan/assets/PLAN_TEMPLATE.md
+++ b/.agents/skills/writing-plan/assets/PLAN_TEMPLATE.md
@@ -1,0 +1,28 @@
+# {{DATE}} — {{TITLE}}
+
+- Date: {{DATE}}
+- GitHub Issue: {{GITHUB_ISSUE_OR_NONE}}
+- Status: Draft
+
+## Goal
+
+## Non-goals
+
+## Context / Constraints
+
+## Approach (Checklist)
+- [ ] **Step 0: Recon** (Inspect existing code, locate files)
+- [ ] **Step 1: Implementation** (Code changes, file paths)
+- [ ] **Step 2: Tests** (Unit tests, manual verification steps)
+- [ ] **Step 3: Rollout / Rollback** (Feature flags, migration steps)
+
+## Validation
+- **Commands to run:**
+- **Expected output:**
+
+## Risks & Rollback
+- **Risks:**
+- **Rollback steps:** (e.g., `git revert`, toggle flag off)
+
+## Open Questions
+- (If any)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Pipeline: `Network -> DOM -> Style -> Layout -> Render -> GUI`
 
 ### Project Rules
 - Use `./.agents/PRIORITY.md` to choose the next issue.
+- Follow the development workflow in `./.agents/docs/development-workflow.md`.
 - Render width is fixed to `800px` unless changed in code.
 - Build/check/lint on host. For daemon/CLI execution, use `drun rust:latest` (resource-limited).
 - Never run long render/integration loops without timeout.


### PR DESCRIPTION
## Summary

- Add `.agents/docs/development-workflow.md` for the issue-to-PR workflow.
- Link the workflow from `AGENTS.md`.
- Vendor project-local workflow skills for writing plans, plan review, and pair review.

Closes #280

## Validation

Docs-only change. Verified staged files and workflow link.
