### PR TITLE
fix(js): support named form globals

### DIFF
--- a/.plan/issues/2026-07-03-issue-278-naver-shell-beyond-search-skeleton.md
+++ b/.plan/issues/2026-07-03-issue-278-naver-shell-beyond-search-skeleton.md
@@ -1,0 +1,89 @@
+# 2026-07-03 — Naver shell beyond search skeleton
+
+- Date: 2026-07-03
+- GitHub Issue: #278
+- Status: Implemented
+
+## Goal
+
+Make `https://www.naver.com` render visible main shell content beyond the tiny search/skip-link skeleton by removing the current JavaScript startup blocker reported as `TypeError: Cannot read properties of undefined (reading 'onsubmit')`.
+
+## Non-goals
+
+- Pixel-perfect parity with Chromium/Naver in this PR.
+- Full implementation of every browser API listed in #270.
+- Large layout, style, renderer, or module-loader rewrites unless a live blocker proves they are required.
+
+## Context / Constraints
+
+- Issue #278 is part of #257 and #252.
+- Current Naver HTML contains `<form id="sform" name="search">`.
+- Existing DOM support includes `HTMLFormElement`, `onsubmit` handler properties, `document.forms`, and collection named lookup.
+- Browser-compat legacy named access such as `document.search` / `window.search` is not currently implemented. Naver or one of its external bundles may read `document.search.onsubmit` or `window.search.onsubmit`, which would match the current error shape.
+- Keep unrelated local files (`storage.json`, `.codex/`, `.claude/worktrees/`) out of the PR.
+
+## Approach (Checklist)
+
+- [x] **Step 0: Recon** (Inspect existing code, locate files)
+  - Reproduce or inspect the Naver blocker with daemon/CLI logs where practical.
+  - Confirm local DOM behavior for `document.search`, `document.forms.search`, and `document.getElementById('sform')`.
+  - Confirm whether `window.search` is also absent.
+  - Inspect `src/js_bootstrap.js` collection, document, and event-handler behavior.
+- [x] **Step 1: Implementation** (Code changes, file paths)
+  - Add focused browser-compatible named document property access for elements by `id`/`name` when the property is not already a real document member.
+  - Add matching named-element fallback on `window` only when the property is not already a real global member.
+  - Prefer a local `Proxy` around the existing `document` object rather than many per-name definitions, so dynamically parsed or inserted named elements work.
+  - Keep `has`, `ownKeys`, and `getOwnPropertyDescriptor` conservative so internal helper properties do not leak into library enumeration and real APIs keep precedence.
+- [x] **Step 2: Tests** (Unit tests, manual verification steps)
+  - Add JS runtime tests for `document.search.onsubmit`, precedence over built-in document properties, and missing-name behavior.
+  - Add JS runtime tests for `window.search` fallback and `in`/`Object.keys` behavior.
+  - Run targeted JS tests first, then broader relevant Rust checks.
+- [x] **Step 3: Rollout / Rollback** (Feature flags, migration steps)
+  - No feature flag or migration needed.
+  - If live Naver still fails on a different startup blocker, document it in PR and keep this PR scoped to the named-access fix if tests prove compatibility.
+
+## Validation
+
+- **Commands to run:**
+  - `cargo test --lib test_document_named_form_property_supports_onsubmit`
+  - `cargo test --lib test_window_named_form_property_supports_onsubmit`
+  - `cargo test --lib test_document_named_property_does_not_shadow_existing_member`
+  - `cargo test --lib`
+  - `cargo build --bins`
+  - `timeout 120s ./target/debug/browser-daemon --no-gui --port 7071`
+  - `timeout 60s ./target/debug/browser-cli --port 7071 navigate https://www.naver.com`
+  - `timeout 30s ./target/debug/browser-cli --port 7071 tick 3`
+  - `timeout 30s ./target/debug/browser-cli --port 7071 logs`
+  - `timeout 30s ./target/debug/browser-cli --port 7071 screenshot /tmp/naver-278.png`
+  - `browser-cli-reviewer`
+- **Expected output:**
+  - Targeted tests pass.
+  - Full relevant build/tests pass.
+  - Naver no longer reports the `onsubmit` startup blocker.
+  - Screenshot shows more visible shell content than the prior tiny search-only state, or any remaining blocker is captured for the next issue.
+
+## Risks & Rollback
+
+- **Risks:**
+  - Named document properties can shadow real document APIs if precedence is wrong.
+  - Proxy behavior can affect `in`, `Object.keys`, or library feature detection.
+  - Naver may have a second blocker immediately after the `onsubmit` issue.
+- **Rollback steps:** `git revert` the commit or remove the document named-property proxy and associated tests.
+
+## Open Questions
+
+- Is the live `onsubmit` error definitely from `document.search.onsubmit`, or from another object access in an external bundle?
+- Does Naver require matching named access on `window` in addition to `document` for the next blocker?
+
+## Plan Review Notes
+
+- Fast review: fixed ambiguity around `window.search` vs `document.search` and explicit trap behavior.
+- Medium review: kept scope local to DOM named access; no new Rust abstraction or layout work.
+- Heavy review: plan is implementable if live Naver reveals the same blocker; any next blocker stays follow-up unless required for this fix verification.
+
+## Implementation Notes
+
+- Added document named-property fallback for form `id`/`name` access.
+- Added initial window named-property getters for parsed form `id`/`name` values.
+- Verified `document.search.onsubmit` and `window.search.onsubmit` compatibility with unit tests.
+- Live Naver verification now shows populated main shell/feed/login/footer content; remaining visual drift is layout/CSS follow-up work.

--- a/src/js.rs
+++ b/src/js.rs
@@ -4211,6 +4211,62 @@ mod tests {
     }
 
     #[test]
+    fn test_document_named_form_property_supports_onsubmit() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body><form id='sform' name='search'></form></body></html>"#,
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "document.search.onsubmit = function(e) { e.preventDefault(); window.__documentSearchSubmit = true; }; \
+             document.search.submit(); \
+             window.__documentSearchSubmit",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_window_named_form_property_supports_onsubmit() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body><form id='sform' name='search'></form></body></html>"#,
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "window.search.onsubmit = function(e) { e.preventDefault(); window.__windowSearchSubmit = true; }; \
+             window.search.submit(); \
+             window.__windowSearchSubmit",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_document_named_property_does_not_shadow_existing_member() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body><form id='forms' name='getElementById'></form></body></html>"#,
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "typeof document.getElementById === 'function' && document.forms.length === 1 && document.forms !== document.getElementById('forms')",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_document_named_property_has_but_does_not_enumerate() {
+        let mut rt = make_dom_runtime(
+            r#"<html><body><form id='sform' name='search'></form></body></html>"#,
+            "https://example.com/",
+        );
+        let outcome = rt.execute_with_result(
+            "'search' in document && Object.keys(document).indexOf('search') === -1 && document.missingNamedElement === undefined",
+        );
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.result.as_deref(), Some("true"));
+    }
+
+    #[test]
     fn test_form_elements_returns_controls() {
         let mut rt = make_dom_runtime(
             r#"<html><body><form id='f'><input name='a'><input name='b'></form></body></html>"#,

--- a/src/js_bootstrap.js
+++ b/src/js_bootstrap.js
@@ -2384,6 +2384,74 @@ var document = {
     }
 };
 
+function __aura_valid_named_property_key(prop) {
+    return typeof prop === 'string' && prop.length > 0 && prop !== '__proto__' && prop !== 'prototype' && prop !== 'constructor';
+}
+
+function __aura_resolve_document_named_property(target, prop) {
+    if (!__aura_valid_named_property_key(prop)) return undefined;
+    var byId = null;
+    try {
+        byId = target.getElementById(prop);
+    } catch (e) {}
+    if (byId) return byId;
+
+    var forms = null;
+    try {
+        forms = Reflect.get(target, 'forms', target);
+    } catch (e) {}
+    if (forms && typeof forms.namedItem === 'function') {
+        var form = forms.namedItem(prop);
+        if (form) return form;
+    }
+    return undefined;
+}
+
+document = new Proxy(document, {
+    get: function(target, prop, receiver) {
+        if (typeof prop !== 'string' || prop in target) {
+            var value = Reflect.get(target, prop, receiver);
+            return typeof value === 'function' ? value.bind(target) : value;
+        }
+        var named = __aura_resolve_document_named_property(target, prop);
+        return named === undefined ? undefined : named;
+    },
+    has: function(target, prop) {
+        return prop in target || __aura_resolve_document_named_property(target, prop) !== undefined;
+    },
+    getOwnPropertyDescriptor: function(target, prop) {
+        var descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+        if (descriptor || typeof prop !== 'string') return descriptor;
+        var named = __aura_resolve_document_named_property(target, prop);
+        if (named === undefined) return undefined;
+        return { value: named, writable: false, enumerable: false, configurable: true };
+    }
+});
+
+function __aura_install_window_named_properties() {
+    var names = [];
+    var forms = document.forms;
+    for (var i = 0; i < forms.length; i++) {
+        var form = forms.item(i);
+        if (!form) continue;
+        if (__aura_valid_named_property_key(form.id)) names.push(form.id);
+        var name = form.getAttribute('name');
+        if (__aura_valid_named_property_key(name)) names.push(name);
+    }
+    for (var j = 0; j < names.length; j++) {
+        (function(name) {
+            if (name in globalThis) return;
+            try {
+                Object.defineProperty(globalThis, name, {
+                    get: function() { return __aura_resolve_document_named_property(document, name) || undefined; },
+                    configurable: true,
+                    enumerable: false
+                });
+            } catch (e) {}
+        })(names[j]);
+    }
+}
+
 var window = globalThis;
 window.document = document;
 window.localStorage = localStorage;
@@ -4421,3 +4489,5 @@ if (typeof Intl === 'undefined') {
         Collator: function() { return { compare: function(a, b) { return a < b ? -1 : a > b ? 1 : 0; } }; },
     };
 }
+
+__aura_install_window_named_properties();


### PR DESCRIPTION
## Summary

Closes #278.

- Add browser-compatible named form access for `document.<name>` and `window.<name>`.
- Cover the Naver `name="search"` form case that can lead to `.onsubmit` reads on `undefined`.
- Add an issue plan for the scoped Naver shell unblock work.

## Validation

- `cargo test --lib named`
- `cargo test --lib`
- `cargo build --bins`
- Live Naver check on port 7071:
  - `browser-cli navigate https://www.naver.com` now shows populated news/feed/login/footer text instead of tiny search-only output.
  - `browser-cli logs` does not show the previous `onsubmit` startup blocker.
  - screenshot captured at `/tmp/naver-278.png` as a 800x2699 PNG.
- Browser CLI reviewer-equivalent smoke on port 7072:
  - `browser-cli navigate https://google.com`
  - `browser-cli navigate https://yunseong.dev`

## Notes

Naver is still not visually close to Chromium. This PR only unblocks the shell population path for #278; layout/CSS fidelity remains follow-up work under #257/#252.

`graphify update .` was run after code changes, but generated graph artifacts were left unstaged to keep this PR focused on the issue fix.
