### PR TITLE
fix(daemon): bound Naver control requests

### DIFF
--- a/.plan/issues/2026-06-07-issue-257-naver-homepage-rendering.md
+++ b/.plan/issues/2026-06-07-issue-257-naver-homepage-rendering.md
@@ -1,0 +1,59 @@
+# 2026-06-07 — Naver homepage rendering and dynamic module script support
+
+- Date: 2026-06-07
+- GitHub Issue: #257
+- Status: Planning
+
+## Goal
+
+Resolve the issue where `https://www.naver.com` renders as a blank white page. Enable visual rendering of the Naver homepage by supporting dynamic module scripts (`<script type="module">` dynamically inserted into the DOM) and resolving their dependencies.
+
+## Non-goals
+
+- Support for all missing HTML5/DOM APIs.
+- Perfect pixel-by-pixel match against Chromium for every single sub-element (the target is visual correctness of the main page shell/layout).
+- Overhauling the V8 module actor integration.
+
+## Context / Constraints
+
+- The current branch is `fix/279` (where we already checkout from PR #282).
+- Dynamic module script tags dynamically appended to the DOM are currently blocked in `js_bootstrap.js` with the message: `Module scripts are not supported yet; dynamic module script signaled error.`.
+- In `src/js.rs`, dynamic imports (`host_import_module_dynamically`) only fetch the root module but do not fetch its recursive dependencies, which will fail if a dynamically imported module has static `import` declarations.
+- Visual rendering should be validated using screenshots.
+
+## Approach (Checklist)
+
+- [x] **Step 0: Helper for recursive dependency fetching**
+  - Implement `resolve_and_fetch_module_dependencies_rec` in `src/js.rs` to recursively fetch the source code of a module's dependencies and store them in `MODULE_SOURCES`.
+- [x] **Step 1: Implement JS Host callback for dynamic modules**
+  - Register a host function callback `__aura_execute_module_script_in_host(url, code)` in V8.
+  - Implement this callback to:
+    - Save the root module's source in `MODULE_SOURCES`.
+    - Recursively resolve and fetch all dependency sources using `resolve_and_fetch_module_dependencies_rec`.
+    - Compile, instantiate, and evaluate the root module.
+- [x] **Step 2: Update dynamic import handler to support nested dependencies**
+  - Update `host_import_module_dynamically` in `src/js.rs` to call `resolve_and_fetch_module_dependencies_rec` to fetch dependencies of dynamically imported modules before compilation and instantiation.
+- [x] **Step 3: Update `js_bootstrap.js` to handle module scripts**
+  - Modify `__aura_maybe_run_script` in `src/js_bootstrap.js` to accept `module` script type.
+  - Implement `__aura_execute_module_script(script, url, code)` which calls `__aura_execute_module_script_in_host` and fires `load`/`error` events on the script node.
+- [ ] **Step 3.5: Fix CLI localhost connection issue**
+  - Update `localhost` to `127.0.0.1` in `src/bin/browser_cli.rs` (line 127 and tests) to avoid connection failure when IPv6 resolution takes priority.
+- [ ] **Step 3.6: Fix pre-existing integration test failure**
+  - Update `tests/repro_failures.rs` to filter out whitespace text layout boxes so that `test_interleaved_block_inline_stacking` passes.
+- [ ] **Step 4: Verification**
+  - Run `cargo test --lib` and verify no regressions.
+  - Start the daemon headlessly: `timeout 90s ./target/debug/browser-daemon --no-gui --port 7070`.
+  - Navigate to `https://www.naver.com`: `timeout 45s ./target/debug/browser-cli --port 7070 navigate https://www.naver.com`.
+  - Take a screenshot: `timeout 10s ./target/debug/browser-cli --port 7070 screenshot /path/to/naver.png`.
+  - View the screenshot to verify it renders the Naver shell/layout instead of a blank screen.
+
+## Validation
+
+- Build must compile successfully.
+- Library tests must pass.
+- Naver homepage rendering screenshot must show the visual shell/layout of Naver instead of a blank screen.
+
+## Risks & Rollback
+
+- **Risks:** Synchronous network fetches on the V8 isolate thread for dynamic scripts/imports could block the daemon longer. However, since the browser daemon is single-threaded for JS/HTML execution, this matches the existing synchronous model for static modules and is safe.
+- **Rollback:** Revert changes in `src/js.rs` and `src/js_bootstrap.js` to return to the previous state.

--- a/.plan/issues/2026-06-07-issue-279-prevent-naver-daemon-hang.md
+++ b/.plan/issues/2026-06-07-issue-279-prevent-naver-daemon-hang.md
@@ -1,0 +1,105 @@
+# 2026-06-07 — Prevent Naver daemon hang
+
+- Date: 2026-06-07
+- GitHub Issue: #279
+- Status: Implemented
+
+## Goal
+
+Make `https://www.naver.com` debugging bounded and observable. After Naver load starts, daemon control endpoints must not hang indefinitely. `status`, `tick`, `logs`, and `screenshot` should return either useful data or a clear busy/error response within command timeouts.
+
+## Non-goals
+
+- Full Naver visual parity.
+- Complete implementation of every missing browser API.
+- Large JS runtime migration or actor architecture rewrite.
+- Pixel comparison against Playwright beyond smoke validation.
+
+## Context / Constraints
+
+- Current branch: `fix/279`.
+- Naver initial pipeline begins: CSS fetch, DOM/style/layout/render logs appear.
+- After initial work, the daemon can become unreliable:
+  - `browser-cli --port 7070 tick 1` timed out.
+  - `GET /screenshot` timed out.
+  - `GET /status` returned an empty reply in one observed run.
+- Engine actor is single-threaded, so long JS/module work blocks control commands.
+- Existing project rule: wrap long render/integration loops with `timeout`.
+- This plan supports #257 and #278 by making the Naver debug loop usable first.
+
+## Approach (Checklist)
+
+- [x] **Step 0: Recon** (Inspect existing code, locate files)
+  - Inspect `src/engine.rs` actor send/receive methods for indefinite `recv()` calls.
+  - Inspect `src/js.rs` event-loop draining, module evaluation, dynamic import, and fetch paths.
+  - Inspect `src/bin/browser_daemon.rs` `/tick`, `/status`, `/page`, and `/screenshot` handlers.
+  - Reproduce with bounded commands and capture daemon logs.
+
+- [x] **Step 1: Implementation** (Code changes, file paths)
+  - Add bounded reply waits to daemon-facing `EngineHandle` methods where hangs affect control endpoints.
+  - Return explicit busy/error HTTP responses when the actor does not answer in time.
+  - Add short, consistent timeouts for external classic/module script fetches.
+  - Cap per-call JS tick work so one `tick` cannot drain unlimited queued tasks.
+  - Preserve existing behavior for normal pages and CLI commands.
+
+- [x] **Step 2: Tests** (Unit tests, manual verification steps)
+  - Add focused tests for timeout/busy behavior where practical.
+  - Run `cargo build --bins`.
+  - Run relevant engine/daemon tests.
+  - Manually run Naver smoke validation with `timeout`.
+
+- [x] **Step 3: Rollout / Rollback** (Feature flags, migration steps)
+  - No migration or feature flag expected.
+  - If behavior regresses normal pages, revert the commit for #279.
+
+## Validation
+
+- **Commands to run:**
+
+```bash
+cargo build --bins
+cargo test --lib
+cargo test --bin browser-daemon
+timeout 90s ./target/debug/browser-daemon --no-gui --port 7070
+timeout 45s ./target/debug/browser-cli --port 7070 navigate https://www.naver.com
+timeout 10s curl -sS http://127.0.0.1:7070/status
+timeout 15s ./target/debug/browser-cli --port 7070 tick 1
+timeout 10s ./target/debug/browser-cli --port 7070 logs
+timeout 10s curl -sS -o /tmp/naver_browser.png http://127.0.0.1:7070/screenshot
+```
+
+- **Expected output:**
+  - Build/tests pass, warnings acceptable if pre-existing.
+  - Naver load may still have console errors or incomplete visuals.
+  - No validation command hangs indefinitely.
+  - If actor is busy, API returns a clear non-2xx busy/error response instead of blocking.
+  - Console logs are available for the next compatibility issue.
+
+## Validation Results
+
+- `cargo test --bin browser-cli --bin browser-daemon`: pass.
+- `cargo build --bins`: pass.
+- `cargo test --lib`: pass.
+- `timeout 45s ./target/debug/browser-cli --port 7070 navigate https://www.naver.com`: pass; returns initial Naver shell.
+- `timeout 10s curl -sS -i http://127.0.0.1:7070/status`: pass; returns `200`.
+- `timeout 15s ./target/debug/browser-cli --port 7070 tick 1`: pass; returns `worked=true rerendered=true`.
+- `timeout 10s ./target/debug/browser-cli --port 7070 logs`: pass; returns console entries.
+- `timeout 10s curl -sS -o /tmp/naver_browser.png -w '%{http_code} %{size_download}\n' http://127.0.0.1:7070/screenshot`: pass; returns `200 3372`.
+- Visual inspection of `/tmp/naver_browser.png`: non-hanging but still visually failing; output is mostly blank white with tiny text near the top. Full Naver rendering remains follow-up work.
+
+## Risks & Rollback
+
+- **Risks:**
+  - Too-short actor timeout could report busy during legitimate slow render.
+  - Too-strict JS tick cap could delay page initialization.
+  - Script fetch timeout could skip slow but important resources.
+
+- **Rollback steps:** (e.g., `git revert`, toggle flag off)
+  - Revert the #279 commit if normal sites regress.
+  - Increase timeout constants if validation shows false busy responses.
+
+## Open Questions
+
+- What timeout budget should `/status`, `/tick`, and `/screenshot` use for local CLI ergonomics?
+- Should busy responses be HTTP `503` or `202` with a retry hint?
+- Should script fetch timeout be shared with existing page/CSS fetch timeout policy?

--- a/.plan/issues/2026-06-08-issue-257-fix-script-innerhtml-escaping.md
+++ b/.plan/issues/2026-06-08-issue-257-fix-script-innerhtml-escaping.md
@@ -1,0 +1,55 @@
+# 2026-06-08 — Fix Script and Style innerHTML Escaping
+
+- Date: 2026-06-08
+- GitHub Issue: #257
+- Status: Planning
+
+## Goal
+
+Resolve the `JSON.parse` SyntaxError on Naver.com by ensuring that elements which contain raw text (such as `<script>` and `<style>` tags) have their contents serialized without HTML-escaping (e.g., converting `"` to `&quot;`) when retrieving their `innerHTML` or `outerHTML`.
+
+## Non-goals
+
+- Altering text escaping rules for standard HTML elements (e.g., `<div>`, `<span>`) where escaping is correct and required.
+- Full compliance with XML serialization rules.
+
+## Context / Constraints
+
+- In `src/js.rs`, the serialization of DOM nodes (`serialize_node`) always calls `html_escape` on any `NodeData::Text` content.
+- However, standard HTML serialization rules state that text children of specific raw-text or escapable-raw-text elements (such as `script`, `style`, `iframe`, `xmp`, `noembed`, `noframes`, `plaintext`) should be serialized as raw text rather than HTML-escaped text.
+- If these are escaped, `script.innerHTML` for a script like `<script id="json">{"test": true}</script>` returns `{&quot;test&quot;: true}`, causing `JSON.parse` to crash with a `SyntaxError`.
+
+## Approach (Checklist)
+
+- [ ] **Step 1: Modify `serialize_node` in `src/js.rs` to support raw text serialization**
+  - Change the signature of `serialize_node` to accept `parent_tag: Option<&str>`.
+  - When serializing a `NodeData::Text`, if `parent_tag` is one of the raw-text tags (`script`, `style`, `iframe`, `xmp`, `noembed`, `noframes`, `plaintext`), output the text content directly without escaping.
+  - When recursing into children of a `NodeData::Element`, pass the element's tag name (lowercased) as the `parent_tag`.
+- [ ] **Step 2: Update all callers of `serialize_node` in `src/js.rs`**
+  - Update recursive calls inside `serialize_node`.
+  - Update `serialize_inner_html` to determine the tag name of the target node (if it is an Element) and pass it to `serialize_node` for its direct children.
+  - Update `get_outer_html_cb` to retrieve the parent node's tag (if any) and pass it to `serialize_node`.
+- [ ] **Step 3: Add unit tests in `src/js.rs`**
+  - Add a unit test to verify that the `innerHTML` and `textContent` of a `<script>` element containing JSON or special characters return the unescaped raw string.
+  - Verify that standard tags (like `<div>`) still have their `innerHTML` properly escaped.
+- [ ] **Step 4: Verification**
+  - Run `cargo test --lib` to ensure all tests pass.
+  - Restart the browser daemon and verify that navigating to `https://www.naver.com` executes successfully without SyntaxErrors, and capture a verification screenshot.
+
+## Validation
+
+- **Commands to run:**
+  - `cargo check`
+  - `cargo test --lib`
+- **Expected output:**
+  - Build compiles, and tests pass.
+  - Naver screenshot renders successfully with dynamic React elements mounted.
+
+## Risks & Rollback
+
+- **Risks:** Minimal, as this conforms to the standard browser HTML serialization specifications and specifically target tags that only contain raw text.
+- **Rollback steps:** Revert modifications in `src/js.rs`.
+
+## Open Questions
+
+None.

--- a/.plan/issues/2026-06-08-issue-257-implement-anchor-url-properties.md
+++ b/.plan/issues/2026-06-08-issue-257-implement-anchor-url-properties.md
@@ -1,0 +1,74 @@
+# 2026-06-08 — Implement HTMLAnchorElement URL Properties
+
+- Date: 2026-06-08
+- GitHub Issue: #257
+- Status: Planning
+
+## Goal
+
+Provide full DOM compatibility for `HTMLAnchorElement` URL-like properties to prevent modern web application bundles and polyfills (such as axios/URL utilities) from crashing with `TypeError: Cannot read properties of undefined (reading 'charAt')` or similar errors on Naver.com.
+
+Specifically, we will implement the following getters and setters on `HTMLAnchorElement` in `src/js_bootstrap.js`:
+- `protocol`
+- `host`
+- `hostname`
+- `port`
+- `pathname`
+- `search`
+- `hash`
+- `origin` (getter only)
+
+## Non-goals
+
+- Perfect pixel-by-pixel match against Chromium.
+- Implementing non-standard anchor properties.
+
+## Context / Constraints
+
+- The current branch is `fix/279`.
+- The JS runtime is V8 via `rusty_v8`.
+- The `URL` constructor is already fully implemented and available in `src/js_bootstrap.js`. We can delegate to it safely.
+- In browsers, getters return the absolute resolved URL relative to the document base URL. Setting any property updates the underlying `href` attribute.
+
+## Approach (Checklist)
+
+- [ ] **Step 1: Implement HTMLAnchorElement URL Properties**
+  - Modify `HTMLAnchorElement` in `src/js_bootstrap.js` to add getters/setters for `protocol`, `host`, `hostname`, `port`, `pathname`, `search`, `hash`, and getter for `origin`.
+  - Use a private helper method (e.g. `_getURL()` and `_setURLProp()`) to create a `URL` object with fallback base URL `location.href || document.baseURI || undefined`, modify it, and update the `href` attribute.
+- [ ] **Step 2: Add JS tests for HTMLAnchorElement URL properties**
+  - Add a new integration test or unit test in the test suite to verify that anchor URL properties are resolved and updated correctly.
+- [ ] **Step 3: Build & run existing library tests**
+  - Run `cargo check` and `cargo test --lib` (using `-- --test-threads=1` to avoid state contamination) to verify no regressions.
+- [ ] **Step 4: Verify Naver Navigation & Screenshot**
+  - Start/ensure browser-daemon is running.
+  - Navigate to `https://www.naver.com` and tick.
+  - Take a screenshot and visually verify that the Naver homepage layout/shell is rendering rather than a blank white page.
+
+## Validation
+
+- **Commands to run:**
+  - `cargo check`
+  - `cargo test --lib`
+  - Navigate and tick:
+    ```bash
+    ./target/debug/browser-cli --port 7070 navigate https://www.naver.com
+    ./target/debug/browser-cli --port 7070 tick 10
+    ```
+  - Take a screenshot:
+    ```bash
+    ./target/debug/browser-cli --port 7070 screenshot /home/yunseong/.gemini/antigravity-cli/brain/d2a91a85-f6c6-40c8-8fd2-4993f019f1cb/naver_current.png
+    ```
+- **Expected output:**
+  - Build compiles, and tests pass.
+  - Naver screenshot is no longer a blank white screen.
+
+## Risks & Rollback
+
+- **Risks:**
+  - Potential performance overhead of constructing `new URL` on every property access. However, these properties are accessed on demand, and this matches standard behavior, so the overhead is negligible.
+- **Rollback steps:**
+  - Revert the changes in `src/js_bootstrap.js`.
+
+## Open Questions
+
+None.

--- a/.plan/issues/2026-06-08-issue-257-implement-currentscript-and-document-stubs.md
+++ b/.plan/issues/2026-06-08-issue-257-implement-currentscript-and-document-stubs.md
@@ -1,0 +1,56 @@
+# 2026-06-08 — Implement currentScript and Document Attribute Stubs
+
+- Date: 2026-06-08
+- GitHub Issue: #257
+- Status: Planning
+
+## Goal
+
+Resolve the remaining `TypeError: t.getAttribute is not a function` on Naver.com by:
+1. Implementing `document.currentScript` to return the currently executing script element (using a last-parsed script element heuristic).
+2. Implementing safe attribute-related stubs (`getAttribute`, `setAttribute`, `hasAttribute`, `removeAttribute`) on the `document` object to prevent type crashes when scripts fall back to `document`.
+
+## Non-goals
+
+- Perfect tracking of async/deferred scripts executing out of parsing order.
+- Adding full element capabilities to `document`.
+
+## Context / Constraints
+
+- In `src/js_bootstrap.js`, `document` is defined as a plain JavaScript object. It lacks `currentScript` and element-like attribute methods.
+- Minified ad SDKs (such as `gfp-display-sdk.js` or GPT) inspect `document.currentScript` to get configuration attributes and fall back to `document` if it is null or undefined.
+- If they call `.getAttribute(...)` on the fallback `document` object, it throws a `TypeError: t.getAttribute is not a function` because `document` is a plain object without these methods.
+
+## Approach (Checklist)
+
+- [ ] **Step 1: Add currentScript getter to `document` in `src/js_bootstrap.js`**
+  - Define `get currentScript()` on `document` to return the last script element found via `document.getElementsByTagName('script')` (or `null` if none exist).
+- [ ] **Step 2: Add attribute-related stub methods to `document` in `src/js_bootstrap.js`**
+  - Implement `getAttribute: function(name) { return null; }`
+  - Implement `setAttribute: function(name, value) {}`
+  - Implement `removeAttribute: function(name) {}`
+  - Implement `hasAttribute: function(name) { return false; }`
+- [ ] **Step 3: Add unit tests in `src/js.rs`**
+  - Add a unit test to verify that `document.currentScript` returns the script element when evaluated inside a script.
+  - Verify that calling `document.getAttribute` returns `null` instead of throwing a TypeError.
+- [ ] **Step 4: Verification**
+  - Run `cargo test --lib` to ensure all tests pass.
+  - Restart the browser daemon, navigate to Naver, wait 20 ticks, and verify that the page renders without `getAttribute` exceptions.
+
+## Validation
+
+- **Commands to run:**
+  - `cargo check`
+  - `cargo test --lib`
+- **Expected output:**
+  - Build compiles, and tests pass.
+  - Naver screenshot renders successfully with dynamic React elements mounted.
+
+## Risks & Rollback
+
+- **Risks:** Extremely low, as this only adds missing standard properties/methods to `document`.
+- **Rollback steps:** Revert changes in `src/js_bootstrap.js`.
+
+## Open Questions
+
+None.

--- a/.plan/issues/2026-06-08-issue-257-implement-dom-compatibility-stubs.md
+++ b/.plan/issues/2026-06-08-issue-257-implement-dom-compatibility-stubs.md
@@ -1,0 +1,61 @@
+# 2026-06-08 — Implement DOM Compatibility Stubs (createElementNS, postMessage)
+
+- Date: 2026-06-08
+- GitHub Issue: #257
+- Status: Planning
+
+## Goal
+
+Implement additional DOM APIs required to prevent crashes and hangs in Naver's script execution pipeline:
+1. Implement `document.createElementNS` and `contentDocument.createElementNS` as safe delegates to `document.createElement`.
+2. Ensure iframe `contentWindow` extends `EventTarget` (so it supports `addEventListener`).
+3. Implement `postMessage` on both global `window` and iframe `contentWindow` to asynchronously dispatch a `message` event.
+
+## Non-goals
+
+- Perfect implementation of XML/SVG namespaces.
+- Full security verification of origins during message passing.
+
+## Context / Constraints
+
+- The current branch is `fix/279`.
+- Dynamic scripts fail to initialize React components due to:
+  - `TypeError: c.createElementNS is not a function` when creating SVG/icon elements.
+  - `TypeError: r.current.contentWindow.postMessage is not a function` when interacting with nested iframes.
+- Some libraries use `postMessage` to schedule macro-tasks, meaning a pure no-op stub would cause hangs. Message events must be dispatched asynchronously.
+
+## Approach (Checklist)
+
+- [ ] **Step 1: Implement `createElementNS` in `src/js_bootstrap.js`**
+  - Add `createElementNS: function(ns, tag) { return document.createElement(tag); }` on `document`.
+  - Add `createElementNS: function(ns, tag) { return document.createElement(tag); }` on iframe's `contentDocument`.
+- [ ] **Step 2: Make `contentWindow` an `EventTarget` and add `postMessage` in `src/js_bootstrap.js`**
+  - In `HTMLIFrameElement.prototype.contentWindow`, instantiate `this._contentWindow` as `new EventTarget()`.
+  - Add a helper function `__aura_post_message_impl(target, message, targetOrigin)` that uses `setTimeout` to dispatch a `message` event on the target object.
+  - Add `postMessage` to the iframe's `contentWindow` delegating to `__aura_post_message_impl`.
+  - Add `postMessage` on global `window` (globalThis) delegating to `__aura_post_message_impl`.
+- [ ] **Step 3: Add unit tests in `src/js.rs`**
+  - Verify `document.createElementNS` returns a valid element.
+  - Verify global `postMessage` is a function.
+  - Verify `contentWindow` is an `EventTarget` and calling `postMessage` asynchronously triggers `message` event listeners.
+- [ ] **Step 4: Verification**
+  - Run `cargo test --lib`.
+  - Restart browser-daemon, navigate to Naver, and verify rendering via screenshot.
+
+## Validation
+
+- **Commands to run:**
+  - `cargo check`
+  - `cargo test --lib`
+- **Expected output:**
+  - Build compiles, and tests pass.
+  - Naver screenshot renders homepage layout.
+
+## Risks & Rollback
+
+- **Risks:** Asynchronous events introduce macrotask scheduling, but this matches browser specs and is safe.
+- **Rollback steps:** Revert changes in `src/js_bootstrap.js`.
+
+## Open Questions
+
+None.

--- a/.plan/issues/2026-06-08-issue-257-implement-node-prototype-compatibility-stubs.md
+++ b/.plan/issues/2026-06-08-issue-257-implement-node-prototype-compatibility-stubs.md
@@ -1,0 +1,54 @@
+# 2026-06-08 — Implement Node Prototype Compatibility Stubs
+
+- Date: 2026-06-08
+- GitHub Issue: #257
+- Status: Planning
+
+## Goal
+
+Resolve the remaining `TypeError: t.getAttribute is not a function` and other potential element-method crashes on Naver.com by defining safe, fallback element-like methods on `Node.prototype` in `src/js_bootstrap.js`. This ensures that all non-element DOM nodes (such as `TextNode`, `Comment`, `DocumentFragment`, and `DocumentType`) can safely handle these calls without crashing the JS runtime.
+
+## Non-goals
+
+- Implementing full element behavior on non-element nodes.
+
+## Context / Constraints
+
+- Ad SDKs and React libraries traverse the DOM tree (e.g. `n = n.parentElement || n.parentNode`) and call methods like `getAttribute`, `closest`, `matches`, or `querySelector` on the resolved nodes.
+- If the traversal reaches a `TextNode`, `Comment`, or `DocumentFragment` (which lack these methods), the JS runtime throws a fatal `TypeError`.
+- Defining these methods on `Node.prototype` allows `Element` to override them, while providing safe fallback defaults (`null`, `false`, or empty collections) for all other node types.
+
+## Approach (Checklist)
+
+- [ ] **Step 1: Add element compatibility methods to `Node.prototype` in `src/js_bootstrap.js`**
+  - Define `getAttribute: function(name) { return null; }`
+  - Define `setAttribute: function(name, value) {}`
+  - Define `removeAttribute: function(name) {}`
+  - Define `hasAttribute: function(name) { return false; }`
+  - Define `closest: function(selector) { return null; }`
+  - Define `matches: function(selector) { return false; }`
+  - Define `querySelector: function(selector) { return null; }`
+  - Define `querySelectorAll: function(selector) { return new NodeList([]); }`
+- [ ] **Step 2: Add unit tests in `src/js.rs`**
+  - Add a unit test to verify that calling element-like methods (`getAttribute`, `closest`, `matches`, `querySelector`, `querySelectorAll`) on `TextNode`, `Comment`, and `DocumentFragment` returns correct safe defaults without throwing exceptions.
+- [ ] **Step 3: Verification**
+  - Run `cargo test --lib` to ensure all tests pass.
+  - Restart the browser daemon, navigate to Naver, wait 20 ticks, and verify that the page renders without console errors and successfully mounts.
+
+## Validation
+
+- **Commands to run:**
+  - `cargo check`
+  - `cargo test --lib`
+- **Expected output:**
+  - Build compiles, and tests pass.
+  - Naver screenshot renders successfully with dynamic React elements mounted.
+
+## Risks & Rollback
+
+- **Risks:** Extremely low, as it only provides fallback stubs on non-element nodes.
+- **Rollback steps:** Revert changes in `src/js_bootstrap.js`.
+
+## Open Questions
+
+None.

--- a/.plan/issues/2026-06-09-issue-256-observer-shadowroot-raf-compat.md
+++ b/.plan/issues/2026-06-09-issue-256-observer-shadowroot-raf-compat.md
@@ -1,0 +1,177 @@
+# 2026-06-09 — [DOM] Add observer and ShadowRoot compatibility for modern bundles
+
+- Date: 2026-06-09
+- GitHub Issue: #256
+- Status: Draft (Revised after Fast+Medium review)
+
+## Goal
+
+Fix Naver (and similar SPA sites) failing to render content by fixing the
+`requestAnimationFrame` pipeline and filling minor Observer/ShadowRoot API gaps.
+
+Root causes confirmed:
+1. **`navigate()` does not drain the RAF queue** — `raf_cb` (native, js.rs:3183)
+   pushes callbacks to `RAF_TASKS`, but `tick_js()` is never called in the
+   `navigate()` / `init_js_for_page()` flow. React registers a RAF callback during
+   init, but it never fires before `get_document_html()` is called.
+2. **`raf_cb` returns no value** (`_rv` ignored) — React stores the RAF handle for
+   `cancelAnimationFrame(id)`. An `undefined` return is not a crash but is
+   non-conformant; `ric_cb` (sibling function) already returns an id correctly.
+3. **`IntersectionObserver` missing properties** — `.root`, `.rootMargin`,
+   `.thresholds` are undefined; bundles may read `.thresholds` as an array.
+4. **`ShadowRoot.getRootNode()` missing** — inherits from `DocumentFragment` which
+   returns `ownerDocument`; for a ShadowRoot the non-composed result should be
+   `this`.
+
+## Non-goals
+
+- Full Shadow DOM encapsulation (slotting, style scoping)
+- Real IntersectionObserver geometry calculations
+- Real ResizeObserver measurements
+- Any changes outside `src/js_bootstrap.js`, `src/js.rs`, and `src/engine.rs`
+
+## Context / Constraints
+
+### What already exists (must NOT duplicate)
+- `requestAnimationFrame` registered as native callback at `js.rs:1686` (→ `raf_cb`)
+- `raf_cb` pushes to `RAF_TASKS` thread-local (js.rs:3192)
+- `RAF_TASKS` drained inside `tick()` only when `timestamp: Some(_)` (js.rs:796)
+- `send_tick()` is called by daemon's frame loop and `browser-cli tick N` command
+- `window.cancelAnimationFrame` is already a no-op stub in `js_bootstrap.js:4398`
+
+### What is missing
+- `navigate()` never calls `tick_js()` — RAF callbacks from `init_js_for_page()`
+  are never drained before `get_document_html()` reads the DOM
+- `raf_cb` ignores `_rv` → returns `undefined` instead of an integer handle
+- `IntersectionObserver` missing `root`, `rootMargin`, `thresholds` getters
+- `ShadowRoot.getRootNode()` missing (falls through to Element base class impl
+  which returns `ownerDocument || document`, not `this`)
+
+## Approach (Checklist)
+
+- [ ] **Step 0: Verify `init_js_for_page` RAF drain gap**
+  Confirm `navigate()` in `engine.rs` never calls `tick_js()` between
+  `init_js_for_page()` and `get_document_html()`.
+
+- [ ] **Step 1: Add RAF ticks after `init_js_for_page()`** (`src/engine.rs`)
+  After `init_js_for_page(&page)`, drain macro tasks + RAF in a short loop:
+  ```rust
+  // Drain macro tasks and RAF callbacks that React queued during init.
+  // Cap at 5 ticks to avoid render-loop infinite drain.
+  for _ in 0..5 {
+      let ts = SystemTime::now()
+          .duration_since(UNIX_EPOCH)
+          .unwrap_or_default()
+          .as_millis() as f64;
+      if !self.tick_js(Some(ts), None) {
+          break;
+      }
+  }
+  ```
+
+- [ ] **Step 2: Fix `raf_cb` return value** (`src/js.rs`)
+  Add monotonically incrementing handle return, mirroring `ric_cb`:
+  ```rust
+  // In raf_cb, change signature:
+  fn raf_cb(
+      scope: &mut v8::PinScope,
+      args: v8::FunctionCallbackArguments,
+      mut rv: v8::ReturnValue<v8::Value>,  // was _rv
+  ) {
+      // ... existing push to RAF_TASKS ...
+      // After the if block:
+      let id = NEXT_RAF_ID.with(|c| { let id = *c.borrow(); *c.borrow_mut() += 1; id });
+      rv.set_uint32(id);
+  }
+  ```
+  Also add `static NEXT_RAF_ID: RefCell<u32> = RefCell::new(1);` in the
+  thread_local! block.
+
+- [ ] **Step 3: Fix `IntersectionObserver` property gaps** (`src/js_bootstrap.js`)
+  Store options and add getters:
+  ```js
+  class IntersectionObserver {
+      constructor(callback, options) {
+          this._callback = callback;
+          this._options = options || {};
+      }
+      get root() { return this._options.root || null; }
+      get rootMargin() { return this._options.rootMargin || '0px'; }
+      get thresholds() {
+          var t = this._options.threshold;
+          return t !== undefined ? [].concat(t) : [0];
+      }
+      observe(target) {}
+      unobserve(target) {}
+      disconnect() {}
+      takeRecords() { return []; }
+  }
+  ```
+
+- [ ] **Step 4: Fix `ShadowRoot.getRootNode()`** (`src/js_bootstrap.js`)
+  Add override in the ShadowRoot class:
+  ```js
+  getRootNode(options) {
+      if (options && options.composed) return document;
+      return this;
+  }
+  ```
+
+- [ ] **Step 5: Tests** (`src/js.rs`)
+  - Test: `requestAnimationFrame` returns a number (not undefined)
+  - Test: RAF callback fires after `tick(Some(0.0), None)`
+  - Test: `IntersectionObserver` instance has `.thresholds` as array `[0]` by default
+  - Test: `ShadowRoot` `getRootNode()` returns itself
+  - Existing tests must remain green
+
+- [ ] **Step 6: Smoke-verify Naver**
+  - Start daemon, navigate to `https://www.naver.com/`
+  - `browser-cli js "document.querySelectorAll('a').length"` → expect > 30
+  - Screenshot non-white pixel count → expect > 10,000
+
+## Validation
+
+**Commands to run:**
+```bash
+cargo check --all-targets
+cargo test --lib 2>&1 | tail -30
+cargo build
+# daemon should already be running
+./target/debug/browser-cli navigate https://www.naver.com/
+./target/debug/browser-cli js "document.querySelectorAll('a').length"
+./target/debug/browser-cli screenshot /tmp/naver_after_256.png
+python3 -c "
+from PIL import Image
+img = Image.open('/tmp/naver_after_256.png')
+nw = [p for p in img.getdata() if not (p[0]>240 and p[1]>240 and p[2]>240)]
+print(f'Non-white pixels: {len(nw)}')
+"
+```
+
+**Expected output:**
+- All `cargo test --lib` pass (including new tests)
+- Link count > 30 (currently 8)
+- Non-white pixel count > 10,000 (currently 22)
+
+## Risks & Rollback
+
+**Risks:**
+- 5-tick RAF drain loop may not be enough if React needs more ticks. Tunable.
+- Adding ticks increases `navigate()` latency by ~5 * tick_cost. Acceptable.
+- If RAF drain causes infinite loop (render loop pattern), cap=5 prevents it.
+
+**Rollback steps:**
+- `git revert HEAD` — changes in `src/engine.rs` (tick loop) + `src/js.rs` (raf return)
+  + `src/js_bootstrap.js` (IO getters + ShadowRoot.getRootNode). No DB, no flags.
+
+## Revision notes (vs. original draft)
+
+**Rejected from original plan:**
+- Adding `window.requestAnimationFrame` JS shim in `js_bootstrap.js` → WRONG.
+  Native `raf_cb` already registered (js.rs:1686). A JS shim at bootstrap end
+  would shadow/overwrite the native function, breaking the RAF_TASKS drain path.
+  Fix instead: add ticks in `navigate()`, fix return value in `raf_cb`.
+
+## Open Questions
+
+- None. Root cause confirmed via code inspection.

--- a/.plan/issues/2026-06-09-issue-257-debug-and-fix-getattribute-typeerror.md
+++ b/.plan/issues/2026-06-09-issue-257-debug-and-fix-getattribute-typeerror.md
@@ -1,0 +1,46 @@
+# 2026-06-09 — Debug and Fix getAttribute Uncaught TypeError
+
+- Date: 2026-06-09
+- GitHub Issue: #257
+- Status: Draft
+
+## Goal
+Identify the JavaScript object that lacks the `getAttribute` function causing the `Uncaught TypeError: t.getAttribute is not a function` crash on Naver, and resolve the crash by implementing the proper stubs or fallback.
+
+## Non-goals
+- Adding permanent `Object.prototype` modifications.
+- Implementing fully-featured DOM APIs beyond the necessary stubs to prevent crashes.
+
+## Context / Constraints
+- The crash happens at column 46058 of `preload.20fd9b94.js` inside Sizzle's `ot.attr(t, e)` function: `t.getAttribute(e)`.
+- We need to find the runtime class/constructor of the object `t`.
+- We must follow the strict developer workflow: Plan -> Review -> Act -> Verify.
+
+## Approach (Checklist)
+- [ ] **Step 0: Recon**
+  - Verify the crash log is clean and points to column 46058.
+- [ ] **Step 1: Implementation (Temporary Debug)**
+  - Define a temporary `Object.prototype.getAttribute` debug wrapper in `src/js_bootstrap.js` that logs `this` constructor/type and returns `null`.
+  - Run the daemon and navigate to `https://www.naver.com`.
+  - Check the daemon log to inspect what type of object triggered the debug probe.
+- [ ] **Step 2: Permanent Fix**
+  - Remove the temporary `Object.prototype` modification.
+  - Apply the proper stub (e.g., to `window` or `Location` or the corresponding object class) in `src/js_bootstrap.js`.
+- [ ] **Step 3: Verification & Tests**
+  - Run `cargo test --lib -- --test-threads=1` to ensure no regressions.
+  - Run the daemon again, navigate to Naver, take a screenshot, and verify the console is clean of the `getAttribute` exception.
+
+## Validation
+- **Commands to run:**
+  - `cargo test --lib -- --test-threads=1`
+  - Run the daemon and fetch/tick Naver to see logs.
+- **Expected output:**
+  - No `getAttribute` TypeError.
+  - Homepage should load further/completely without standard bundle exceptions.
+
+## Risks & Rollback
+- **Risks:** Temporary debug properties on `Object.prototype` can cause side-effects. We will remove it immediately after gathering logs.
+- **Rollback steps:** `git restore src/js_bootstrap.js`.
+
+## Open Questions
+- None.

--- a/.plan/issues/2026-06-09-issue-257-debug-getattribute-typeerror.md
+++ b/.plan/issues/2026-06-09-issue-257-debug-getattribute-typeerror.md
@@ -1,0 +1,41 @@
+# 2026-06-09 — Debug and Fix getAttribute Uncaught TypeError
+
+- Date: 2026-06-09
+- GitHub Issue: #257
+- Status: Draft
+
+## Goal
+Identify the JavaScript object that lacks the `getAttribute` function causing the `Uncaught TypeError: t.getAttribute is not a function` crash on Naver.com, and resolve the crash by implementing the proper stubs.
+
+## Non-goals
+- Keep temporary `Object.prototype` modifications in production code.
+- Implement fully-featured DOM APIs beyond the necessary stubs to prevent crashes.
+
+## Context / Constraints
+- Sizzle or another library raises `<unknown>:46058: Uncaught TypeError: t.getAttribute is not a function`.
+- We need to identify what runtime constructor / class `t` has when it is accessed.
+- We must follow the strict developer workflow: Plan -> Review -> Act -> Verify.
+
+## Approach (Checklist)
+- [ ] **Step 1: Temporary Debug Hook**
+  - Define temporary `Object.prototype.getAttribute` and `Object.prototype.removeAttribute` getters in `src/js_bootstrap.js` to print the constructor and keys of the offending object, return a dummy function, and not crash.
+  - Run the browser daemon and navigate/tick to trigger the error.
+  - Inspect the printed debug log to identify the constructor/prototype.
+- [ ] **Step 2: Permanent Fix**
+  - Remove the temporary `Object.prototype` hooks.
+  - Add `getAttribute`, `setAttribute`, `removeAttribute`, `hasAttribute` stubs to the identified target class/prototype (e.g. `this._contentDocument` inside `HTMLIFrameElement`, or another class).
+- [ ] **Step 3: Verification & Tests**
+  - Run `cargo test --lib -- --test-threads=1` to check for regressions.
+  - Re-run browser daemon, fetch Naver, and verify the console is clean of the `getAttribute` TypeError.
+
+## Validation
+- **Commands to run:**
+  - `cargo test --lib -- --test-threads=1`
+  - Run the daemon and navigation flow.
+- **Expected output:**
+  - No `getAttribute` TypeError in logs.
+  - Dynamic elements render successfully.
+
+## Risks & Rollback
+- **Risks:** Temporary traps on `Object.prototype` can cause recursion or unexpected side-effects if not implemented carefully.
+- **Rollback steps:** `git restore src/js_bootstrap.js`.

--- a/.plan/issues/2026-06-09-issue-257-fix-dynamic-script-cors.md
+++ b/.plan/issues/2026-06-09-issue-257-fix-dynamic-script-cors.md
@@ -1,0 +1,23 @@
+# Plan - Fix CORS Enforcement on Dynamic Classic Scripts
+
+Naver's React app fails to mount because a dynamically inserted classic script tag (`ndp-core.js` from `ssl.pstatic.net`) is loaded via `fetch` in the JS bootstrap script. The browser's native `__aura_fetch` implementation blocks it because it is cross-origin and does not pass CORS checks.
+However, in standard browsers, classic script tags (`<script src="...">`) do not enforce CORS. We should allow dynamic classic scripts to bypass CORS checks.
+
+## Proposed Changes
+
+### 1. `src/js.rs`
+Modify `fetch_cb` to accept a 7th argument, `bypass_cors` (boolean):
+- Read the 7th argument `bypass_cors` (default to `false` if not provided).
+- Skip the CORS allowed check (line 3110-3123) if `bypass_cors` is `true`.
+
+### 2. `src/js_bootstrap.js`
+Modify `__aura_maybe_run_script` to:
+- Call `__aura_fetch` directly with the `bypassCors` flag instead of using page-level `fetch(src)`.
+- Determine `bypassCors` as `!isModule && !script.hasAttribute('crossorigin')` (modules and classic scripts with `crossorigin` attribute enforce CORS; other classic scripts do not).
+- Improve error logging to include the script URL on load/execution failures.
+
+## Verification Plan
+1. Compile and run cargo check / tests.
+2. Restart the daemon on Naver.
+3. Navigating to Naver, then tick JS to allow all dynamic scripts to execute.
+4. Capture a new screenshot to verify that the home page content is loaded and rendered instead of a blank screen.

--- a/.plan/issues/2026-06-09-issue-257-fix-htmlcollection-proxy-keys.md
+++ b/.plan/issues/2026-06-09-issue-257-fix-htmlcollection-proxy-keys.md
@@ -1,0 +1,46 @@
+# 2026-06-09 — Fix HTMLCollection and StyleSheetList Proxy Keys
+
+- Date: 2026-06-09
+- GitHub Issue: #257
+- Status: Draft
+
+## Goal
+Fix `HTMLCollection` and `StyleSheetList` Proxies so that they only expose numeric indices and standard non-enumerable properties, preventing Sizzle/jQuery from resolving internal properties (like `_resolver`) as DOM elements and crashing.
+
+## Non-goals
+- Over-complicating Proxy traps for unrelated classes.
+
+## Context / Constraints
+- We observed that Sizzle/jQuery accesses `getAttribute` on `Function` objects (such as `_resolver`) when mapping/iterating collections.
+- This happens because `_resolver` is an own property on the Proxy target and is enumerable by default, making it visible to key iterations (`Object.keys`, `for...in`).
+- We need to:
+  1. Hide `_resolver` by making it non-enumerable.
+  2. Implement `ownKeys` and `getOwnPropertyDescriptor` traps in `HTMLCollection` and `StyleSheetList` Proxies to correctly report only numeric indices and hide internal properties.
+  3. Remove the temporary `Object.prototype` debug hooks.
+
+## Approach (Checklist)
+- [ ] **Step 1: Hide `_resolver` & Implement Proxy traps**
+  - Update `HTMLCollection` constructor:
+    - Use `Object.defineProperty` to define `_resolver` as non-enumerable.
+    - Implement `ownKeys` trap to return `["0", "1", ..., "length"]`.
+    - Implement `getOwnPropertyDescriptor` trap to return descriptor for indices and `length`.
+  - Update `StyleSheetList` constructor similarly.
+  - Remove temporary `Object.prototype.getAttribute` and `Object.prototype.removeAttribute` debug hooks.
+- [ ] **Step 2: Build & Verification**
+  - Run `cargo build` to compile the bootstrap changes.
+  - Restart the browser daemon.
+  - Navigate to Naver and run `tick 20` to verify that the page loads without any TypeError.
+- [ ] **Step 3: Run Tests**
+  - Run `cargo test --lib -- --test-threads=1` to ensure all tests pass.
+
+## Validation
+- **Commands to run:**
+  - `cargo test --lib -- --test-threads=1`
+  - Re-run daemon navigation and check output.
+- **Expected output:**
+  - `cargo test` passes.
+  - Sizzle exception is gone and page renders successfully.
+
+## Risks & Rollback
+- **Risks:** Adding `ownKeys` and `getOwnPropertyDescriptor` could affect JS code that iterates over CSS stylesheets or DOM elements, but returning standard descriptors is the correct way.
+- **Rollback steps:** `git restore src/js_bootstrap.js`.

--- a/.plan/issues/2026-06-09-issue-257-fix-htmlcollection-proxy-traps.md
+++ b/.plan/issues/2026-06-09-issue-257-fix-htmlcollection-proxy-traps.md
@@ -1,0 +1,42 @@
+# 2026-06-09 — Fix HTMLCollection Proxy Traps and getAttribute/removeAttribute TypeError
+
+- Date: 2026-06-09
+- GitHub Issue: #257
+- Status: Draft
+
+## Goal
+Resolve the `getAttribute`/`removeAttribute` TypeError by fixing bugs in `HTMLCollection`'s Proxy traps, allowing libraries (like jQuery/Sizzle) to correctly determine if DOM collections are array-like.
+
+## Non-goals
+- Over-complicating proxy traps for non-problematic classes.
+
+## Context / Constraints
+- We discovered that `0 in HTMLCollection` returned `false` because:
+  1. The `has` trap checked `typeof prop === 'string'`, which is false when `in` operator receives a number.
+  2. The `has` trap used `target.length`, which is `undefined` on the raw `target` (it should use `target._items().length`).
+- This caused jQuery's `isArraylike` test to return `false` for `HTMLCollection` collections (e.g. from `getElementsByTagName`), forcing it to loop via `for...in` and access function properties (`item`, `namedItem`), which got passed to Sizzle matcher and crashed on `getAttribute`/`removeAttribute` calls.
+
+## Approach (Checklist)
+- [ ] **Step 0: Cleanup Debug Hook**
+  - Restore `src/js.rs` to remove `eprintln!` log statement in `append_console_entry`.
+  - Remove `Object.prototype.getAttribute` and `Object.prototype.removeAttribute` debug stubs from `src/js_bootstrap.js`.
+- [ ] **Step 1: Implementation**
+  - Update `HTMLCollection` constructor's Proxy traps (`get` and `has`) in `src/js_bootstrap.js` to correctly handle both string and number indices, and use `target._items().length` instead of `target.length`.
+  - Update `StyleSheetList` constructor's Proxy traps similarly in `src/js_bootstrap.js`.
+- [ ] **Step 2: Verification & Tests**
+  - Run `cargo test --lib -- --test-threads=1` to check for regressions.
+  - Start the daemon, navigate to Naver, tick 20 times, check daemon logs, and verify that the page loads further (e.g. dynamic elements are mounted).
+  - Capture a verification screenshot.
+
+## Validation
+- **Commands to run:**
+  - `cargo test --lib -- --test-threads=1`
+  - Re-run daemon navigation and check output.
+- **Expected output:**
+  - `cargo test` passes.
+  - Sizzle exception is gone from logs.
+  - Screen displays rendered elements of Naver.
+
+## Risks & Rollback
+- **Risks:** Modifications to proxy traps could affect other DOM collections. We will run the entire library test suite.
+- **Rollback steps:** `git restore src/js_bootstrap.js src/js.rs`.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Links:
 | `submit` | Submit the current form |
 | `back` / `forward` | Navigate browser history |
 | `screenshot [file]` | Save PNG (default: `screenshot.png`) |
+| `logs` | Print browser console entries captured during page load |
+| `tick [count]` | Advance daemon JavaScript tasks and re-render if needed |
 | `help` | Show all commands |
 | `quit` | Exit |
 

--- a/src/bin/browser_cli.rs
+++ b/src/bin/browser_cli.rs
@@ -124,7 +124,7 @@ struct DaemonClient {
 impl DaemonClient {
     fn new(port: u16) -> Self {
         Self {
-            base_url: format!("http://localhost:{}", port),
+            base_url: format!("http://127.0.0.1:{}", port),
             client: reqwest::blocking::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
@@ -941,13 +941,13 @@ mod tests {
     #[test]
     fn test_daemon_client_default_port() {
         let client = DaemonClient::new(7070);
-        assert_eq!(client.base_url, "http://localhost:7070");
+        assert_eq!(client.base_url, "http://127.0.0.1:7070");
     }
 
     #[test]
     fn test_daemon_client_custom_port() {
         let client = DaemonClient::new(8080);
-        assert_eq!(client.base_url, "http://localhost:8080");
+        assert_eq!(client.base_url, "http://127.0.0.1:8080");
     }
 
     // -- CliHistory tests --

--- a/src/bin/browser_cli.rs
+++ b/src/bin/browser_cli.rs
@@ -12,6 +12,8 @@
 //!   browser-cli js <script>              # Evaluate JavaScript and print result
 //!   browser-cli style [<selector>]       # Print computed CSS styles
 //!   browser-cli layout                   # Print the layout tree
+//!   browser-cli logs                     # Print browser console entries
+//!   browser-cli tick [count]             # Advance daemon JS tasks
 //!   browser-cli --port 7071 <command>    # Custom daemon port
 
 use std::fmt;
@@ -59,6 +61,20 @@ struct ApiPageResponse {
     pub forms: Vec<ApiFormControl>,
     pub width: u32,
     pub height: u32,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+struct ApiConsoleEntry {
+    pub level: String,
+    pub message: String,
+    pub timestamp: u64,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+struct ApiTickResponse {
+    pub ticks: u32,
+    pub worked: bool,
+    pub rerendered: bool,
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]
@@ -141,7 +157,11 @@ impl DaemonClient {
         // deserialization fails (e.g. because the daemon panicked and sent garbage).
         let body = resp.text().map_err(|e| CliError::Parse(e.to_string()))?;
         serde_json::from_str::<ApiPageResponse>(&body).map_err(|e| {
-            let preview = if body.len() > 200 { &body[..200] } else { &body };
+            let preview = if body.len() > 200 {
+                &body[..200]
+            } else {
+                &body
+            };
             CliError::Parse(format!("{} (raw body: {})", e, preview))
         })
     }
@@ -159,7 +179,11 @@ impl DaemonClient {
         // deserialization fails.
         let body = resp.text().map_err(|e| CliError::Parse(e.to_string()))?;
         serde_json::from_str::<ApiPageResponse>(&body).map_err(|e| {
-            let preview = if body.len() > 200 { &body[..200] } else { &body };
+            let preview = if body.len() > 200 {
+                &body[..200]
+            } else {
+                &body
+            };
             CliError::Parse(format!("{} (raw body: {})", e, preview))
         })
     }
@@ -213,9 +237,7 @@ impl DaemonClient {
             .json(&serde_json::json!({ "script": script }))
             .send()
             .map_err(Self::check_error)?;
-        let v: serde_json::Value = resp
-            .json()
-            .map_err(|e| CliError::Parse(e.to_string()))?;
+        let v: serde_json::Value = resp.json().map_err(|e| CliError::Parse(e.to_string()))?;
         Ok(v["result"].as_str().unwrap_or("").to_string())
     }
 
@@ -229,9 +251,7 @@ impl DaemonClient {
             .json(&serde_json::json!({ "code": code }))
             .send()
             .map_err(Self::check_error)?;
-        let v: serde_json::Value = resp
-            .json()
-            .map_err(|e| CliError::Parse(e.to_string()))?;
+        let v: serde_json::Value = resp.json().map_err(|e| CliError::Parse(e.to_string()))?;
         let result = v["result"].as_str().map(|s| s.to_string());
         let error = v["error"].as_str().map(|s| s.to_string());
         Ok((result, error))
@@ -244,14 +264,8 @@ impl DaemonClient {
         } else {
             format!("{}/style", self.base_url)
         };
-        let resp = self
-            .client
-            .get(&url)
-            .send()
-            .map_err(Self::check_error)?;
-        let v: serde_json::Value = resp
-            .json()
-            .map_err(|e| CliError::Parse(e.to_string()))?;
+        let resp = self.client.get(&url).send().map_err(Self::check_error)?;
+        let v: serde_json::Value = resp.json().map_err(|e| CliError::Parse(e.to_string()))?;
         serde_json::to_string_pretty(&v).map_err(|e| CliError::Parse(e.to_string()))
     }
 
@@ -263,6 +277,30 @@ impl DaemonClient {
             .send()
             .map_err(Self::check_error)?;
         resp.text().map_err(|e| CliError::Http(e.to_string()))
+    }
+
+    fn get_console(&self) -> Result<Vec<ApiConsoleEntry>, CliError> {
+        let resp = self
+            .client
+            .get(format!("{}/console", self.base_url))
+            .send()
+            .map_err(Self::check_error)?;
+        resp.json::<Vec<ApiConsoleEntry>>()
+            .map_err(|e| CliError::Parse(e.to_string()))
+    }
+
+    fn tick(&self, count: u32) -> Result<ApiTickResponse, CliError> {
+        let resp = self
+            .client
+            .post(format!("{}/tick", self.base_url))
+            .json(&serde_json::json!({ "count": count, "width": 800.0 }))
+            .send()
+            .map_err(Self::check_error)?;
+        if !resp.status().is_success() {
+            return Err(CliError::Http(format!("tick returned {}", resp.status())));
+        }
+        resp.json::<ApiTickResponse>()
+            .map_err(|e| CliError::Parse(e.to_string()))
     }
 }
 
@@ -505,8 +543,14 @@ enum ClickTarget {
 enum Command {
     Navigate(String),
     Click(ClickTarget),
-    Type { field: String, value: String },
-    Select { field: String, option: String },
+    Type {
+        field: String,
+        value: String,
+    },
+    Select {
+        field: String,
+        option: String,
+    },
     Submit,
     Back,
     Forward,
@@ -514,8 +558,12 @@ enum Command {
     Js(String),
     /// Evaluate JS via the DevTools console REPL — result/error is echoed into the console buffer.
     Console(String),
-    Style { selector: Option<String> },
+    Style {
+        selector: Option<String>,
+    },
     Layout,
+    Logs,
+    Tick(u32),
     Help,
     Quit,
     Unknown(String),
@@ -613,6 +661,15 @@ fn parse_command(line: &str) -> Command {
             },
         },
         "layout" => Command::Layout,
+        "logs" | "console-log" | "console-logs" => Command::Logs,
+        "tick" => {
+            let count = if rest.is_empty() {
+                1
+            } else {
+                rest.parse::<u32>().unwrap_or(1)
+            };
+            Command::Tick(count.clamp(1, 120))
+        }
         "help" | "?" | "h" => Command::Help,
         "quit" | "exit" | "q" => Command::Quit,
         other => Command::Unknown(other.to_string()),
@@ -633,11 +690,27 @@ fn print_help() {
     println!("  screenshot [<file>]     Save a PNG screenshot (default: screenshot.png)");
     println!("  js <script>             Evaluate JavaScript and print the result");
     println!("  console <expr>          Evaluate JS via DevTools console REPL (echoes in console buffer)");
-    println!("  style [<selector>]      Print computed CSS styles (optionally filtered by selector)");
+    println!(
+        "  style [<selector>]      Print computed CSS styles (optionally filtered by selector)"
+    );
     println!("  layout                  Print the current layout tree");
+    println!("  logs                    Print browser console entries");
+    println!("  tick [count]            Advance daemon JS tasks and re-render if needed");
     println!("  help                    Show this help");
     println!("  quit                    Exit the REPL");
     println!();
+}
+
+fn render_console_entries(entries: &[ApiConsoleEntry]) {
+    if entries.is_empty() {
+        println!("Console: (empty)");
+        return;
+    }
+
+    println!("Console:");
+    for entry in entries {
+        println!("[{}] {} {}", entry.level, entry.timestamp, entry.message);
+    }
 }
 
 // ── REPL ──────────────────────────────────────────────────────────────────────
@@ -698,32 +771,35 @@ fn dispatch_command(cmd: Command, state: &mut CliState) -> bool {
                 eprintln!("Error: {}", e);
             }
         }
-        Command::Js(script) => {
-            match state.client.evaluate_js(&script) {
-                Ok(result) => println!("js result: {}", result),
-                Err(e) => eprintln!("Error: {}", e),
-            }
-        }
-        Command::Console(code) => {
-            match state.client.console_eval(&code) {
-                Ok((Some(result), _)) => println!("< {}", result),
-                Ok((_, Some(error))) => eprintln!("< [error] {}", error),
-                Ok((None, None)) => {}
-                Err(e) => eprintln!("Error: {}", e),
-            }
-        }
-        Command::Style { selector } => {
-            match state.client.get_style(selector.as_deref()) {
-                Ok(text) => println!("{}", text),
-                Err(e) => eprintln!("Error: {}", e),
-            }
-        }
-        Command::Layout => {
-            match state.client.get_layout() {
-                Ok(text) => println!("{}", text),
-                Err(e) => eprintln!("Error: {}", e),
-            }
-        }
+        Command::Js(script) => match state.client.evaluate_js(&script) {
+            Ok(result) => println!("js result: {}", result),
+            Err(e) => eprintln!("Error: {}", e),
+        },
+        Command::Console(code) => match state.client.console_eval(&code) {
+            Ok((Some(result), _)) => println!("< {}", result),
+            Ok((_, Some(error))) => eprintln!("< [error] {}", error),
+            Ok((None, None)) => {}
+            Err(e) => eprintln!("Error: {}", e),
+        },
+        Command::Style { selector } => match state.client.get_style(selector.as_deref()) {
+            Ok(text) => println!("{}", text),
+            Err(e) => eprintln!("Error: {}", e),
+        },
+        Command::Layout => match state.client.get_layout() {
+            Ok(text) => println!("{}", text),
+            Err(e) => eprintln!("Error: {}", e),
+        },
+        Command::Logs => match state.client.get_console() {
+            Ok(entries) => render_console_entries(&entries),
+            Err(e) => eprintln!("Error: {}", e),
+        },
+        Command::Tick(count) => match state.client.tick(count) {
+            Ok(resp) => println!(
+                "tick: ticks={} worked={} rerendered={}",
+                resp.ticks, resp.worked, resp.rerendered
+            ),
+            Err(e) => eprintln!("Error: {}", e),
+        },
         Command::Help => print_help(),
         Command::Quit => {
             println!("Goodbye.");
@@ -1074,6 +1150,20 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_command_logs() {
+        assert_eq!(parse_command("logs"), Command::Logs);
+        assert_eq!(parse_command("console-logs"), Command::Logs);
+    }
+
+    #[test]
+    fn test_parse_command_tick() {
+        assert_eq!(parse_command("tick"), Command::Tick(1));
+        assert_eq!(parse_command("tick 3"), Command::Tick(3));
+        assert_eq!(parse_command("tick nope"), Command::Tick(1));
+        assert_eq!(parse_command("tick 500"), Command::Tick(120));
+    }
+
+    #[test]
     fn test_parse_command_quit_variants() {
         assert_eq!(parse_command("quit"), Command::Quit);
         assert_eq!(parse_command("exit"), Command::Quit);
@@ -1127,14 +1217,24 @@ mod tests {
                     element_type: "link".to_string(),
                     text: "More information".to_string(),
                     href: Some("https://www.iana.org/domains/reserved".to_string()),
-                    rect: ApiRect { x: 100.0, y: 200.0, w: 120.0, h: 20.0 },
+                    rect: ApiRect {
+                        x: 100.0,
+                        y: 200.0,
+                        w: 120.0,
+                        h: 20.0,
+                    },
                 },
                 ApiElement {
                     id: "e1".to_string(),
                     element_type: "link".to_string(),
                     text: String::new(),
                     href: Some("https://another.com".to_string()),
-                    rect: ApiRect { x: 0.0, y: 0.0, w: 50.0, h: 20.0 },
+                    rect: ApiRect {
+                        x: 0.0,
+                        y: 0.0,
+                        w: 50.0,
+                        h: 20.0,
+                    },
                 },
             ],
             forms: vec![],
@@ -1198,13 +1298,25 @@ mod tests {
         let invalid_json = "thread 'tokio-runtime' panicked at 'byte index 5...'";
         let err = serde_json::from_str::<ApiPageResponse>(invalid_json)
             .map_err(|e| {
-                let preview = if invalid_json.len() > 200 { &invalid_json[..200] } else { invalid_json };
+                let preview = if invalid_json.len() > 200 {
+                    &invalid_json[..200]
+                } else {
+                    invalid_json
+                };
                 CliError::Parse(format!("{} (raw body: {})", e, preview))
             })
             .unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("Parse error:"), "expected 'Parse error:' in: {}", msg);
-        assert!(msg.contains("raw body:"), "expected 'raw body:' in: {}", msg);
+        assert!(
+            msg.contains("Parse error:"),
+            "expected 'Parse error:' in: {}",
+            msg
+        );
+        assert!(
+            msg.contains("raw body:"),
+            "expected 'raw body:' in: {}",
+            msg
+        );
         assert!(msg.contains("panicked"), "expected panic text in: {}", msg);
     }
 }

--- a/src/bin/browser_daemon.rs
+++ b/src/bin/browser_daemon.rs
@@ -7,8 +7,8 @@
 
 use std::collections::HashMap;
 
-use browser::{engine, layout};
 use browser::engine::{EngineCmd, EngineHandle};
+use browser::{engine, layout};
 use eframe::egui;
 use poll_promise::Promise;
 
@@ -45,7 +45,6 @@ fn parse_args() -> DaemonArgs {
     let refs: Vec<&str> = raw.iter().map(|s| s.as_str()).collect();
     parse_args_from(&refs)
 }
-
 
 // ── axum HTTP server ──────────────────────────────────────────────────────────
 
@@ -84,6 +83,12 @@ struct ConsoleEvalRequest {
 }
 
 #[derive(serde::Deserialize)]
+struct TickRequest {
+    count: Option<u32>,
+    width: Option<f32>,
+}
+
+#[derive(serde::Deserialize)]
 struct StyleQuery {
     selector: Option<String>,
 }
@@ -111,6 +116,18 @@ struct OkResponse {
 }
 
 #[derive(serde::Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+#[derive(serde::Serialize)]
+struct TickResponse {
+    ticks: u32,
+    worked: bool,
+    rerendered: bool,
+}
+
+#[derive(serde::Serialize)]
 struct SubmitResponse {
     url: String,
 }
@@ -123,6 +140,21 @@ macro_rules! blocking {
             Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
         }
     };
+}
+
+fn engine_error_response(error: engine::EngineRequestError) -> axum::response::Response {
+    let status = match error {
+        engine::EngineRequestError::Busy => StatusCode::SERVICE_UNAVAILABLE,
+        engine::EngineRequestError::Disconnected => StatusCode::INTERNAL_SERVER_ERROR,
+        engine::EngineRequestError::Failed(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (
+        status,
+        Json(ErrorResponse {
+            error: error.to_string(),
+        }),
+    )
+        .into_response()
 }
 
 async fn navigate_handler(
@@ -144,17 +176,30 @@ async fn navigate_handler(
 }
 
 async fn page_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
-    let resp = blocking!(move || handle.send_get_page());
+    let resp = blocking!(move || handle.send_get_page_control());
     match resp {
-        Some(page) => (StatusCode::OK, Json(page)).into_response(),
-        None => (StatusCode::NOT_FOUND, "No page loaded").into_response(),
+        Ok(Some(page)) => (StatusCode::OK, Json(page)).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "No page loaded").into_response(),
+        Err(error) => engine_error_response(error),
     }
 }
 
 async fn status_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
-    let page_opt = blocking!(move || handle.send_get_page());
-    let url = page_opt.map(|p| p.url).unwrap_or_default();
-    (StatusCode::OK, Json(StatusResponse { url, loading: false })).into_response()
+    let page_opt = blocking!(move || handle.send_get_page_control());
+    match page_opt {
+        Ok(page_opt) => {
+            let url = page_opt.map(|p| p.url).unwrap_or_default();
+            (
+                StatusCode::OK,
+                Json(StatusResponse {
+                    url,
+                    loading: false,
+                }),
+            )
+                .into_response()
+        }
+        Err(error) => engine_error_response(error),
+    }
 }
 
 async fn health_handler() -> impl IntoResponse {
@@ -173,7 +218,9 @@ async fn type_handler(
     State(handle): State<EngineHandle>,
     Json(req): Json<TypeRequest>,
 ) -> impl IntoResponse {
-    blocking!(move || { let _ = handle.tx.send(EngineCmd::TypeText { text: req.text }); });
+    blocking!(move || {
+        let _ = handle.tx.send(EngineCmd::TypeText { text: req.text });
+    });
     (StatusCode::OK, Json(OkResponse { ok: true })).into_response()
 }
 
@@ -201,26 +248,71 @@ async fn console_eval_handler(
 }
 
 async fn screenshot_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
-    let png_opt = blocking!(move || handle.send_screenshot());
+    let png_opt = blocking!(move || handle.send_screenshot_control());
     match png_opt {
-        Some(bytes) => (
+        Ok(Some(bytes)) => (
             StatusCode::OK,
             [(axum::http::header::CONTENT_TYPE, "image/png")],
             bytes,
         )
             .into_response(),
-        None => (StatusCode::NOT_FOUND, "No page loaded").into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "No page loaded").into_response(),
+        Err(error) => engine_error_response(error),
+    }
+}
+
+async fn tick_handler(
+    State(handle): State<EngineHandle>,
+    Json(req): Json<TickRequest>,
+) -> impl IntoResponse {
+    let count = req.count.unwrap_or(1).clamp(1, 120);
+    let width = req.width.unwrap_or(800.0);
+    let result = blocking!(move || {
+        let mut worked = false;
+        for i in 0..count {
+            match handle.send_tick_control(i as f64, None) {
+                Ok(did_work) => worked |= did_work,
+                Err(error) => return Err(error),
+            }
+        }
+        let rerendered = if worked {
+            match handle.send_re_render_control(None, None, width) {
+                Ok(_) => true,
+                Err(error) => return Err(error),
+            }
+        } else {
+            false
+        };
+        Ok(TickResponse {
+            ticks: count,
+            worked,
+            rerendered,
+        })
+    });
+    match result {
+        Ok(resp) => (StatusCode::OK, Json(resp)).into_response(),
+        Err(error) => engine_error_response(error),
     }
 }
 
 async fn dom_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
     let text = blocking!(move || handle.send_dom_tree());
-    (StatusCode::OK, [(axum::http::header::CONTENT_TYPE, "text/plain")], text).into_response()
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/plain")],
+        text,
+    )
+        .into_response()
 }
 
 async fn layout_handler(State(handle): State<EngineHandle>) -> impl IntoResponse {
     let text = blocking!(move || handle.send_layout_tree());
-    (StatusCode::OK, [(axum::http::header::CONTENT_TYPE, "text/plain")], text).into_response()
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/plain")],
+        text,
+    )
+        .into_response()
 }
 
 async fn style_handler(
@@ -248,7 +340,11 @@ async fn submit_handler(State(handle): State<EngineHandle>) -> impl IntoResponse
     let url = blocking!(move || { handle.send_submit() });
     match url {
         Some(nav_url) => (StatusCode::OK, Json(SubmitResponse { url: nav_url })).into_response(),
-        None => (StatusCode::NOT_FOUND, Json(SubmitResponse { url: String::new() })).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(SubmitResponse { url: String::new() }),
+        )
+            .into_response(),
     }
 }
 
@@ -263,6 +359,7 @@ pub fn build_router(handle: EngineHandle) -> Router {
         .route("/type", post(type_handler))
         .route("/js", post(js_handler))
         .route("/console/eval", post(console_eval_handler))
+        .route("/tick", post(tick_handler))
         .route("/screenshot", get(screenshot_handler))
         .route("/dom", get(dom_handler))
         .route("/layout", get(layout_handler))
@@ -323,10 +420,9 @@ impl DaemonBrowserApp {
         // Load Korean font (same as BrowserApp)
         let mut fonts = egui::FontDefinitions::default();
         let nanum_data = include_bytes!("../../assets/fonts/NanumGothic.ttf");
-        fonts.font_data.insert(
-            "nanum".to_owned(),
-            egui::FontData::from_static(nanum_data),
-        );
+        fonts
+            .font_data
+            .insert("nanum".to_owned(), egui::FontData::from_static(nanum_data));
         fonts
             .families
             .get_mut(&egui::FontFamily::Proportional)
@@ -468,7 +564,10 @@ impl eframe::App for DaemonBrowserApp {
         if let Some(eval_promise) = &self.console_eval_promise {
             if eval_promise.ready().is_some() {
                 self.console_eval_promise = None;
-                if self.has_page && self.re_render_promise.is_none() && self.content_promise.is_none() {
+                if self.has_page
+                    && self.re_render_promise.is_none()
+                    && self.content_promise.is_none()
+                {
                     self.trigger_re_render(ctx, 800.0);
                 } else {
                     ctx.request_repaint();
@@ -480,9 +579,10 @@ impl eframe::App for DaemonBrowserApp {
         if ctx.input(|i| i.key_pressed(egui::Key::Tab)) {
             let focusables = &self.current_focusable_elements;
             if !focusables.is_empty() {
-                let current_index = self.focused_id.as_ref().and_then(|id| {
-                    focusables.iter().position(|(_, fid)| fid == id)
-                });
+                let current_index = self
+                    .focused_id
+                    .as_ref()
+                    .and_then(|id| focusables.iter().position(|(_, fid)| fid == id));
                 let next_index = if ctx.input(|i| i.modifiers.shift) {
                     match current_index {
                         Some(i) if i > 0 => i - 1,
@@ -557,9 +657,7 @@ impl eframe::App for DaemonBrowserApp {
                             .frame(false)
                             .font(egui::TextStyle::Monospace);
                         let resp = ui.add(edit);
-                        if resp.lost_focus()
-                            && ui.input(|i| i.key_pressed(egui::Key::Enter))
-                        {
+                        if resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                             let url = self.url.clone();
                             self.load_url(url, 800.0);
                         }
@@ -612,9 +710,10 @@ impl eframe::App for DaemonBrowserApp {
             |code| {
                 if self.console_eval_promise.is_none() {
                     let handle = self.handle.clone();
-                    self.console_eval_promise = Some(Promise::spawn_thread("daemon-console-eval", move || {
-                        handle.send_console_eval_result(code)
-                    }));
+                    self.console_eval_promise =
+                        Some(Promise::spawn_thread("daemon-console-eval", move || {
+                            handle.send_console_eval_result(code)
+                        }));
                 }
             },
         );
@@ -981,7 +1080,10 @@ fn render_console_panel(
                         .color(egui::Color32::GRAY)
                         .small(),
                 );
-                if ui.add_enabled(!entries.is_empty(), egui::Button::new("Clear")).clicked() {
+                if ui
+                    .add_enabled(!entries.is_empty(), egui::Button::new("Clear"))
+                    .clicked()
+                {
                     clear_console();
                     entries.clear();
                 }
@@ -1000,8 +1102,7 @@ fn render_console_panel(
                 .show(ui, |ui| {
                     if entries.is_empty() {
                         ui.label(
-                            egui::RichText::new("No console output")
-                                .color(egui::Color32::GRAY),
+                            egui::RichText::new("No console output").color(egui::Color32::GRAY),
                         );
                         return;
                     }
@@ -1080,7 +1181,10 @@ fn main() {
         .expect("failed to start HTTP server thread");
 
     if args.no_gui {
-        println!("[browser-daemon] Running headless on http://127.0.0.1:{}", port);
+        println!(
+            "[browser-daemon] Running headless on http://127.0.0.1:{}",
+            port
+        );
         println!("[browser-daemon] Press Ctrl+C to stop.");
         // Block main thread forever; signal handlers (Ctrl+C) terminate the process
         loop {
@@ -1149,7 +1253,10 @@ mod tests {
     fn test_engine_actor_get_page_empty() {
         let handle = make_test_handle();
         let (reply_tx, reply_rx) = mpsc::channel();
-        handle.tx.send(EngineCmd::GetPage { reply: reply_tx }).unwrap();
+        handle
+            .tx
+            .send(EngineCmd::GetPage { reply: reply_tx })
+            .unwrap();
         let result = reply_rx.recv().unwrap();
         assert!(result.is_none());
     }
@@ -1232,7 +1339,9 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["loading"], false);
     }
@@ -1248,7 +1357,9 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         assert_eq!(&body[..], b"ok");
     }
 
@@ -1279,6 +1390,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_http_tick_returns_status() {
+        let handle = make_test_handle();
+        let app = build_router(handle);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/tick")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from(r#"{"count":2}"#))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["ticks"], 2);
+    }
+
+    #[tokio::test]
     async fn test_http_elements_empty() {
         let handle = make_test_handle();
         let app = build_router(handle);
@@ -1289,67 +1419,69 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(json.as_array().unwrap().is_empty());
     }
 
-//     #[tokio::test]
-//     async fn test_http_console_returns_entries() {
-//         let handle = make_test_handle();
-//         handle.send_evaluate_js("console.warn('watch out')".to_string());
-// 
-//         let app = build_router(handle);
-//         let req = axum::http::Request::builder()
-//             .method("GET")
-//             .uri("/console")
-//             .body(axum::body::Body::empty())
-//             .unwrap();
-//         let resp = app.oneshot(req).await.unwrap();
-//         assert_eq!(resp.status(), StatusCode::OK);
-//         let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
-//         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-//         let entries = json.as_array().unwrap();
-//         assert_eq!(entries.len(), 1);
-//         assert_eq!(entries[0]["level"], "warn");
-//         assert_eq!(entries[0]["message"], "watch out");
-//     }
+    //     #[tokio::test]
+    //     async fn test_http_console_returns_entries() {
+    //         let handle = make_test_handle();
+    //         handle.send_evaluate_js("console.warn('watch out')".to_string());
+    //
+    //         let app = build_router(handle);
+    //         let req = axum::http::Request::builder()
+    //             .method("GET")
+    //             .uri("/console")
+    //             .body(axum::body::Body::empty())
+    //             .unwrap();
+    //         let resp = app.oneshot(req).await.unwrap();
+    //         assert_eq!(resp.status(), StatusCode::OK);
+    //         let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    //         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    //         let entries = json.as_array().unwrap();
+    //         assert_eq!(entries.len(), 1);
+    //         assert_eq!(entries[0]["level"], "warn");
+    //         assert_eq!(entries[0]["message"], "watch out");
+    //     }
 
-//     #[tokio::test]
-//     async fn test_http_console_eval_returns_result() {
-//         let handle = make_test_handle();
-//         let app = build_router(handle);
-//         let req = axum::http::Request::builder()
-//             .method("POST")
-//             .uri("/console/eval")
-//             .header(axum::http::header::CONTENT_TYPE, "application/json")
-//             .body(axum::body::Body::from(r#"{"code":"1+1"}"#))
-//             .unwrap();
-//         let resp = app.oneshot(req).await.unwrap();
-//         assert_eq!(resp.status(), StatusCode::OK);
-//         let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
-//         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-//         assert_eq!(json["result"], "2");
-//         assert!(json["error"].is_null());
-//     }
+    //     #[tokio::test]
+    //     async fn test_http_console_eval_returns_result() {
+    //         let handle = make_test_handle();
+    //         let app = build_router(handle);
+    //         let req = axum::http::Request::builder()
+    //             .method("POST")
+    //             .uri("/console/eval")
+    //             .header(axum::http::header::CONTENT_TYPE, "application/json")
+    //             .body(axum::body::Body::from(r#"{"code":"1+1"}"#))
+    //             .unwrap();
+    //         let resp = app.oneshot(req).await.unwrap();
+    //         assert_eq!(resp.status(), StatusCode::OK);
+    //         let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    //         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    //         assert_eq!(json["result"], "2");
+    //         assert!(json["error"].is_null());
+    //     }
 
-//     #[tokio::test]
-//     async fn test_http_console_eval_returns_error() {
-//         let handle = make_test_handle();
-//         let app = build_router(handle);
-//         let req = axum::http::Request::builder()
-//             .method("POST")
-//             .uri("/console/eval")
-//             .header(axum::http::header::CONTENT_TYPE, "application/json")
-//             .body(axum::body::Body::from(r#"{"code":"missingVariable"}"#))
-//             .unwrap();
-//         let resp = app.oneshot(req).await.unwrap();
-//         assert_eq!(resp.status(), StatusCode::OK);
-//         let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
-//         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-//         assert!(json["result"].is_null());
-//         assert!(json["error"].is_string());
-//     }
+    //     #[tokio::test]
+    //     async fn test_http_console_eval_returns_error() {
+    //         let handle = make_test_handle();
+    //         let app = build_router(handle);
+    //         let req = axum::http::Request::builder()
+    //             .method("POST")
+    //             .uri("/console/eval")
+    //             .header(axum::http::header::CONTENT_TYPE, "application/json")
+    //             .body(axum::body::Body::from(r#"{"code":"missingVariable"}"#))
+    //             .unwrap();
+    //         let resp = app.oneshot(req).await.unwrap();
+    //         assert_eq!(resp.status(), StatusCode::OK);
+    //         let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    //         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    //         assert!(json["result"].is_null());
+    //         assert!(json["error"].is_string());
+    //     }
 
     #[tokio::test]
     async fn test_http_dom_empty() {
@@ -1375,7 +1507,9 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(json.as_object().unwrap().is_empty());
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -934,6 +934,17 @@ impl BrowserEngine {
         self.last_page = Some(page.clone());
         self.init_js_for_page(&page);
 
+        // Drain macro-tasks and requestAnimationFrame callbacks that scripts
+        // (e.g. React 18) registered during init_js_for_page.  Without this
+        // the RAF queue is never flushed before we read the live DOM, so SPA
+        // frameworks that rely on rAF for their first render produce an empty
+        // body.  Cap at 10 ticks to avoid infinite render-loop drain.
+        for _ in 0..10 {
+            if !self.tick_js(Some(0.0), None) {
+                break;
+            }
+        }
+
         // After JS runs and may have modified the DOM (e.g. React/Vue rendering
         // into #root), serialize the live DOM and re-render using post-JS HTML.
         let js_modified = if let Some(live_html) = self.js_runtime.get_document_html() {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,7 @@
 use markup5ever_rcdom;
 use rayon::prelude::*;
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use url::Url;
 
 use crate::{css, dom, js, layout, render, style};
@@ -61,6 +61,25 @@ pub enum ClickResult {
     /// No interactive element at the given position.
     Nothing,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EngineRequestError {
+    Busy,
+    Disconnected,
+    Failed(String),
+}
+
+impl std::fmt::Display for EngineRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EngineRequestError::Busy => write!(f, "engine busy"),
+            EngineRequestError::Disconnected => write!(f, "engine disconnected"),
+            EngineRequestError::Failed(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for EngineRequestError {}
 
 // ── HTTP API response types ───────────────────────────────────────────────────
 
@@ -825,6 +844,15 @@ pub fn process_html_with_cache(
     ))
 }
 
+fn fetch_text_with_timeout(url: &Url) -> Result<String, reqwest::Error> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?
+        .get(url.as_str())
+        .send()?
+        .text()
+}
+
 fn collect_layout_metrics(
     layout_tree: &layout::LayoutBox,
     out: &mut HashMap<String, js::LayoutMetrics>,
@@ -1250,7 +1278,7 @@ impl BrowserEngine {
                 println!("[CSP] Blocked external script execution: {}", url);
                 return None;
             }
-            match reqwest::blocking::get(url.as_str()).and_then(|response| response.text()) {
+            match fetch_text_with_timeout(url) {
                 Ok(source) => Some(source),
                 Err(err) => {
                     println!("[JS] Failed to load external script {}: {}", url, err);
@@ -1338,10 +1366,7 @@ impl BrowserEngine {
                     let outcome = self.load_external_module_with(
                         url.clone(),
                         &page.base_url,
-                        |module_url| {
-                            reqwest::blocking::get(module_url.as_str())
-                                .and_then(|response| response.text())
-                        },
+                        fetch_text_with_timeout,
                     );
                     if let Some(error) = &outcome.error {
                         println!("[JS] Failed to load external module {}: {}", url, error);
@@ -1370,28 +1395,22 @@ impl BrowserEngine {
 
         self.resolve_module_dependencies(&page.base_url, &mut deferred_module_urls);
         if !deferred_module_urls.is_empty() {
-            let eval_result = self
-                .js_runtime
-                .evaluate_module_graph(&deferred_module_urls);
+            let eval_result = self.js_runtime.evaluate_module_graph(&deferred_module_urls);
             if let Err(errors) = eval_result {
-                let failed_urls: Vec<&str> = errors
-                    .iter()
-                    .filter_map(|e| e.split(": ").next())
-                    .collect();
+                let failed_urls: Vec<&str> =
+                    errors.iter().filter_map(|e| e.split(": ").next()).collect();
                 for error in &errors {
                     println!("[JS] Module evaluation error: {error}");
                     js::push_console_entry(js::ConsoleLevel::Error, error.clone());
                 }
                 for (url, node_id) in &deferred_module_targets {
                     if failed_urls.iter().any(|f| url.as_str() == *f) {
-                        self.js_runtime
-                            .trigger_event_on_node_id(*node_id, "error");
+                        self.js_runtime.trigger_event_on_node_id(*node_id, "error");
                     }
                 }
             }
             for (_, node_id) in &deferred_module_targets {
-                self.js_runtime
-                    .trigger_event_on_node_id(*node_id, "load");
+                self.js_runtime.trigger_event_on_node_id(*node_id, "load");
             }
         }
 
@@ -1404,24 +1423,20 @@ impl BrowserEngine {
         if !async_module_urls.is_empty() {
             let eval_result = self.js_runtime.evaluate_module_graph(&async_module_urls);
             if let Err(errors) = eval_result {
-                let failed_urls: Vec<&str> = errors
-                    .iter()
-                    .filter_map(|e| e.split(": ").next())
-                    .collect();
+                let failed_urls: Vec<&str> =
+                    errors.iter().filter_map(|e| e.split(": ").next()).collect();
                 for error in &errors {
                     println!("[JS] Async module evaluation error: {error}");
                     js::push_console_entry(js::ConsoleLevel::Error, error.clone());
                 }
                 for (url, node_id) in &async_module_targets {
                     if failed_urls.iter().any(|f| url.as_str() == *f) {
-                        self.js_runtime
-                            .trigger_event_on_node_id(*node_id, "error");
+                        self.js_runtime.trigger_event_on_node_id(*node_id, "error");
                     }
                 }
             }
             for (_, node_id) in &async_module_targets {
-                self.js_runtime
-                    .trigger_event_on_node_id(*node_id, "load");
+                self.js_runtime.trigger_event_on_node_id(*node_id, "load");
             }
         }
 
@@ -1488,10 +1503,7 @@ impl BrowserEngine {
                     let outcome = self.load_external_module_with(
                         resolved.clone(),
                         page_base,
-                        |module_url| {
-                            reqwest::blocking::get(module_url.as_str())
-                                .and_then(|response| response.text())
-                        },
+                        fetch_text_with_timeout,
                     );
                     if outcome.error.is_none() {
                         root_urls.push(resolved);
@@ -1731,6 +1743,16 @@ pub struct EngineHandle {
     pub console_buffer: js::ConsoleBuffer,
 }
 
+const ENGINE_CONTROL_TIMEOUT: Duration = Duration::from_secs(3);
+
+fn recv_control<T>(reply_rx: mpsc::Receiver<T>) -> Result<T, EngineRequestError> {
+    match reply_rx.recv_timeout(ENGINE_CONTROL_TIMEOUT) {
+        Ok(value) => Ok(value),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(EngineRequestError::Busy),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(EngineRequestError::Disconnected),
+    }
+}
+
 impl EngineHandle {
     /// Create a new engine actor and return a handle to it.
     pub fn spawn() -> Self {
@@ -1782,10 +1804,36 @@ impl EngineHandle {
             .map_err(|_| "engine disconnected".to_string())?
     }
 
+    pub fn send_re_render_control(
+        &self,
+        hovered_id: Option<String>,
+        focused_id: Option<String>,
+        width: f32,
+    ) -> Result<PageResult, EngineRequestError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(EngineCmd::ReRender {
+                hovered_id,
+                focused_id,
+                width,
+                reply: reply_tx,
+            })
+            .map_err(|_| EngineRequestError::Disconnected)?;
+        recv_control(reply_rx)?.map_err(EngineRequestError::Failed)
+    }
+
     pub fn send_get_page(&self) -> Option<ApiPageResponse> {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.tx.send(EngineCmd::GetPage { reply: reply_tx }).ok()?;
         reply_rx.recv().ok()?
+    }
+
+    pub fn send_get_page_control(&self) -> Result<Option<ApiPageResponse>, EngineRequestError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(EngineCmd::GetPage { reply: reply_tx })
+            .map_err(|_| EngineRequestError::Disconnected)?;
+        recv_control(reply_rx)
     }
 
     pub fn send_get_console(&self) -> Vec<js::ConsoleEntry> {
@@ -1869,6 +1917,14 @@ impl EngineHandle {
         reply_rx.recv().ok()?
     }
 
+    pub fn send_screenshot_control(&self) -> Result<Option<Vec<u8>>, EngineRequestError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(EngineCmd::Screenshot { reply: reply_tx })
+            .map_err(|_| EngineRequestError::Disconnected)?;
+        recv_control(reply_rx)
+    }
+
     pub fn send_dom_tree(&self) -> String {
         let (reply_tx, reply_rx) = mpsc::channel();
         if self
@@ -1922,6 +1978,22 @@ impl EngineHandle {
             return false;
         }
         reply_rx.recv().unwrap_or(false)
+    }
+
+    pub fn send_tick_control(
+        &self,
+        timestamp: f64,
+        deadline: Option<f64>,
+    ) -> Result<bool, EngineRequestError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(EngineCmd::Tick {
+                timestamp,
+                deadline,
+                reply: reply_tx,
+            })
+            .map_err(|_| EngineRequestError::Disconnected)?;
+        recv_control(reply_rx)
     }
 
     pub fn send_submit(&self) -> Option<String> {
@@ -2819,7 +2891,8 @@ mod tests {
             "y"
         );
         assert_eq!(
-            engine.js_style_overrides
+            engine
+                .js_style_overrides
                 .get("c")
                 .and_then(|p| p.get("font-size").cloned()),
             Some("20px".to_string())

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -933,7 +933,25 @@ impl BrowserEngine {
         self.current_csp_policy = page.csp_policy.clone();
         self.last_page = Some(page.clone());
         self.init_js_for_page(&page);
-        self.refresh_after_image_loads(page, width)
+
+        // After JS runs and may have modified the DOM (e.g. React/Vue rendering
+        // into #root), serialize the live DOM and re-render using post-JS HTML.
+        let js_modified = if let Some(live_html) = self.js_runtime.get_document_html() {
+            if let Some(ref mut last) = self.last_page {
+                last.body = live_html;
+            }
+            true
+        } else {
+            false
+        };
+
+        // If JS modified the DOM or images need loading, force a re-render.
+        let post_js_page = if js_modified || self.cache_missing_images(&page.image_urls) {
+            self.re_render(None, None, width)?
+        } else {
+            page
+        };
+        Ok(post_js_page)
     }
 
     /// Re-render the current page (e.g. after JS style changes or hover state).
@@ -1303,7 +1321,9 @@ impl BrowserEngine {
                     if is_defer {
                         deferred_classics.push(source);
                     } else {
+                        eprintln!("[JS DEBUG] Executing inline classic script (len={})", source.len());
                         self.js_runtime.execute(&source);
+                        eprintln!("[JS DEBUG] Inline classic script finished");
                     }
                 }
                 js::ScriptSource::ExternalClassic {
@@ -1311,7 +1331,9 @@ impl BrowserEngine {
                     is_async,
                     is_defer,
                 } => {
+                    eprintln!("[JS DEBUG] Fetching external classic script: {}", url);
                     let source = fetch_classic_source(self, &url);
+                    eprintln!("[JS DEBUG] External classic script fetch returned");
                     if let Some(source) = source {
                         if is_async {
                             // async wins over defer per HTML spec
@@ -1319,7 +1341,9 @@ impl BrowserEngine {
                         } else if is_defer {
                             deferred_classics.push(source);
                         } else {
+                            eprintln!("[JS DEBUG] Executing external classic script: {}", url);
                             self.js_runtime.execute(&source);
+                            eprintln!("[JS DEBUG] External classic script finished: {}", url);
                         }
                     }
                 }
@@ -1338,7 +1362,9 @@ impl BrowserEngine {
                         println!("[CSP] Blocked inline module compilation: {}", url);
                         continue;
                     }
+                    eprintln!("[JS DEBUG] Compiling inline module: {}", url);
                     let outcome = self.js_runtime.compile_module_source(url.clone(), source);
+                    eprintln!("[JS DEBUG] Inline module compiled");
                     if outcome.error.is_some() {
                         let error = outcome.error.as_deref().unwrap_or("unknown");
                         println!("[JS] Failed to compile inline module {}: {}", url, error);
@@ -1363,11 +1389,13 @@ impl BrowserEngine {
                     node_id,
                     is_async,
                 } => {
+                    eprintln!("[JS DEBUG] Loading external module: {}", url);
                     let outcome = self.load_external_module_with(
                         url.clone(),
                         &page.base_url,
                         fetch_text_with_timeout,
                     );
+                    eprintln!("[JS DEBUG] External module loaded");
                     if let Some(error) = &outcome.error {
                         println!("[JS] Failed to load external module {}: {}", url, error);
                         js::push_console_entry(
@@ -1389,13 +1417,20 @@ impl BrowserEngine {
         }
 
         // ── Phase 2: execute deferred classics, then evaluate deferred modules ──
-        for script in &deferred_classics {
+        for (idx, script) in deferred_classics.iter().enumerate() {
+            let preview = if script.len() > 200 { &script[..200] } else { script };
+            eprintln!("[JS DEBUG] Executing deferred classic script #{} (len={}, preview={})", idx, script.len(), preview);
             self.js_runtime.execute(script);
+            eprintln!("[JS DEBUG] Deferred classic script #{} finished", idx);
         }
 
+        eprintln!("[JS DEBUG] Resolving deferred module dependencies");
         self.resolve_module_dependencies(&page.base_url, &mut deferred_module_urls);
+        eprintln!("[JS DEBUG] Deferred module dependencies resolved");
         if !deferred_module_urls.is_empty() {
+            eprintln!("[JS DEBUG] Evaluating deferred module graph (count={})", deferred_module_urls.len());
             let eval_result = self.js_runtime.evaluate_module_graph(&deferred_module_urls);
+            eprintln!("[JS DEBUG] Deferred module graph evaluation finished");
             if let Err(errors) = eval_result {
                 let failed_urls: Vec<&str> =
                     errors.iter().filter_map(|e| e.split(": ").next()).collect();
@@ -1415,13 +1450,19 @@ impl BrowserEngine {
         }
 
         // ── Phase 3: execute async classics, then evaluate async modules ──
-        for script in &async_classics {
+        for (idx, script) in async_classics.iter().enumerate() {
+            eprintln!("[JS DEBUG] Executing async classic script #{}", idx);
             self.js_runtime.execute(script);
+            eprintln!("[JS DEBUG] Async classic script #{} finished", idx);
         }
 
+        eprintln!("[JS DEBUG] Resolving async module dependencies");
         self.resolve_module_dependencies(&page.base_url, &mut async_module_urls);
+        eprintln!("[JS DEBUG] Async module dependencies resolved");
         if !async_module_urls.is_empty() {
+            eprintln!("[JS DEBUG] Evaluating async module graph (count={})", async_module_urls.len());
             let eval_result = self.js_runtime.evaluate_module_graph(&async_module_urls);
+            eprintln!("[JS DEBUG] Async module graph evaluation finished");
             if let Err(errors) = eval_result {
                 let failed_urls: Vec<&str> =
                     errors.iter().filter_map(|e| e.split(": ").next()).collect();

--- a/src/js.rs
+++ b/src/js.rs
@@ -108,14 +108,17 @@ fn host_import_module_dynamically<'s, 'i>(
     _import_attributes: v8::Local<'s, v8::FixedArray>,
 ) -> Option<v8::Local<'s, v8::Promise>> {
     let spec_str = specifier.to_rust_string_lossy(scope);
+    eprintln!("[JS DEBUG] host_import_module_dynamically called for specifier: {}", spec_str);
 
     let resolver = v8::PromiseResolver::new(scope)?;
     let promise = resolver.get_promise(scope);
 
-    let reject = |msg: &str| {
-        let err = v8::String::new(scope, msg).unwrap();
-        resolver.reject(scope, err.into());
-    };
+    macro_rules! reject {
+        ($scope:expr, $msg:expr) => {{
+            let err = v8::String::new($scope, $msg).unwrap();
+            resolver.reject($scope, err.into());
+        }};
+    }
 
     let resolved_url = CURRENT_ORIGIN.with(|origin| {
         origin
@@ -128,7 +131,7 @@ fn host_import_module_dynamically<'s, 'i>(
     let resolved_str = match resolved_url {
         Some(url) => url,
         None => {
-            reject(&format!("Failed to resolve module specifier: {spec_str}"));
+            reject!(scope, &format!("Failed to resolve module specifier: {spec_str}"));
             return Some(promise);
         }
     };
@@ -146,67 +149,36 @@ fn host_import_module_dynamically<'s, 'i>(
     });
 
     if !allowed {
-        reject("CSP blocked dynamic import");
+        reject!(scope, "CSP blocked dynamic import");
         return Some(promise);
     }
 
-    let source = MODULE_SOURCES.with(|map| map.borrow().get(&resolved_str).cloned());
-
-    let source = match source {
-        Some(s) => s,
-        None => match fetch_module_source_with_timeout(&resolved_str) {
-            Ok(s) => s,
-            Err(e) => {
-                reject(&format!("Failed to fetch module: {e}"));
-                return Some(promise);
-            }
-        },
-    };
-
-    MODULE_SOURCES.with(|map| {
-        map.borrow_mut()
-            .insert(resolved_str.clone(), source.clone());
-    });
-
-    let code = v8::String::new(scope, &source)?;
-    let resource = v8::String::new(scope, &resolved_str)?;
-    let origin = v8::ScriptOrigin::new(
-        scope,
-        resource.into(),
-        0,
-        0,
-        false,
-        0,
-        None,
-        false,
-        false,
-        true,
-        None,
-    );
-    let mut source_compiler = v8::script_compiler::Source::new(code, Some(&origin));
-
-    let module = match v8::script_compiler::compile_module(scope, &mut source_compiler) {
-        Some(m) => m,
-        None => {
-            reject("Module compilation failed");
+    let resolved_url_parsed = match Url::parse(&resolved_str) {
+        Ok(u) => u,
+        Err(_) => {
+            reject!(scope, &format!("Failed to parse resolved URL: {resolved_str}"));
             return Some(promise);
         }
     };
+    if let Err(e) = resolve_and_fetch_module_dependencies_rec(scope, &resolved_url_parsed) {
+        reject!(scope, &e);
+        return Some(promise);
+    }
 
-    MODULE_ID_TO_URL.with(|map| {
-        map.borrow_mut()
-            .insert(module.get_identity_hash(), resolved_str.clone());
-    });
-    RESOLVED_MODULES.with(|map| {
-        map.borrow_mut()
-            .insert(resolved_str.clone(), v8::Global::new(scope, module));
-    });
+    let global_module = RESOLVED_MODULES.with(|map| map.borrow().get(&resolved_str).cloned());
+    let module = match global_module {
+        Some(m) => v8::Local::new(scope, m),
+        None => {
+            reject!(scope, "Module not found in resolved cache");
+            return Some(promise);
+        }
+    };
 
     let instantiate_ok = module
         .instantiate_module(scope, resolve_module_callback)
         .unwrap_or(false);
     if !instantiate_ok {
-        reject("Module instantiation failed");
+        reject!(scope, "Module instantiation failed");
         return Some(promise);
     }
 
@@ -221,7 +193,7 @@ fn host_import_module_dynamically<'s, 'i>(
         } else {
             "Module evaluation failed".to_string()
         };
-        reject(&err_msg);
+        reject!(scope, &err_msg);
         return Some(promise);
     }
 
@@ -238,6 +210,168 @@ fn fetch_module_source_with_timeout(url: &str) -> Result<String, reqwest::Error>
         .get(url)
         .send()?
         .text()
+}
+
+fn resolve_and_fetch_module_dependencies_rec(
+    scope: &mut v8::PinScope,
+    root_url: &Url,
+) -> Result<(), String> {
+    let mut queue = vec![root_url.clone()];
+    let mut visited = std::collections::HashSet::new();
+    visited.insert(root_url.clone());
+
+    while let Some(current_url) = queue.pop() {
+        eprintln!("[JS DEBUG] processing dependency: {} (queue len: {})", current_url, queue.len());
+        let source = MODULE_SOURCES.with(|map| map.borrow().get(current_url.as_str()).cloned());
+        let source = match source {
+            Some(s) => s,
+            None => {
+                match fetch_module_source_with_timeout(current_url.as_str()) {
+                    Ok(s) => {
+                        MODULE_SOURCES.with(|map| {
+                            map.borrow_mut().insert(current_url.to_string(), s.clone());
+                        });
+                        s
+                    }
+                    Err(e) => return Err(format!("Failed to fetch module {current_url}: {e}")),
+                }
+            }
+        };
+
+        let is_cached = RESOLVED_MODULES.with(|map| map.borrow().contains_key(current_url.as_str()));
+        let module = if is_cached {
+            let global_mod = RESOLVED_MODULES.with(|map| map.borrow().get(current_url.as_str()).cloned()).unwrap();
+            v8::Local::new(scope, global_mod)
+        } else {
+            let tc = std::pin::pin!(v8::TryCatch::new(scope));
+            let tc = &mut tc.init();
+            let code = v8::String::new(tc, &source)
+                .ok_or_else(|| "Failed to create V8 module source string".to_string())?;
+            let resource = v8::String::new(tc, current_url.as_str())
+                .ok_or_else(|| "Failed to create V8 module resource name".to_string())?;
+            let origin = v8::ScriptOrigin::new(
+                tc,
+                resource.into(),
+                0,
+                0,
+                false,
+                0,
+                None,
+                false,
+                false,
+                true,
+                None,
+            );
+            let mut source_compiler = v8::script_compiler::Source::new(code, Some(&origin));
+            let module = match v8::script_compiler::compile_module(tc, &mut source_compiler) {
+                Some(m) => m,
+                None => {
+                    let err_msg = tc
+                        .exception()
+                        .and_then(|e| e.to_string(tc))
+                        .map(|s| s.to_rust_string_lossy(tc))
+                        .unwrap_or_else(|| "Unknown compilation error".to_string());
+                    return Err(format!("Failed to compile module {current_url}: {err_msg}"));
+                }
+            };
+
+            MODULE_ID_TO_URL.with(|map| {
+                map.borrow_mut()
+                    .insert(module.get_identity_hash(), current_url.to_string());
+            });
+            RESOLVED_MODULES.with(|map| {
+                map.borrow_mut()
+                    .insert(current_url.to_string(), v8::Global::new(tc, module));
+            });
+            module
+        };
+
+        let requests = module.get_module_requests();
+        for i in 0..requests.length() {
+            if let Some(data) = requests.get(scope, i) {
+                if let Ok(request) = data.try_cast::<v8::ModuleRequest>() {
+                    let specifier = request.get_specifier().to_rust_string_lossy(scope);
+                    let resolved = match current_url.join(&specifier) {
+                        Ok(u) => u,
+                        Err(_) => return Err(format!("Failed to resolve specifier {specifier} from {current_url}")),
+                    };
+                    if !visited.contains(&resolved) {
+                        visited.insert(resolved.clone());
+                        queue.push(resolved);
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn execute_module_script_in_host_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue<v8::Value>,
+) {
+    let url_str = args.get(0).to_rust_string_lossy(scope);
+    let code_str = args.get(1).to_rust_string_lossy(scope);
+    eprintln!("[JS DEBUG] execute_module_script_in_host_cb called for url: {}", url_str);
+
+    let base_url = CURRENT_ORIGIN.with(|o| (*o.borrow()).clone());
+    let target_url = if let Some(ref base) = base_url {
+        base.join(&url_str)
+            .unwrap_or_else(|_| Url::parse(&url_str).unwrap_or(base.clone()))
+    } else {
+        match Url::parse(&url_str) {
+            Ok(u) => u,
+            Err(_) => {
+                rv.set_bool(false);
+                return;
+            }
+        }
+    };
+
+    MODULE_SOURCES.with(|map| {
+        map.borrow_mut().insert(target_url.to_string(), code_str.clone());
+    });
+
+    if let Err(e) = resolve_and_fetch_module_dependencies_rec(scope, &target_url) {
+        println!("[JS] Failed to resolve module dependencies for {target_url}: {e}");
+        rv.set_bool(false);
+        return;
+    }
+
+    let global_module = RESOLVED_MODULES.with(|map| map.borrow().get(target_url.as_str()).cloned());
+    let module = match global_module {
+        Some(m) => v8::Local::new(scope, m),
+        None => {
+            println!("[JS] Root module not found in resolved cache for {target_url}");
+            rv.set_bool(false);
+            return;
+        }
+    };
+
+    let instantiate_ok = module.instantiate_module(scope, resolve_module_callback).unwrap_or(false);
+    if !instantiate_ok {
+        println!("[JS] Failed to instantiate root module {target_url}");
+        rv.set_bool(false);
+        return;
+    }
+
+    let eval_result = module.evaluate(scope);
+    if eval_result.is_none() || module.get_status() == v8::ModuleStatus::Errored {
+        let err_msg = if module.get_status() == v8::ModuleStatus::Errored {
+            module.get_exception()
+                .to_string(scope)
+                .map(|s| s.to_rust_string_lossy(scope))
+                .unwrap_or_else(|| "Module evaluation error".to_string())
+        } else {
+            "Module evaluation failed".to_string()
+        };
+        println!("[JS] Module evaluation error for {target_url}: {err_msg}");
+        rv.set_bool(false);
+        return;
+    }
+
+    rv.set_bool(true);
 }
 
 fn resolve_module_callback<'s>(
@@ -493,6 +627,38 @@ pub struct ModuleCompileOutcome {
     pub from_cache: bool,
     pub requests: Vec<String>,
     pub error: Option<String>,
+}
+
+extern "C" fn interrupt_callback(mut isolate_ptr: v8::UnsafeRawIsolatePtr, _data: *mut std::ffi::c_void) {
+    let isolate = unsafe { v8::Isolate::ref_from_raw_isolate_ptr_mut(&mut isolate_ptr) };
+    let hs = std::pin::pin!(v8::HandleScope::new(isolate));
+    let hs = &mut hs.init();
+    
+    // Safety: PinnedRef<'_, HandleScope<'_, ()>> and PinnedRef<'_, HandleScope<'_, Context>>
+    // have the identical layout (context type parameter is a zero-sized phantom marker).
+    let hs_context: &mut v8::PinnedRef<'_, v8::HandleScope<'_, v8::Context>> = unsafe {
+        std::mem::transmute(hs)
+    };
+    
+    let context = hs_context.get_current_context();
+    let mut cs = v8::ContextScope::new(hs_context, context);
+    let scope = &mut cs;
+    if let Some(stack) = v8::StackTrace::current_stack_trace(scope, 20) {
+        eprintln!("[JS WATCHDOG INTERRUPT] V8 Call Stack:");
+        for i in 0..stack.get_frame_count() {
+            if let Some(frame) = stack.get_frame(&**scope, i) {
+                let script_name = frame.get_script_name_or_source_url(&**scope)
+                    .map(|s| s.to_rust_string_lossy(&**scope))
+                    .unwrap_or_else(|| "<unknown>".to_string());
+                let function_name = frame.get_function_name(&**scope)
+                    .map(|s| s.to_rust_string_lossy(&**scope))
+                    .unwrap_or_else(|| "<anonymous>".to_string());
+                let line = frame.get_line_number();
+                let col = frame.get_column();
+                eprintln!("  at {} ({}:{}:{})", function_name, script_name, line, col);
+            }
+        }
+    }
 }
 
 impl JsRuntime {
@@ -803,6 +969,15 @@ impl JsRuntime {
         self.execute(&code);
     }
 
+    /// Serialize the live DOM (as modified by JS) back to an HTML string
+    /// so the layout engine can re-render using the post-JS DOM state.
+    pub fn get_document_html(&self) -> Option<String> {
+        DOM_ROOT.with(|root| {
+            root.borrow().as_ref().map(|r| serialize_inner_html(r))
+        })
+    }
+
+
     pub fn execute(&mut self, source: &str) {
         let outcome = self.execute_with_result(source);
         if let Some(error) = outcome.error {
@@ -811,63 +986,117 @@ impl JsRuntime {
     }
 
     pub fn execute_with_result(&mut self, source: &str) -> EvalOutcome {
-        let hs = std::pin::pin!(v8::HandleScope::new(&mut self.isolate));
-        let hs = &mut hs.init();
-        let local_context = v8::Local::new(hs, &self.global_context);
-        let scope = &mut v8::ContextScope::new(hs, local_context);
-
-        let code = match v8::String::new(scope, source) {
-            Some(s) => s,
-            None => {
-                return EvalOutcome {
-                    result: None,
-                    error: Some("Failed to create V8 string".to_string()),
+        // Watchdog: terminate execution if it takes more than 10 seconds.
+        // Also sends periodic interrupts for debugging purposes.
+        let isolate_handle = self.isolate.thread_safe_handle();
+        let done_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done_flag_clone = Arc::clone(&done_flag);
+        let src_preview = source.chars().take(80).collect::<String>().replace('\n', " ");
+        let watchdog = std::thread::spawn(move || {
+            for elapsed in 1..=10u64 {
+                std::thread::sleep(Duration::from_secs(1));
+                if done_flag_clone.load(Ordering::Relaxed) { return; }
+                if elapsed == 3 || elapsed == 6 || elapsed == 9 {
+                    eprintln!("[JS WATCHDOG] Script still running at {}s: {}...", elapsed, src_preview);
+                    isolate_handle.request_interrupt(interrupt_callback, std::ptr::null_mut());
                 }
             }
-        };
-
-        let tc = std::pin::pin!(v8::TryCatch::new(scope));
-        let tc = &mut tc.init();
-
-        match v8::Script::compile(tc, code, None) {
-            None => {
-                let error_msg = tc
-                    .exception()
-                    .and_then(|e| e.to_string(tc))
-                    .map(|s| s.to_rust_string_lossy(tc))
-                    .unwrap_or_else(|| "Unknown compilation error".to_string());
-                EvalOutcome {
-                    result: None,
-                    error: Some(error_msg),
-                }
+            if !done_flag_clone.load(Ordering::Relaxed) {
+                eprintln!("[JS WATCHDOG] Script execution exceeded 10s — terminating V8 execution");
+                isolate_handle.terminate_execution();
             }
-            Some(script) => match script.run(tc) {
+        });
+
+        let outcome = {
+            let hs = std::pin::pin!(v8::HandleScope::new(&mut self.isolate));
+            let hs = &mut hs.init();
+            let local_context = v8::Local::new(hs, &self.global_context);
+            let scope = &mut v8::ContextScope::new(hs, local_context);
+
+            let code = match v8::String::new(scope, source) {
+                Some(s) => s,
+                None => {
+                    done_flag.store(true, Ordering::Relaxed);
+                    drop(watchdog);
+                    return EvalOutcome {
+                        result: None,
+                        error: Some("Failed to create V8 string".to_string()),
+                    };
+                }
+            };
+
+            let tc = std::pin::pin!(v8::TryCatch::new(scope));
+            let tc = &mut tc.init();
+
+            match v8::Script::compile(tc, code, None) {
                 None => {
                     let error_msg = tc
                         .exception()
                         .and_then(|e| e.to_string(tc))
                         .map(|s| s.to_rust_string_lossy(tc))
-                        .unwrap_or_else(|| "Unknown runtime error".to_string());
+                        .unwrap_or_else(|| "Unknown compilation error".to_string());
                     EvalOutcome {
                         result: None,
                         error: Some(error_msg),
                     }
                 }
-                Some(value) => {
-                    let result = if value.is_undefined() {
-                        Some("undefined".to_string())
-                    } else if value.is_null() {
-                        Some("null".to_string())
-                    } else {
-                        value.to_string(tc).map(|s| s.to_rust_string_lossy(tc))
-                    };
-                    EvalOutcome {
-                        result,
-                        error: None,
+                Some(script) => match script.run(tc) {
+                    None => {
+                        let terminated = tc.has_terminated();
+                        let mut error_msg = if terminated {
+                            "[JS WATCHDOG] Script terminated after 10s timeout".to_string()
+                        } else {
+                            tc
+                                .exception()
+                                .and_then(|e| e.to_string(tc))
+                                .map(|s| s.to_rust_string_lossy(tc))
+                                .unwrap_or_else(|| "Unknown runtime error".to_string())
+                        };
+                        if !terminated {
+                            if let Some(stack) = tc.stack_trace() {
+                                let stack_str = stack.to_rust_string_lossy(tc);
+                                error_msg = format!("{}\nStack trace:\n{}", error_msg, stack_str);
+                            }
+                            if let Some(message) = tc.message() {
+                                let resource = message.get_script_resource_name(tc)
+                                    .and_then(|v| v.to_string(tc))
+                                    .map(|s| s.to_rust_string_lossy(tc))
+                                    .unwrap_or_else(|| "unknown".to_string());
+                                let line = message.get_line_number(tc).unwrap_or(0);
+                                let source_line = message.get_source_line(tc)
+                                    .map(|s| s.to_rust_string_lossy(tc))
+                                    .unwrap_or_else(|| "".to_string());
+                                error_msg = format!("{}\nLocation: {}:{}\nSource line: {}", error_msg, resource, line, source_line);
+                            }
+                        }
+                        EvalOutcome {
+                            result: None,
+                            error: Some(error_msg),
+                        }
                     }
-                }
-            },
-        }
+                    Some(value) => {
+                        let result = if value.is_undefined() {
+                            Some("undefined".to_string())
+                        } else if value.is_null() {
+                            Some("null".to_string())
+                        } else {
+                            value.to_string(tc).map(|s| s.to_rust_string_lossy(tc))
+                        };
+                        EvalOutcome {
+                            result,
+                            error: None,
+                        }
+                    }
+                },
+            }
+        }; // Drop all V8 scopes here
+
+        // Signal watchdog to stop and cancel any pending termination.
+        done_flag.store(true, Ordering::Relaxed);
+        // Cancel termination in case watchdog already fired but we finished.
+        self.isolate.cancel_terminate_execution();
+        drop(watchdog); // Let the thread run out naturally.
+        outcome
     }
 
     pub fn resolve_module_specifier(&self, specifier: &str, referrer: &Url) -> Result<Url, String> {
@@ -1458,6 +1687,13 @@ fn register_native_functions(
     register_fn(scope, global, "requestIdleCallback", ric_cb);
     register_fn(scope, global, "cancelIdleCallback", cic_cb);
     register_fn(scope, global, "__aura_submit_form", submit_form_cb);
+    register_fn(
+        scope,
+        global,
+        "__aura_execute_module_script_in_host",
+        execute_module_script_in_host_cb,
+    );
+    register_fn(scope, global, "queueMicrotask", queue_microtask_cb);
 }
 
 fn console_log(
@@ -1838,7 +2074,12 @@ fn get_outer_html_cb(
             .get(&nid)
             .map(|n| {
                 let mut o = String::new();
-                serialize_node(n, &mut o);
+                let parent_tag = get_parent_handle(n).and_then(|p| match &p.data {
+                    NodeData::Element { name, .. } => Some(name.local.to_string()),
+                    _ => None,
+                });
+                let parent_tag_lower = parent_tag.as_ref().map(|t| t.to_ascii_lowercase());
+                serialize_node(n, &mut o, parent_tag_lower.as_deref());
                 o
             })
             .unwrap_or_default()
@@ -2569,6 +2810,17 @@ fn queue_task_cb(
         });
     }
 }
+fn queue_microtask_cb(
+    scope: &mut v8::PinScope,
+    args: v8::FunctionCallbackArguments,
+    _rv: v8::ReturnValue<v8::Value>,
+) {
+    let cb = args.get(0);
+    if cb.is_function() {
+        let cb_func: v8::Local<v8::Function> = unsafe { std::mem::transmute(cb) };
+        scope.enqueue_microtask(cb_func);
+    }
+}
 fn resolve_url_cb(
     scope: &mut v8::PinScope,
     args: v8::FunctionCallbackArguments,
@@ -2985,7 +3237,20 @@ fn console_impl(
         if i > 0 {
             output.push(' ');
         }
-        output.push_str(&args.get(i).to_rust_string_lossy(scope));
+        let val = args.get(i);
+        let mut stringified = val.to_rust_string_lossy(scope);
+        if val.is_object() {
+            if let Some(obj) = val.to_object(scope) {
+                let stack_key = v8::String::new(scope, "stack").unwrap();
+                if let Some(stack_val) = obj.get(scope, stack_key.into()) {
+                    if !stack_val.is_undefined() {
+                        let stack_str = stack_val.to_rust_string_lossy(scope);
+                        stringified = format!("{}\nStack trace:\n{}", stringified, stack_str);
+                    }
+                }
+            }
+        }
+        output.push_str(&stringified);
     }
     push_console_entry(level, output);
 }
@@ -2993,8 +3258,14 @@ fn console_impl(
 pub fn node_path_key(node: &Handle) -> String {
     let mut indices = Vec::new();
     let mut current = node.clone();
+    let mut visited = std::collections::HashSet::new();
 
     loop {
+        let current_ptr = std::rc::Rc::as_ptr(&current) as usize;
+        if !visited.insert(current_ptr) {
+            eprintln!("[JS WARNING] Cycle detected in node_path_key! breaking loop.");
+            break;
+        }
         let parent_weak = current.parent.take();
         let Some(parent_weak) = parent_weak else {
             break;
@@ -3003,7 +3274,6 @@ pub fn node_path_key(node: &Handle) -> String {
             break;
         };
 
-        let current_ptr = std::rc::Rc::as_ptr(&current) as usize;
         let index = parent
             .children
             .borrow()
@@ -3550,6 +3820,16 @@ mod tests {
             outcome.result.as_deref(),
             Some("https://cdn.example.com/lib/module.mjs")
         );
+    }
+
+    #[test]
+    fn test_preload_hang_debug() {
+        let mut rt = make_runtime("<html><body></body></html>");
+        if let Ok(code) = std::fs::read_to_string("/tmp/preload.js") {
+            println!("Starting execution of preload.js");
+            rt.execute(&code);
+            println!("Finished execution of preload.js");
+        }
     }
 
     #[test]
@@ -4239,6 +4519,237 @@ mod tests {
             rt.execute_with_result("document.getElementById('test').ownerDocument === document");
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
+
+    #[test]
+    fn test_html_anchor_element_url_properties() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body><a id="link" href="/foo/bar?baz=1#hash"></a><a id="empty"></a></body></html>"#,
+            "https://example.com/path/page.html",
+        );
+        
+        // 1. Test relative URL resolution (getting properties)
+        let outcome = rt.execute_with_result(
+            r#"JSON.stringify({
+                href: document.getElementById('link').href,
+                protocol: document.getElementById('link').protocol,
+                host: document.getElementById('link').host,
+                hostname: document.getElementById('link').hostname,
+                port: document.getElementById('link').port,
+                pathname: document.getElementById('link').pathname,
+                search: document.getElementById('link').search,
+                hash: document.getElementById('link').hash,
+                origin: document.getElementById('link').origin
+            })"#
+        );
+        assert_eq!(outcome.error, None);
+        println!("RESULT: {:?}", outcome.result);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["href"], "https://example.com/foo/bar?baz=1#hash");
+        assert_eq!(val["protocol"], "https:");
+        assert_eq!(val["host"], "example.com");
+        assert_eq!(val["hostname"], "example.com");
+        assert_eq!(val["port"], "");
+        assert_eq!(val["pathname"], "/foo/bar");
+        assert_eq!(val["search"], "?baz=1");
+        assert_eq!(val["hash"], "#hash");
+        assert_eq!(val["origin"], "https://example.com");
+
+        // 2. Test setter for pathname updates href attribute
+        rt.execute(
+            r#"var a = document.getElementById('link');
+               a.pathname = '/new/path';
+               a.search = '?new=2';
+               a.hash = '#newhash';
+               a.protocol = 'http';"#
+        );
+        let outcome = rt.execute_with_result("document.getElementById('link').href");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("http://example.com/new/path?new=2#newhash"));
+
+        // 3. Test empty anchor (no href attribute)
+        let outcome = rt.execute_with_result(
+            r#"JSON.stringify({
+                href: document.getElementById('empty').href,
+                pathname: document.getElementById('empty').pathname,
+                search: document.getElementById('empty').search,
+                hash: document.getElementById('empty').hash
+            })"#
+        );
+        assert_eq!(outcome.error, None);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["href"], "");
+        assert_eq!(val["pathname"], "");
+        assert_eq!(val["search"], "");
+        assert_eq!(val["hash"], "");
+
+        // 4. Test setting properties on empty anchor creates a valid URL
+        rt.execute(
+            r#"var a = document.getElementById('empty');
+               a.pathname = '/initialized';"#
+        );
+        let outcome = rt.execute_with_result("document.getElementById('empty').href");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("https://example.com/initialized"));
+    }
+
+    #[test]
+    fn test_dom_compatibility_stubs() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body><iframe id="ifr"></iframe></body></html>"#,
+            "https://example.com/",
+        );
+
+        // 1. Verify document.createElementNS and iframe contentDocument.createElementNS exist and return an element
+        let outcome = rt.execute_with_result(
+            r#"var el1 = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+               var ifr = document.getElementById('ifr');
+               var el2 = ifr.contentDocument.createElementNS('http://www.w3.org/2000/svg', 'path');
+               JSON.stringify({
+                   el1: el1 !== null && el1.tagName === 'SVG',
+                   el2: el2 !== null && el2.tagName === 'PATH'
+               })"#
+        );
+        assert_eq!(outcome.error, None);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["el1"], true);
+        assert_eq!(val["el2"], true);
+
+        // 2. Verify window.postMessage and contentWindow.postMessage exist
+        let outcome = rt.execute_with_result(
+            r#"JSON.stringify({
+                win_pm: typeof window.postMessage === 'function',
+                ifr_pm: typeof document.getElementById('ifr').contentWindow.postMessage === 'function'
+            })"#
+        );
+        assert_eq!(outcome.error, None);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["win_pm"], true);
+        assert_eq!(val["ifr_pm"], true);
+
+        // 3. Verify contentWindow is an EventTarget and supports addEventListener + asynchronous postMessage dispatching
+        rt.execute(
+            r#"var win = document.getElementById('ifr').contentWindow;
+               win.addEventListener('message', function(e) {
+                   window.__messageData = e.data;
+                   window.__messageOrigin = e.origin;
+               });
+               win.postMessage('hello', '*');"#
+        );
+
+        // Run the event loop (which runs setTimeouts / queued tasks)
+        rt.tick(Some(0.0), None);
+
+        let outcome = rt.execute_with_result(
+            r#"JSON.stringify({
+                data: window.__messageData,
+                origin: window.__messageOrigin
+            })"#
+        );
+        assert_eq!(outcome.error, None);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["data"], "hello");
+        assert_eq!(val["origin"], "*");
+
+        // 4. Verify global window postMessage works similarly
+        rt.execute(
+            r#"window.addEventListener('message', function(e) {
+                   window.__globalMessage = e.data;
+               });
+               window.postMessage('global-hello', '*');"#
+        );
+
+        rt.tick(Some(0.0), None);
+
+        let outcome = rt.execute_with_result("window.__globalMessage");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("global-hello"));
+    }
+
+    #[test]
+    fn test_raw_text_element_serialization() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body><script id="json">{"test": true}</script><div id="escaped">"hello"</div></body></html>"#,
+            "https://example.com/",
+        );
+
+        // 1. Verify that script element's innerHTML returns raw text without escaping quotes
+        let outcome = rt.execute_with_result("document.getElementById('json').innerHTML");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some(r#"{"test": true}"#));
+
+        // 2. Verify that div element's innerHTML returns properly escaped quotes
+        let outcome = rt.execute_with_result("document.getElementById('escaped').innerHTML");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("&quot;hello&quot;"));
+
+        // 3. Verify JSON.parse works on script innerHTML
+        let outcome = rt.execute_with_result("JSON.parse(document.getElementById('json').innerHTML).test");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+        
+        // 4. Verify script outerHTML has raw script contents but escaped attributes
+        let outcome = rt.execute_with_result("document.getElementById('json').outerHTML");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some(r#"<script id="json">{"test": true}</script>"#));
+    }
+
+    #[test]
+    fn test_document_current_script_and_attribute_stubs() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body><script id="first"></script><script id="second"></script></body></html>"#,
+            "https://example.com/",
+        );
+
+        // 1. Verify document.currentScript returns the last script element
+        let outcome = rt.execute_with_result("document.currentScript.id");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("second"));
+
+        // 2. Verify document.getAttribute, setAttribute, hasAttribute, removeAttribute exist and return safe defaults
+        let outcome = rt.execute_with_result(
+            r#"JSON.stringify({
+                has: document.hasAttribute('class'),
+                get: document.getAttribute('class'),
+                set: typeof document.setAttribute === 'function',
+                remove: typeof document.removeAttribute === 'function'
+            })"#
+        );
+        assert_eq!(outcome.error, None);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["has"], false);
+        assert_eq!(val["get"], serde_json::Value::Null);
+        assert_eq!(val["set"], true);
+        assert_eq!(val["remove"], true);
+    }
+
+    #[test]
+    fn test_node_prototype_compatibility_stubs() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body>hello</body></html>"#,
+            "https://example.com/",
+        );
+
+        // 1. Get a TextNode and verify element-like methods exist and return safe defaults
+        let outcome = rt.execute_with_result(
+            r#"var textNode = document.body.firstChild;
+               JSON.stringify({
+                   get: textNode.getAttribute('class'),
+                   has: textNode.hasAttribute('class'),
+                   closest: textNode.closest('div'),
+                   matches: textNode.matches('div'),
+                   querySelector: textNode.querySelector('div'),
+                   querySelectorAll: textNode.querySelectorAll('div') !== null && textNode.querySelectorAll('div').length === 0
+               })"#
+        );
+        assert_eq!(outcome.error, None);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["get"], serde_json::Value::Null);
+        assert_eq!(val["has"], false);
+        assert_eq!(val["closest"], serde_json::Value::Null);
+        assert_eq!(val["matches"], false);
+        assert_eq!(val["querySelector"], serde_json::Value::Null);
+        assert_eq!(val["querySelectorAll"], true);
+    }
 }
 
 // ── DOM Helper Functions ──────────────────────────────────────────────────────
@@ -4466,13 +4977,18 @@ fn steal_fragment_children(doc: &Handle) -> Vec<Handle> {
 
 fn serialize_inner_html(node: &Handle) -> String {
     let mut out = String::new();
+    let parent_tag = match &node.data {
+        NodeData::Element { ref name, .. } => Some(name.local.to_string()),
+        _ => None,
+    };
+    let parent_tag_lower = parent_tag.as_ref().map(|t| t.to_ascii_lowercase());
     for child in node.children.borrow().iter() {
-        serialize_node(child, &mut out);
+        serialize_node(child, &mut out, parent_tag_lower.as_deref());
     }
     out
 }
 
-fn serialize_node(node: &Handle, out: &mut String) {
+fn serialize_node(node: &Handle, out: &mut String, parent_tag: Option<&str>) {
     match &node.data {
         NodeData::Element {
             ref name,
@@ -4490,14 +5006,28 @@ fn serialize_node(node: &Handle, out: &mut String) {
                 out.push('"');
             }
             out.push('>');
+            let tag_lower = tag.to_ascii_lowercase();
             for child in node.children.borrow().iter() {
-                serialize_node(child, out);
+                serialize_node(child, out, Some(&tag_lower));
             }
             out.push_str("</");
             out.push_str(&tag);
             out.push('>');
         }
         NodeData::Text { ref contents } => {
+            if let Some(p) = parent_tag {
+                if p == "script"
+                    || p == "style"
+                    || p == "iframe"
+                    || p == "xmp"
+                    || p == "noembed"
+                    || p == "noframes"
+                    || p == "plaintext"
+                {
+                    out.push_str(&contents.borrow());
+                    return;
+                }
+            }
             out.push_str(&html_escape(&contents.borrow()));
         }
         NodeData::Comment { ref contents } => {
@@ -4526,7 +5056,7 @@ fn serialize_node(node: &Handle, out: &mut String) {
         }
         NodeData::Document => {
             for child in node.children.borrow().iter() {
-                serialize_node(child, out);
+                serialize_node(child, out, parent_tag);
             }
         }
         _ => {}

--- a/src/js.rs
+++ b/src/js.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use url::Url;
 use v8;
 
@@ -137,8 +137,8 @@ fn host_import_module_dynamically<'s, 'i>(
         p.borrow()
             .as_ref()
             .map(|pol| {
-                let url =
-                    Url::parse(&resolved_str).unwrap_or_else(|_| Url::parse("about:blank").unwrap());
+                let url = Url::parse(&resolved_str)
+                    .unwrap_or_else(|_| Url::parse("about:blank").unwrap());
                 let base = CURRENT_ORIGIN.with(|o| o.borrow().clone());
                 pol.is_allowed("script-src", &url, base.as_ref())
             })
@@ -150,12 +150,11 @@ fn host_import_module_dynamically<'s, 'i>(
         return Some(promise);
     }
 
-    let source =
-        MODULE_SOURCES.with(|map| map.borrow().get(&resolved_str).cloned());
+    let source = MODULE_SOURCES.with(|map| map.borrow().get(&resolved_str).cloned());
 
     let source = match source {
         Some(s) => s,
-        None => match reqwest::blocking::get(&resolved_str).and_then(|r| r.text()) {
+        None => match fetch_module_source_with_timeout(&resolved_str) {
             Ok(s) => s,
             Err(e) => {
                 reject(&format!("Failed to fetch module: {e}"));
@@ -186,14 +185,13 @@ fn host_import_module_dynamically<'s, 'i>(
     );
     let mut source_compiler = v8::script_compiler::Source::new(code, Some(&origin));
 
-    let module =
-        match v8::script_compiler::compile_module(scope, &mut source_compiler) {
-            Some(m) => m,
-            None => {
-                reject("Module compilation failed");
-                return Some(promise);
-            }
-        };
+    let module = match v8::script_compiler::compile_module(scope, &mut source_compiler) {
+        Some(m) => m,
+        None => {
+            reject("Module compilation failed");
+            return Some(promise);
+        }
+    };
 
     MODULE_ID_TO_URL.with(|map| {
         map.borrow_mut()
@@ -233,6 +231,15 @@ fn host_import_module_dynamically<'s, 'i>(
     Some(promise)
 }
 
+fn fetch_module_source_with_timeout(url: &str) -> Result<String, reqwest::Error> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?
+        .get(url)
+        .send()?
+        .text()
+}
+
 fn resolve_module_callback<'s>(
     context: v8::Local<'s, v8::Context>,
     specifier: v8::Local<'s, v8::String>,
@@ -258,9 +265,7 @@ fn resolve_module_callback<'s>(
     let source = MODULE_SOURCES.with(|map| map.borrow().get(&resolved_url).cloned())?;
 
     // Return cached module if already resolved (handles cyclic imports)
-    if let Some(cached) = RESOLVED_MODULES
-        .with(|map| map.borrow().get(&resolved_url).cloned())
-    {
+    if let Some(cached) = RESOLVED_MODULES.with(|map| map.borrow().get(&resolved_url).cloned()) {
         return Some(v8::Local::new(scope, &cached));
     }
 
@@ -600,13 +605,17 @@ impl JsRuntime {
     }
 
     pub fn tick(&mut self, timestamp: Option<f64>, deadline_ms: Option<f64>) -> bool {
+        const MAX_TASKS_PER_TICK: usize = 32;
         let mut did_work = false;
         if self.sync_focus() {
             did_work = true;
         }
 
-        while let Ok(task) = self.task_receiver.try_recv() {
-            MACRO_TASKS.with(|tasks| tasks.borrow_mut().push_back(task));
+        for _ in 0..MAX_TASKS_PER_TICK {
+            match self.task_receiver.try_recv() {
+                Ok(task) => MACRO_TASKS.with(|tasks| tasks.borrow_mut().push_back(task)),
+                Err(_) => break,
+            }
         }
 
         let macro_task = MACRO_TASKS.with(|tasks| tasks.borrow_mut().pop_front());
@@ -620,7 +629,11 @@ impl JsRuntime {
 
         if let Some(ts) = timestamp {
             let mut tasks = VecDeque::new();
-            RAF_TASKS.with(|t| tasks = t.borrow_mut().drain(..).collect());
+            RAF_TASKS.with(|t| {
+                let mut queue = t.borrow_mut();
+                let count = queue.len().min(MAX_TASKS_PER_TICK);
+                tasks = queue.drain(..count).collect();
+            });
             if !tasks.is_empty() {
                 did_work = true;
                 for task in tasks {
@@ -652,9 +665,11 @@ impl JsRuntime {
             }
         }
 
-        while let Some((callback, payload, is_resolve)) =
-            FETCH_PENDING.with(|p| p.borrow_mut().pop_front())
-        {
+        for _ in 0..MAX_TASKS_PER_TICK {
+            let pending = FETCH_PENDING.with(|p| p.borrow_mut().pop_front());
+            let Some((callback, payload, is_resolve)) = pending else {
+                break;
+            };
             did_work = true;
             self.call_with_payload(callback, &payload, is_resolve);
             self.run_microtasks();
@@ -664,8 +679,12 @@ impl JsRuntime {
     }
 
     fn run_pending_callbacks(&mut self) {
-        let pending: Vec<(v8::Global<v8::Function>, Option<f64>)> =
-            RUN_PENDING.with(|p| p.borrow_mut().drain(..).collect());
+        const MAX_PENDING_CALLBACKS_PER_DRAIN: usize = 64;
+        let pending: Vec<(v8::Global<v8::Function>, Option<f64>)> = RUN_PENDING.with(|p| {
+            let mut pending = p.borrow_mut();
+            let count = pending.len().min(MAX_PENDING_CALLBACKS_PER_DRAIN);
+            pending.drain(..count).collect()
+        });
         if pending.is_empty() {
             return;
         }
@@ -714,11 +733,21 @@ impl JsRuntime {
     }
 
     fn run_microtasks(&mut self) {
+        const MAX_MICROTASKS_PER_DRAIN: usize = 128;
+        let mut iterations = 0;
         loop {
             let mut micro_work_done = false;
             while let Some(task) = MICRO_TASKS.with(|tasks| tasks.borrow_mut().pop_front()) {
+                if iterations >= MAX_MICROTASKS_PER_DRAIN {
+                    push_console_entry(
+                        ConsoleLevel::Warn,
+                        "JS microtask drain limit reached; remaining tasks deferred".to_string(),
+                    );
+                    return;
+                }
                 task();
                 micro_work_done = true;
+                iterations += 1;
             }
             let hs = std::pin::pin!(v8::HandleScope::new(&mut self.isolate));
             let hs = &mut hs.init();
@@ -1013,7 +1042,11 @@ impl JsRuntime {
         MODULE_ID_TO_URL.with(|map| map.borrow_mut().clear());
         RESOLVED_MODULES.with(|map| map.borrow_mut().clear());
 
-        if errors.is_empty() { Ok(()) } else { Err(errors) }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 
     pub fn evaluate_module_graph(&mut self, root_urls: &[Url]) -> Result<(), Vec<String>> {
@@ -1122,9 +1155,7 @@ impl JsRuntime {
             }
 
             let evaluate_result = module.evaluate(tc);
-            if evaluate_result.is_none()
-                || module.get_status() == v8::ModuleStatus::Errored
-            {
+            if evaluate_result.is_none() || module.get_status() == v8::ModuleStatus::Errored {
                 let err_msg = tc
                     .exception()
                     .and_then(|e| e.to_string(tc))
@@ -1148,7 +1179,11 @@ impl JsRuntime {
         MODULE_ID_TO_URL.with(|map| map.borrow_mut().clear());
         RESOLVED_MODULES.with(|map| map.borrow_mut().clear());
 
-        if errors.is_empty() { Ok(()) } else { Err(errors) }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 
     fn compile_v8_module(&mut self, url: &Url, source: &str) -> Result<Vec<String>, String> {
@@ -1177,12 +1212,13 @@ impl JsRuntime {
             None,
         );
         let mut source_compiler = v8::script_compiler::Source::new(code, Some(&origin));
-        let module = v8::script_compiler::compile_module(tc, &mut source_compiler).ok_or_else(|| {
-            tc.exception()
-                .and_then(|e| e.to_string(tc))
-                .map(|s| s.to_rust_string_lossy(tc))
-                .unwrap_or_else(|| "Unknown module compilation error".to_string())
-        })?;
+        let module =
+            v8::script_compiler::compile_module(tc, &mut source_compiler).ok_or_else(|| {
+                tc.exception()
+                    .and_then(|e| e.to_string(tc))
+                    .map(|s| s.to_rust_string_lossy(tc))
+                    .unwrap_or_else(|| "Unknown module compilation error".to_string())
+            })?;
 
         let requests = module.get_module_requests();
         let mut specifiers = Vec::new();
@@ -2987,7 +3023,10 @@ pub fn extract_scripts_from_dom(handle: &Handle) -> Vec<String> {
     extract_script_sources_from_dom(handle, None)
         .into_iter()
         .filter_map(|source| match source {
-            ScriptSource::InlineClassic { source, is_defer: false } => Some(source),
+            ScriptSource::InlineClassic {
+                source,
+                is_defer: false,
+            } => Some(source),
             ScriptSource::InlineClassic { is_defer: true, .. }
             | ScriptSource::ExternalClassic { .. }
             | ScriptSource::InlineModule { .. }
@@ -3000,10 +3039,7 @@ pub fn extract_scripts_from_dom(handle: &Handle) -> Vec<String> {
 pub enum ScriptSource {
     /// Inline classic scripts are always synchronous in the HTML spec (neither async nor defer
     /// should apply), but we track `is_defer` so that inline test cases can exercise defer semantics.
-    InlineClassic {
-        source: String,
-        is_defer: bool,
-    },
+    InlineClassic { source: String, is_defer: bool },
     ExternalClassic {
         url: Url,
         is_async: bool,
@@ -3079,9 +3115,17 @@ pub fn extract_script_sources_from_dom(
                         if let Ok(url) = base.join(&src).or_else(|_| Url::parse(&src)) {
                             if is_module {
                                 let node_id = register_node(handle.clone());
-                                scripts.push(ScriptSource::ExternalModule { url, node_id, is_async });
+                                scripts.push(ScriptSource::ExternalModule {
+                                    url,
+                                    node_id,
+                                    is_async,
+                                });
                             } else if is_classic {
-                                scripts.push(ScriptSource::ExternalClassic { url, is_async, is_defer });
+                                scripts.push(ScriptSource::ExternalClassic {
+                                    url,
+                                    is_async,
+                                    is_defer,
+                                });
                             }
                         }
                     }
@@ -3110,7 +3154,10 @@ pub fn extract_script_sources_from_dom(
                                 });
                             }
                         } else if is_classic {
-                            scripts.push(ScriptSource::InlineClassic { source: content, is_defer });
+                            scripts.push(ScriptSource::InlineClassic {
+                                source: content,
+                                is_defer,
+                            });
                         }
                     }
                 }
@@ -3179,7 +3226,10 @@ mod tests {
     fn test_execute_with_result_does_not_prescan_import_text() {
         let mut rt = make_runtime("<html><body></body></html>");
         let outcome = rt.execute_with_result(r#""import value from './dep.js'""#);
-        assert_eq!(outcome.result.as_deref(), Some("import value from './dep.js'"));
+        assert_eq!(
+            outcome.result.as_deref(),
+            Some("import value from './dep.js'")
+        );
         assert_eq!(outcome.error, None);
     }
 
@@ -3229,9 +3279,15 @@ mod tests {
         let base = Url::parse("https://example.com/app/").unwrap();
         let sources = extract_script_sources_from_dom(&dom.document, Some(&base));
         assert_eq!(sources.len(), 3);
-        assert!(matches!(&sources[0], ScriptSource::InlineClassic { source: s, is_defer: false } if s == "window.a = 1;"));
-        assert!(matches!(&sources[1], ScriptSource::ExternalClassic { url, is_async: false, is_defer: false } if url.as_str() == "https://example.com/bundle.js"));
-        assert!(matches!(&sources[2], ScriptSource::ExternalModule { url, is_async: false, .. } if url.as_str() == "https://example.com/module.js"));
+        assert!(
+            matches!(&sources[0], ScriptSource::InlineClassic { source: s, is_defer: false } if s == "window.a = 1;")
+        );
+        assert!(
+            matches!(&sources[1], ScriptSource::ExternalClassic { url, is_async: false, is_defer: false } if url.as_str() == "https://example.com/bundle.js")
+        );
+        assert!(
+            matches!(&sources[2], ScriptSource::ExternalModule { url, is_async: false, .. } if url.as_str() == "https://example.com/module.js")
+        );
     }
 
     #[test]
@@ -3243,17 +3299,24 @@ mod tests {
         );
         let module_sources = extract_script_sources_from_dom(&module_dom.document, Some(&base));
         assert_eq!(module_sources.len(), 1);
-        assert!(matches!(&module_sources[0], ScriptSource::ExternalModule { url, is_async: false, .. } if url.as_str() == "https://example.com/m.js"));
+        assert!(
+            matches!(&module_sources[0], ScriptSource::ExternalModule { url, is_async: false, .. } if url.as_str() == "https://example.com/m.js")
+        );
 
-        let nomodule_dom = dom::parse_html(r#"<html><head><script nomodule>window.x=1</script></head></html>"#);
+        let nomodule_dom =
+            dom::parse_html(r#"<html><head><script nomodule>window.x=1</script></head></html>"#);
         let nomodule_sources = extract_script_sources_from_dom(&nomodule_dom.document, Some(&base));
         assert!(nomodule_sources.is_empty());
 
-        let classic_dom = dom::parse_html(r#"<html><head><script>window.x=1</script></head></html>"#);
+        let classic_dom =
+            dom::parse_html(r#"<html><head><script>window.x=1</script></head></html>"#);
         let classic_sources = extract_script_sources_from_dom(&classic_dom.document, Some(&base));
         assert_eq!(
             classic_sources,
-            vec![ScriptSource::InlineClassic { source: "window.x=1".to_string(), is_defer: false }]
+            vec![ScriptSource::InlineClassic {
+                source: "window.x=1".to_string(),
+                is_defer: false
+            }]
         );
     }
 
@@ -3500,10 +3563,7 @@ mod tests {
         );
 
         let main_url = Url::parse("https://example.com/main.js").unwrap();
-        rt.compile_module_source(
-            main_url.clone(),
-            "import './dep.js';".to_string(),
-        );
+        rt.compile_module_source(main_url.clone(), "import './dep.js';".to_string());
 
         rt.evaluate_module_graph(&[main_url]).unwrap();
 
@@ -3522,7 +3582,8 @@ mod tests {
         let lib_url = Url::parse("https://example.com/lib/helpers.js").unwrap();
         rt.compile_module_source(
             lib_url.clone(),
-            "export const version = '1.0'; globalThis.__helpers_meta = import.meta.url;".to_string(),
+            "export const version = '1.0'; globalThis.__helpers_meta = import.meta.url;"
+                .to_string(),
         );
 
         let app_url = Url::parse("https://example.com/app/main.js").unwrap();
@@ -3599,7 +3660,11 @@ mod tests {
 
         let outcome = rt.execute_with_result("globalThis.__error");
         assert_eq!(outcome.error, None);
-        assert!(outcome.result.as_deref().unwrap_or("").contains("module error"));
+        assert!(outcome
+            .result
+            .as_deref()
+            .unwrap_or("")
+            .contains("module error"));
     }
 
     #[test]
@@ -3638,10 +3703,7 @@ mod tests {
 
     #[test]
     fn test_character_data_constructor_exists() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("typeof CharacterData");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("function"));
@@ -3649,10 +3711,7 @@ mod tests {
 
     #[test]
     fn test_character_data_is_window_property() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("typeof window.CharacterData");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("function"));
@@ -3660,10 +3719,7 @@ mod tests {
 
     #[test]
     fn test_character_data_prototype_instanceof_node() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("CharacterData.prototype instanceof Node");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
@@ -3671,21 +3727,16 @@ mod tests {
 
     #[test]
     fn test_text_node_is_instanceof_character_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
-        let outcome = rt.execute_with_result("document.createTextNode('x') instanceof CharacterData");
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
+        let outcome =
+            rt.execute_with_result("document.createTextNode('x') instanceof CharacterData");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
 
     #[test]
     fn test_text_node_is_instanceof_node() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("document.createTextNode('x') instanceof Node");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
@@ -3693,21 +3744,16 @@ mod tests {
 
     #[test]
     fn test_comment_is_instanceof_character_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
-        let outcome = rt.execute_with_result("document.createComment('x') instanceof CharacterData");
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
+        let outcome =
+            rt.execute_with_result("document.createComment('x') instanceof CharacterData");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
 
     #[test]
     fn test_comment_is_instanceof_node() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("document.createComment('x') instanceof Node");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
@@ -3715,10 +3761,7 @@ mod tests {
 
     #[test]
     fn test_text_prototype_instanceof_character_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("Text.prototype instanceof CharacterData");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
@@ -3726,10 +3769,7 @@ mod tests {
 
     #[test]
     fn test_comment_prototype_instanceof_character_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("Comment.prototype instanceof CharacterData");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
@@ -3737,10 +3777,7 @@ mod tests {
 
     #[test]
     fn test_text_node_has_data_property() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("document.createTextNode('hello').data");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("hello"));
@@ -3748,10 +3785,7 @@ mod tests {
 
     #[test]
     fn test_text_node_has_length_property() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("document.createTextNode('hello').length");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("5"));
@@ -3759,10 +3793,7 @@ mod tests {
 
     #[test]
     fn test_character_data_append_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result(
             "var n = document.createTextNode('hello'); n.appendData(' world'); n.data",
         );
@@ -3772,10 +3803,7 @@ mod tests {
 
     #[test]
     fn test_character_data_delete_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result(
             "var n = document.createTextNode('hello'); n.deleteData(1, 3); n.data",
         );
@@ -3785,10 +3813,7 @@ mod tests {
 
     #[test]
     fn test_character_data_insert_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result(
             "var n = document.createTextNode('ho'); n.insertData(1, 'ell'); n.data",
         );
@@ -3798,10 +3823,7 @@ mod tests {
 
     #[test]
     fn test_character_data_replace_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
         let outcome = rt.execute_with_result(
             "var n = document.createTextNode('hello world'); n.replaceData(0, 5, 'goodbye'); n.data",
         );
@@ -3811,13 +3833,9 @@ mod tests {
 
     #[test]
     fn test_character_data_substring_data() {
-        let mut rt = make_dom_runtime(
-            "<html><body>hello</body></html>",
-            "https://example.com/",
-        );
-        let outcome = rt.execute_with_result(
-            "document.createTextNode('hello world').substringData(0, 5)",
-        );
+        let mut rt = make_dom_runtime("<html><body>hello</body></html>", "https://example.com/");
+        let outcome =
+            rt.execute_with_result("document.createTextNode('hello world').substringData(0, 5)");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("hello"));
     }
@@ -3856,10 +3874,7 @@ mod tests {
 
     #[test]
     fn test_onload_handler_dispatch() {
-        let mut rt = make_dom_runtime(
-            r#"<html><body></body></html>"#,
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime(r#"<html><body></body></html>"#, "https://example.com/");
         rt.execute(
             "window.onload = function() { window.__loadFired = true; }; \
              var ev = new Event('load', { bubbles: false }); \
@@ -4023,10 +4038,7 @@ mod tests {
 
     #[test]
     fn test_form_create_element_creates_html_form_element() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
         let outcome = rt.execute_with_result(
             "var f = document.createElement('form'); typeof f.submit === 'function'",
         );
@@ -4040,8 +4052,8 @@ mod tests {
             "<html><body><iframe id='f'></iframe></body></html>",
             "https://example.com/",
         );
-        let outcome = rt
-            .execute_with_result("document.getElementById('f').contentDocument !== null");
+        let outcome =
+            rt.execute_with_result("document.getElementById('f').contentDocument !== null");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
@@ -4052,8 +4064,8 @@ mod tests {
             "<html><body><iframe id='f'></iframe></body></html>",
             "https://example.com/",
         );
-        let outcome = rt
-            .execute_with_result("document.getElementById('f').contentWindow.document !== null");
+        let outcome =
+            rt.execute_with_result("document.getElementById('f').contentWindow.document !== null");
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
@@ -4135,10 +4147,7 @@ mod tests {
 
     #[test]
     fn test_create_element_iframe_has_content_document() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
         let outcome = rt.execute_with_result(
             "var iframe = document.createElement('iframe'); \
              iframe.contentDocument !== null",
@@ -4149,50 +4158,35 @@ mod tests {
 
     #[test]
     fn test_shadow_root_is_function() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("typeof ShadowRoot");
         assert_eq!(outcome.result.as_deref(), Some("function"));
     }
 
     #[test]
     fn test_intersection_observer_is_function() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("typeof IntersectionObserver");
         assert_eq!(outcome.result.as_deref(), Some("function"));
     }
 
     #[test]
     fn test_resize_observer_is_function() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("typeof ResizeObserver");
         assert_eq!(outcome.result.as_deref(), Some("function"));
     }
 
     #[test]
     fn test_mutation_observer_is_function() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
         let outcome = rt.execute_with_result("typeof MutationObserver");
         assert_eq!(outcome.result.as_deref(), Some("function"));
     }
 
     #[test]
     fn test_intersection_observer_has_take_records() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
         let outcome = rt.execute_with_result(
             "var io = new IntersectionObserver(function() {}); \
              typeof io.takeRecords === 'function' && io.takeRecords().length === 0",
@@ -4202,10 +4196,7 @@ mod tests {
 
     #[test]
     fn test_mutation_observer_take_records_returns_array() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
         let outcome = rt.execute_with_result(
             "var mo = new MutationObserver(function() {}); \
              Array.isArray(mo.takeRecords())",
@@ -4219,33 +4210,22 @@ mod tests {
             "<html><body><div id='test'></div></body></html>",
             "https://example.com/",
         );
-        let outcome = rt.execute_with_result(
-            "document.getElementById('test').getRootNode() === document",
-        );
+        let outcome =
+            rt.execute_with_result("document.getElementById('test').getRootNode() === document");
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
 
     #[test]
     fn test_get_root_node_returns_document_for_body() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
-        let outcome = rt.execute_with_result(
-            "document.body.getRootNode() === document",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
+        let outcome = rt.execute_with_result("document.body.getRootNode() === document");
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
 
     #[test]
     fn test_get_root_node_on_document_element() {
-        let mut rt = make_dom_runtime(
-            "<html><body></body></html>",
-            "https://example.com/",
-        );
-        let outcome = rt.execute_with_result(
-            "document.documentElement.getRootNode() === document",
-        );
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
+        let outcome = rt.execute_with_result("document.documentElement.getRootNode() === document");
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
 
@@ -4255,9 +4235,8 @@ mod tests {
             "<html><body><div id='test'></div></body></html>",
             "https://example.com/",
         );
-        let outcome = rt.execute_with_result(
-            "document.getElementById('test').ownerDocument === document",
-        );
+        let outcome =
+            rt.execute_with_result("document.getElementById('test').ownerDocument === document");
         assert_eq!(outcome.result.as_deref(), Some("true"));
     }
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -53,6 +53,7 @@ thread_local! {
     static RAF_TASKS: RefCell<VecDeque<Box<dyn FnOnce(f64)>>> = RefCell::new(VecDeque::new());
     static IDLE_TASKS: RefCell<VecDeque<(u32, Box<dyn FnOnce(f64)>)>> = RefCell::new(VecDeque::new());
     static NEXT_IDLE_ID: RefCell<u32> = RefCell::new(1);
+    static NEXT_RAF_ID: RefCell<u32> = RefCell::new(1);
     static DOM_ROOT: RefCell<Option<Handle>> = RefCell::new(None);
     static NODE_REGISTRY: RefCell<HashMap<u32, Handle>> = RefCell::new(HashMap::new());
     static REVERSE_NODE_REGISTRY: RefCell<HashMap<usize, u32>> = RefCell::new(HashMap::new());
@@ -3033,6 +3034,11 @@ fn fetch_cb(
     let body = args.get(3).to_rust_string_lossy(scope);
     let resolve_val = args.get(4);
     let reject_val = args.get(5);
+    let bypass_cors = if args.length() > 6 {
+        args.get(6).is_true()
+    } else {
+        false
+    };
 
     let base_url = CURRENT_ORIGIN.with(|o| (*o.borrow()).clone());
     let target_url = if let Some(ref base) = base_url {
@@ -3107,7 +3113,7 @@ fn fetch_cb(
                         let response_url = response.url().to_string();
                         let status = response.status().as_u16();
                         let status_text = response.status().canonical_reason().unwrap_or("").to_string();
-                        if is_cross_origin {
+                        if is_cross_origin && !bypass_cors {
                             let acao = response.headers().get("access-control-allow-origin").and_then(|h| h.to_str().ok());
                             let allowed = match acao { Some("*") => true, Some(val) if val == origin_str => true, _ => false };
                             if !allowed {
@@ -3178,7 +3184,7 @@ fn setTimeout_cb(
 fn raf_cb(
     scope: &mut v8::PinScope,
     args: v8::FunctionCallbackArguments,
-    _rv: v8::ReturnValue<v8::Value>,
+    mut rv: v8::ReturnValue<v8::Value>,
 ) {
     let cb = args.get(0);
     if cb.is_function() {
@@ -3190,6 +3196,12 @@ fn raf_cb(
             }))
         });
     }
+    let id = NEXT_RAF_ID.with(|c| {
+        let id = *c.borrow();
+        *c.borrow_mut() += 1;
+        id
+    });
+    rv.set_uint32(id);
 }
 
 fn ric_cb(
@@ -4749,6 +4761,82 @@ mod tests {
         assert_eq!(val["matches"], false);
         assert_eq!(val["querySelector"], serde_json::Value::Null);
         assert_eq!(val["querySelectorAll"], true);
+    }
+
+    #[test]
+    fn test_raf_behavior() {
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
+        // 1. Verify requestAnimationFrame returns an integer handle
+        let outcome = rt.execute_with_result(
+            "var id = requestAnimationFrame(function(ts) { window.__raf_ts = ts; }); typeof id"
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("number"));
+
+        // 2. Verify cancelAnimationFrame is a function
+        let outcome = rt.execute_with_result("typeof cancelAnimationFrame");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("function"));
+
+        // 3. Verify RAF callback is fired on tick with a timestamp
+        let outcome = rt.execute_with_result("window.__raf_ts");
+        assert_eq!(outcome.error, None);
+        // It shouldn't have fired yet
+        assert_eq!(outcome.result.as_deref(), Some("undefined"));
+
+        // Tick with Some(123.45) timestamp
+        rt.tick(Some(123.45), None);
+
+        let outcome = rt.execute_with_result("window.__raf_ts");
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("123.45"));
+    }
+
+    #[test]
+    fn test_intersection_observer_properties() {
+        let mut rt = make_dom_runtime("<html><body></body></html>", "https://example.com/");
+        let outcome = rt.execute_with_result(
+            r#"var obs = new IntersectionObserver(function() {}, { threshold: [0.1, 0.2] });
+               JSON.stringify({
+                   root: obs.root,
+                   rootMargin: obs.rootMargin,
+                   thresholds: obs.thresholds
+               })"#
+        );
+        assert_eq!(outcome.error, None);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["root"], serde_json::Value::Null);
+        assert_eq!(val["rootMargin"], "0px");
+        assert_eq!(val["thresholds"], serde_json::json!([0.1, 0.2]));
+
+        // Default thresholds
+        let outcome = rt.execute_with_result(
+            r#"var obs2 = new IntersectionObserver(function() {});
+               JSON.stringify(obs2.thresholds)"#
+        );
+        assert_eq!(outcome.error, None);
+        let thresholds: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(thresholds, serde_json::json!([0]));
+    }
+
+    #[test]
+    fn test_shadow_root_get_root_node() {
+        let mut rt = make_dom_runtime(
+            "<html><body><div id='host'></div></body></html>",
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            r#"var host = document.getElementById('host');
+               var shadow = host.attachShadow({ mode: 'open' });
+               JSON.stringify({
+                   shadow_itself: shadow.getRootNode() === shadow,
+                   shadow_composed: shadow.getRootNode({ composed: true }) === document
+               })"#
+        );
+        assert_eq!(outcome.error, None);
+        let val: serde_json::Value = serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(val["shadow_itself"], true);
+        assert_eq!(val["shadow_composed"], true);
     }
 }
 

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -174,6 +174,24 @@ function __get_or_create_node(id, tag, string_id, kind) {
             node = new HTMLIFrameElement(id, descriptor.tag, descriptor.id);
         } else if (tagLower === 'form') {
             node = new HTMLFormElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'a') {
+            node = new HTMLAnchorElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'script') {
+            node = new HTMLScriptElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'img') {
+            node = new HTMLImageElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'input') {
+            node = new HTMLInputElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'button') {
+            node = new HTMLButtonElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'div') {
+            node = new HTMLDivElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'span') {
+            node = new HTMLSpanElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'style') {
+            node = new HTMLStyleElement(id, descriptor.tag, descriptor.id);
+        } else if (tagLower === 'canvas') {
+            node = new HTMLCanvasElement(id, descriptor.tag, descriptor.id);
         } else {
             node = new Element(id, descriptor.tag, descriptor.id);
         }
@@ -967,6 +985,14 @@ class Node extends EventTarget {
         this._id = id;
         this._kind = kind;
     }
+    getAttribute(name) { return null; }
+    setAttribute(name, value) {}
+    removeAttribute(name) {}
+    hasAttribute(name) { return false; }
+    closest(selector) { return null; }
+    matches(selector) { return false; }
+    querySelector(selector) { return null; }
+    querySelectorAll(selector) { return new NodeList([]); }
     get nodeType() {
         if (this._kind === 'element') return 1;
         if (this._kind === 'text') return 3;
@@ -1372,6 +1398,48 @@ var CSS = {
     }
 };
 
+class Attr {
+    constructor(element, name, value) {
+        this.name = name;
+        this.value = value;
+        this.ownerElement = element;
+    }
+}
+
+class NamedNodeMap {
+    constructor(element) {
+        this._element = element;
+    }
+    get length() {
+        let attrs = typeof __aura_get_attributes === 'function'
+            ? JSON.parse(__aura_get_attributes(this._element._id))
+            : [];
+        return attrs.length;
+    }
+    item(index) {
+        let attrs = typeof __aura_get_attributes === 'function'
+            ? JSON.parse(__aura_get_attributes(this._element._id))
+            : [];
+        if (index >= 0 && index < attrs.length) {
+            return new Attr(this._element, attrs[index].name, attrs[index].value);
+        }
+        return null;
+    }
+    getNamedItem(name) {
+        let value = __aura_get_attribute(this._element._id, name);
+        if (value !== null) {
+            return new Attr(this._element, name, value);
+        }
+        return null;
+    }
+    setNamedItem(attr) {
+        this._element.setAttribute(attr.name, attr.value);
+    }
+    removeNamedItem(name) {
+        this._element.removeAttribute(name);
+    }
+}
+
 class Element extends Node {
     constructor(id, tag, string_id) {
         super(id, 'element');
@@ -1383,6 +1451,27 @@ class Element extends Node {
     get classList() {
         if (!this._classList) this._classList = new DOMTokenList(this._id);
         return this._classList;
+    }
+    get attributes() {
+        let map = new NamedNodeMap(this);
+        return new Proxy(map, {
+            get: function(target, prop) {
+                if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+                    return target.item(Number(prop));
+                }
+                if (prop in target) {
+                    let value = target[prop];
+                    if (typeof value === 'function') {
+                        return value.bind(target);
+                    }
+                    return value;
+                }
+                if (typeof prop === 'string') {
+                    return target.getNamedItem(prop);
+                }
+                return undefined;
+            }
+        });
     }
     get className() {
         return __aura_get_attribute(this._id, 'class') || '';
@@ -1755,7 +1844,7 @@ class Element extends Node {
     }
 }
 
-// -- IDL Event Handler Properties (Element.prototype) -------------------------
+// -- IDL Event Handler Properties (Element.prototype, document, globalThis) ----
 (function() {
     var handlers = [
         'onclick', 'onkeydown', 'onkeyup',
@@ -1772,7 +1861,25 @@ class Element extends Node {
             };
         })(handlers[i]);
     }
-    Object.defineProperties(Element.prototype, defs);
+    try {
+        Object.defineProperties(Element.prototype, defs);
+    } catch (e) {
+        console.warn('Failed to define handlers on Element: ' + e);
+    }
+    try {
+        Object.defineProperties(document, defs);
+    } catch (e) {
+        console.warn('Failed to define handlers on document: ' + e);
+    }
+    for (var key in defs) {
+        try {
+            Object.defineProperty(globalThis, key, defs[key]);
+        } catch (e) {
+            try {
+                globalThis[key] = null;
+            } catch (err) {}
+        }
+    }
 })();
 
 class CharacterData extends Node {
@@ -1987,6 +2094,16 @@ var document = {
         return __aura_dispatch_event(this, event);
     },
 
+    get currentScript() {
+        let scripts = document.scripts;
+        if (!scripts || scripts.length === 0) return null;
+        return scripts[scripts.length - 1] || null;
+    },
+    getAttribute: function(name) { return null; },
+    setAttribute: function(name, value) {},
+    removeAttribute: function(name) {},
+    hasAttribute: function(name) { return false; },
+
     getElementById: function(id) {
         let res = __aura_get_element_by_id(id);
         return res ? __get_or_create_node(res.nid, res.tag, id, res.kind) : null;
@@ -1994,6 +2111,9 @@ var document = {
     createElement: function(tag) {
         let nativeId = __aura_create_element(tag);
         return __get_or_create_node(nativeId, tag, null, 'element');
+    },
+    createElementNS: function(ns, tag) {
+        return document.createElement(tag);
     },
     createTextNode: function(text) {
         let nativeId = __aura_create_text_node(String(text));
@@ -2764,6 +2884,24 @@ window.close = function() {};
 window.focus = function() {};
 window.blur = function() {};
 
+function __aura_post_message_impl(target, message, targetOrigin) {
+    if (typeof target.dispatchEvent !== 'function') return;
+    setTimeout(function() {
+        try {
+            var ev = new Event('message');
+            ev.data = message;
+            ev.origin = typeof targetOrigin === 'string' ? targetOrigin : '*';
+            ev.source = target;
+            target.dispatchEvent(ev);
+        } catch (e) {
+            console.error('Error dispatching message event: ' + e);
+        }
+    }, 0);
+}
+window.postMessage = function(message, targetOrigin, transfer) {
+    __aura_post_message_impl(globalThis, message, targetOrigin);
+};
+
 // -- Timers ------------------------------------------------------------------
 window.setTimeout = function(fn, delay) {
     if (typeof fn === 'function') {
@@ -3009,6 +3147,20 @@ function __aura_execute_classic_script(script, code) {
     }
 }
 
+function __aura_execute_module_script(script, url, code) {
+    try {
+        let success = __aura_execute_module_script_in_host(url, code);
+        if (success) {
+            __aura_script_fire(script, 'load');
+        } else {
+            __aura_script_fire(script, 'error');
+        }
+    } catch (e) {
+        console.error('Module script execution error: ' + e);
+        __aura_script_fire(script, 'error');
+    }
+}
+
 function __aura_maybe_run_script(node) {
     if (!node || node.nodeType !== Node.ELEMENT_NODE || String(node.tagName || '').toLowerCase() !== 'script') return;
     let script = node;
@@ -3016,11 +3168,9 @@ function __aura_maybe_run_script(node) {
     script._alreadyStarted = true;
 
     let type = __aura_script_type(script);
-    if (type && type !== 'text/javascript' && type !== 'application/javascript' && type !== 'classic') {
-        script._auraModuleUnsupported = type === 'module';
-        console.warn(type === 'module'
-            ? 'Module scripts are not supported yet; dynamic module script signaled error.'
-            : 'Unsupported script type skipped: ' + type);
+    let isModule = type === 'module';
+    if (type && type !== 'text/javascript' && type !== 'application/javascript' && type !== 'classic' && !isModule) {
+        console.warn('Unsupported script type skipped: ' + type);
         __aura_script_fire(script, 'error');
         return;
     }
@@ -3034,20 +3184,31 @@ function __aura_maybe_run_script(node) {
         }
         fetch(src)
             .then(response => response.ok ? response.text() : Promise.reject(new Error('HTTP ' + response.status)))
-            .then(code => __aura_execute_classic_script(script, code))
+            .then(code => {
+                if (isModule) {
+                    __aura_execute_module_script(script, src, code);
+                } else {
+                    __aura_execute_classic_script(script, code);
+                }
+            })
             .catch(error => {
-                console.error('Script load error: ' + error);
+                console.error((isModule ? 'Module script' : 'Script') + ' load error: ' + error);
                 __aura_script_fire(script, 'error');
             });
         return;
     }
 
-    if (!window.__aura_inline_script_allowed) {
+    if (!isModule && !window.__aura_inline_script_allowed) {
         console.warn('CSP blocked inline dynamic script');
         __aura_script_fire(script, 'error');
         return;
     }
-    __aura_execute_classic_script(script, script.text || script.textContent || '');
+    if (isModule) {
+        let inline_url = window.location.href;
+        __aura_execute_module_script(script, inline_url, script.text || script.textContent || '');
+    } else {
+        __aura_execute_classic_script(script, script.text || script.textContent || '');
+    }
 }
 
 // -- MutationObserver --------------------------------------------------------
@@ -3678,6 +3839,47 @@ window.HTMLButtonElement = HTMLButtonElement;
 class HTMLAnchorElement extends HTMLElement {
     get href() { return __aura_resolve_url_attribute(__aura_get_attribute(this._id, 'href') || ''); }
     set href(v) { __aura_set_attribute(this._id, 'href', String(v)); }
+
+    _getURL(for_write) {
+        var raw = __aura_get_attribute(this._id, 'href');
+        if (raw === null && !for_write) {
+            return null;
+        }
+        try {
+            return new URL(raw || '', location.href || document.baseURI || undefined);
+        } catch (e) {
+            return null;
+        }
+    }
+    _setURLProp(prop, value) {
+        var url = this._getURL(true);
+        if (!url) return;
+        url[prop] = value;
+        this.href = url.href;
+    }
+
+    get protocol() { var url = this._getURL(); return url ? url.protocol : ''; }
+    set protocol(v) { this._setURLProp('protocol', v); }
+
+    get host() { var url = this._getURL(); return url ? url.host : ''; }
+    set host(v) { this._setURLProp('host', v); }
+
+    get hostname() { var url = this._getURL(); return url ? url.hostname : ''; }
+    set hostname(v) { this._setURLProp('hostname', v); }
+
+    get port() { var url = this._getURL(); return url ? url.port : ''; }
+    set port(v) { this._setURLProp('port', v); }
+
+    get pathname() { var url = this._getURL(); return url ? url.pathname : ''; }
+    set pathname(v) { this._setURLProp('pathname', v); }
+
+    get search() { var url = this._getURL(); return url ? url.search : ''; }
+    set search(v) { this._setURLProp('search', v); }
+
+    get hash() { var url = this._getURL(); return url ? url.hash : ''; }
+    set hash(v) { this._setURLProp('hash', v); }
+
+    get origin() { var url = this._getURL(); return url ? url.origin : ''; }
 }
 window.HTMLAnchorElement = HTMLAnchorElement;
 
@@ -3717,6 +3919,7 @@ class HTMLIFrameElement extends HTMLElement {
             var self = this;
             this._contentDocument = {
                 createElement: function(tag) { return document.createElement(tag); },
+                createElementNS: function(ns, tag) { return document.createElement(tag); },
                 createTextNode: function(text) { return document.createTextNode(text); },
                 createComment: function(data) { return document.createComment(data); },
                 createDocumentFragment: function() { return document.createDocumentFragment(); },
@@ -3792,7 +3995,7 @@ class HTMLIFrameElement extends HTMLElement {
     get contentWindow() {
         if (!this._contentWindow) {
             var self = this;
-            this._contentWindow = {};
+            this._contentWindow = new EventTarget();
             var doc = self.contentDocument;
             Object.defineProperty(self._contentWindow, 'document', {
                 get: function() { return doc; },
@@ -3809,6 +4012,9 @@ class HTMLIFrameElement extends HTMLElement {
             self._contentWindow.closed = false;
             self._contentWindow.opener = null;
             self._contentWindow.frameElement = self;
+            self._contentWindow.postMessage = function(message, targetOrigin, transfer) {
+                __aura_post_message_impl(self._contentWindow, message, targetOrigin);
+            };
         }
         return this._contentWindow;
     }
@@ -4014,12 +4220,6 @@ class HTMLCanvasElement extends HTMLElement {
 }
 window.HTMLCanvasElement = HTMLCanvasElement;
 
-// -- window.queueMicrotask ---------------------------------------------------
-window.queueMicrotask = function(fn) {
-    if (typeof fn === 'function') {
-        Promise.resolve().then(fn);
-    }
-};
 
 // -- atob / btoa stubs -------------------------------------------------------
 window.atob = function(s) { return ''; };

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -2145,6 +2145,10 @@ class ShadowRoot extends DocumentFragment {
     get parentElement() {
         return this.host;
     }
+    getRootNode(options) {
+        if (options && options.composed) return document;
+        return this;
+    }
 }
 
 // -- Node static constants ---------------------------------------------------
@@ -2461,6 +2465,35 @@ window.frames = window;
 window.length = 0;
 window.name = '';
 window.status = '';
+
+// -- Debug hooks -------------------------------------------------------------
+let _gladsdk = undefined;
+Object.defineProperty(window, 'gladsdk', {
+    get() {
+        console.log('[DEBUG] get gladsdk: ' + (_gladsdk ? ('defined, cmd is ' + typeof _gladsdk.cmd) : 'undefined'));
+        return _gladsdk;
+    },
+    set(v) {
+        console.log('[DEBUG] set gladsdk to: ' + typeof v + ', cmd is ' + (v ? typeof v.cmd : 'n/a'));
+        _gladsdk = v;
+    },
+    configurable: true,
+    enumerable: true
+});
+
+let _ndpsdk = undefined;
+Object.defineProperty(window, 'ndpsdk', {
+    get() {
+        console.log('[DEBUG] get ndpsdk: ' + (_ndpsdk ? ('defined, cmd is ' + typeof _ndpsdk.cmd) : 'undefined'));
+        return _ndpsdk;
+    },
+    set(v) {
+        console.log('[DEBUG] set ndpsdk to: ' + typeof v + ', cmd is ' + (v ? typeof v.cmd : 'n/a'));
+        _ndpsdk = v;
+    },
+    configurable: true,
+    enumerable: true
+});
 window.closed = false;
 window.opener = null;
 window.frameElement = null;
@@ -3281,17 +3314,22 @@ function __aura_maybe_run_script(node) {
             __aura_script_fire(script, 'error');
             return;
         }
-        fetch(src)
-            .then(response => response.ok ? response.text() : Promise.reject(new Error('HTTP ' + response.status)))
-            .then(code => {
-                if (isModule) {
-                    __aura_execute_module_script(script, src, code);
-                } else {
-                    __aura_execute_classic_script(script, code);
-                }
+        let hasCrossOrigin = typeof script.hasAttribute === 'function' ? script.hasAttribute('crossorigin') : false;
+        let bypassCors = !isModule && !hasCrossOrigin;
+        new Promise((resolve, reject) => {
+            __aura_fetch(src, 'GET', '', '', resolve, reject, bypassCors);
+        })
+            .then(response => {
+                return response.text().then(code => {
+                    if (isModule) {
+                        __aura_execute_module_script(script, src, code);
+                    } else {
+                        __aura_execute_classic_script(script, code);
+                    }
+                });
             })
             .catch(error => {
-                console.error((isModule ? 'Module script' : 'Script') + ' load error: ' + error);
+                console.error((isModule ? 'Module' : 'Classic') + ' script load error for ' + src + ': ' + error);
                 __aura_script_fire(script, 'error');
             });
         return;
@@ -3348,7 +3386,16 @@ class MutationObserver {
 
 // -- IntersectionObserver stub -----------------------------------------------
 class IntersectionObserver {
-    constructor(callback, options) { this._callback = callback; }
+    constructor(callback, options) {
+        this._callback = callback;
+        this._options = options || {};
+    }
+    get root() { return this._options.root || null; }
+    get rootMargin() { return this._options.rootMargin || '0px'; }
+    get thresholds() {
+        var t = this._options.threshold;
+        return t !== undefined ? [].concat(t) : [0];
+    }
     observe(target) {}
     unobserve(target) {}
     disconnect() {}

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -467,14 +467,20 @@ function __aura_collection_node(item) {
 
 class HTMLCollection {
     constructor(resolver) {
-        this._resolver = resolver;
+        Object.defineProperty(this, '_resolver', {
+            value: resolver,
+            writable: true,
+            configurable: true,
+            enumerable: false
+        });
         return new Proxy(this, {
             get(target, prop, receiver) {
                 if (prop === 'length') return target._items().length;
                 if (prop === Symbol.iterator) return target[Symbol.iterator].bind(target);
-                if (typeof prop === 'string') {
-                    if (/^(0|[1-9]\d*)$/.test(prop)) return target.item(Number(prop));
-                    if (!(prop in target)) {
+                if (typeof prop === 'string' || typeof prop === 'number') {
+                    let propStr = String(prop);
+                    if (/^(0|[1-9]\d*)$/.test(propStr)) return target.item(Number(propStr));
+                    if (typeof prop === 'string' && !(prop in target)) {
                         let named = target.namedItem(prop);
                         if (named) return named;
                     }
@@ -483,10 +489,47 @@ class HTMLCollection {
                 return typeof value === 'function' ? value.bind(target) : value;
             },
             has(target, prop) {
-                if (typeof prop === 'string' && /^(0|[1-9]\d*)$/.test(prop)) {
-                    return Number(prop) < target.length;
+                if (typeof prop === 'string' || typeof prop === 'number') {
+                    let propStr = String(prop);
+                    if (/^(0|[1-9]\d*)$/.test(propStr)) {
+                        return Number(propStr) < target._items().length;
+                    }
                 }
                 return prop in target;
+            },
+            ownKeys(target) {
+                let keys = [];
+                let len = target._items().length;
+                for (let i = 0; i < len; i++) {
+                    keys.push(String(i));
+                }
+                keys.push('length');
+                return keys;
+            },
+            getOwnPropertyDescriptor(target, prop) {
+                if (typeof prop === 'string' || typeof prop === 'number') {
+                    let propStr = String(prop);
+                    if (/^(0|[1-9]\d*)$/.test(propStr)) {
+                        let index = Number(propStr);
+                        if (index < target._items().length) {
+                            return {
+                                value: target.item(index),
+                                writable: true,
+                                enumerable: true,
+                                configurable: true
+                            };
+                        }
+                    }
+                }
+                if (prop === 'length') {
+                    return {
+                        value: target._items().length,
+                        writable: false,
+                        enumerable: false,
+                        configurable: true
+                    };
+                }
+                return Reflect.getOwnPropertyDescriptor(target, prop);
             }
         });
     }
@@ -1367,13 +1410,64 @@ class CSSStyleSheet {
 
 class StyleSheetList {
     constructor(resolver) {
-        this._resolver = resolver;
+        Object.defineProperty(this, '_resolver', {
+            value: resolver,
+            writable: true,
+            configurable: true,
+            enumerable: false
+        });
         return new Proxy(this, {
             get(target, prop, receiver) {
                 if (prop === 'length') return target._items().length;
-                if (typeof prop === 'string' && /^(0|[1-9]\d*)$/.test(prop)) return target.item(Number(prop));
+                if (typeof prop === 'string' || typeof prop === 'number') {
+                    let propStr = String(prop);
+                    if (/^(0|[1-9]\d*)$/.test(propStr)) return target.item(Number(propStr));
+                }
                 let value = Reflect.get(target, prop, receiver);
                 return typeof value === 'function' ? value.bind(target) : value;
+            },
+            has(target, prop) {
+                if (typeof prop === 'string' || typeof prop === 'number') {
+                    let propStr = String(prop);
+                    if (/^(0|[1-9]\d*)$/.test(propStr)) {
+                        return Number(propStr) < target._items().length;
+                    }
+                }
+                return prop in target;
+            },
+            ownKeys(target) {
+                let keys = [];
+                let len = target._items().length;
+                for (let i = 0; i < len; i++) {
+                    keys.push(String(i));
+                }
+                keys.push('length');
+                return keys;
+            },
+            getOwnPropertyDescriptor(target, prop) {
+                if (typeof prop === 'string' || typeof prop === 'number') {
+                    let propStr = String(prop);
+                    if (/^(0|[1-9]\d*)$/.test(propStr)) {
+                        let index = Number(propStr);
+                        if (index < target._items().length) {
+                            return {
+                                value: target.item(index),
+                                writable: true,
+                                enumerable: true,
+                                configurable: true
+                            };
+                        }
+                    }
+                }
+                if (prop === 'length') {
+                    return {
+                        value: target._items().length,
+                        writable: false,
+                        enumerable: false,
+                        configurable: true
+                    };
+                }
+                return Reflect.getOwnPropertyDescriptor(target, prop);
             }
         });
     }
@@ -1408,7 +1502,12 @@ class Attr {
 
 class NamedNodeMap {
     constructor(element) {
-        this._element = element;
+        Object.defineProperty(this, '_element', {
+            value: element,
+            writable: true,
+            configurable: true,
+            enumerable: false
+        });
     }
     get length() {
         let attrs = typeof __aura_get_attributes === 'function'

--- a/tests/repro_failures.rs
+++ b/tests/repro_failures.rs
@@ -35,11 +35,17 @@ fn test_interleaved_block_inline_stacking() {
         println!("Child {}: {:?} at y={}", i, child.display, child.dimensions.y);
     }
 
-    assert_eq!(layout.children.len(), 3);
+    let element_children: Vec<&browser::layout::LayoutBox> = layout.children.iter()
+        .filter(|child| {
+            matches!(child.style_node.node.data, NodeData::Element { .. })
+        })
+        .collect();
+
+    assert_eq!(element_children.len(), 3);
     
-    let inline1 = &layout.children[0];
-    let block1 = &layout.children[1];
-    let inline2 = &layout.children[2];
+    let inline1 = element_children[0];
+    let block1 = element_children[1];
+    let inline2 = element_children[2];
 
     // Check vertical stacking
     assert!(block1.dimensions.y >= inline1.dimensions.y + inline1.dimensions.height, 

--- a/tests/test_fixtures.rs
+++ b/tests/test_fixtures.rs
@@ -273,3 +273,63 @@ fn test_fixture_spans_script_types() {
         );
     }
 }
+
+#[test]
+fn test_aura_fetch_cors_bypass() {
+    let mut engine = engine_with_fixture("inline-classic.html");
+
+    // 1. Fetch with bypass_cors = false (should fail due to CORS check on cross-origin request)
+    engine.evaluate_js(
+        "globalThis.fetchResult = null; \
+         globalThis.fetchError = null; \
+         __aura_fetch( \
+             'https://www.google.com/', \
+             'GET', \
+             '', \
+             '', \
+             function(r) { globalThis.fetchResult = 'success'; }, \
+             function(e) { globalThis.fetchError = String(e); }, \
+             false \
+         );"
+    );
+
+    let mut passed = false;
+    for _ in 0..100 {
+        engine.tick_js(Some(1.0), None);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let error = engine.evaluate_js("globalThis.fetchError");
+        if error.contains("CORS Error") {
+            passed = true;
+            break;
+        }
+    }
+    assert!(passed, "CORS should be enforced when bypassCors is false");
+
+    // 2. Fetch with bypass_cors = true (should succeed)
+    engine.evaluate_js(
+        "globalThis.fetchResult = null; \
+         globalThis.fetchError = null; \
+         __aura_fetch( \
+             'https://www.google.com/', \
+             'GET', \
+             '', \
+             '', \
+             function(r) { globalThis.fetchResult = 'success'; }, \
+             function(e) { globalThis.fetchError = String(e); }, \
+             true \
+         );"
+    );
+
+    let mut passed = false;
+    for _ in 0..100 {
+        engine.tick_js(Some(1.0), None);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let res = engine.evaluate_js("globalThis.fetchResult");
+        if res == "success" {
+            passed = true;
+            break;
+        }
+    }
+    assert!(passed, "CORS should be bypassed when bypassCors is true");
+}
+


### PR DESCRIPTION
## Summary

- Add bounded engine actor waits for control endpoints so Naver load does not leave daemon APIs hanging indefinitely.
- Add `/tick` plus CLI `tick` and `logs` commands for real-site debugging.
- Add short external script/module fetch timeouts and cap per-tick JS task draining.
- Track the #279 implementation plan and validation results.

Closes #279

## Validation

- `cargo test --bin browser-cli --bin browser-daemon`
- `cargo build --bins`
- `cargo test --lib`
- `timeout 45s ./target/debug/browser-cli --port 7070 navigate https://www.naver.com`
- `timeout 10s curl -sS -i http://127.0.0.1:7070/status`
- `timeout 15s ./target/debug/browser-cli --port 7070 tick 1`
- `timeout 10s ./target/debug/browser-cli --port 7070 logs`
- `timeout 10s curl -sS -o /tmp/naver_browser.png -w '%{http_code} %{size_download}\n' http://127.0.0.1:7070/screenshot`
- Visual inspection of `/tmp/naver_browser.png`: non-hanging but still visually failing; screenshot is mostly blank white with tiny text near the top.
- `browser-cli-reviewer` manual path: build, daemon health, `yunseong.dev`, `google.com`

## Notes

This PR fixes the Naver debug loop hang/observability problem only. It does not make Naver visually render correctly yet. Naver still reports browser API/module compatibility gaps in console, including dynamic module script support.