### PR TITLE
Add Naver parity verification fixture

### DIFF
--- a/.agents/docs/development-workflow.md
+++ b/.agents/docs/development-workflow.md
@@ -46,15 +46,20 @@ test/278
    - Prefer existing project patterns over new abstractions.
    - Run targeted tests as the implementation progresses.
    - Keep long browser/daemon/site checks wrapped in `timeout`.
+   - Treat the issue acceptance criteria as the completion contract. If only a sub-blocker is fixed, do not present the issue as complete unless the issue explicitly allows partial delivery.
+   - For visual/rendering issues, capture the target/baseline image and the browser output image at the same viewport. Compare them before deciding the issue is solved.
+   - If meaningful visual drift remains, document it in the plan and PR, and create or link a focused follow-up issue before opening the PR.
 
 6. Run pair review.
    - Use the project-local `pair-review` skill before final validation.
    - Focus review on YAGNI, DRY, maintainability, scope control, correctness, and validation gaps.
    - Fix must-fix findings before PR.
+   - Pair review must explicitly check whether the issue acceptance criteria were actually satisfied, not just whether the code is clean.
 
 7. Validate and open PR.
    - Run build/tests relevant to touched scope.
    - Run `browser-cli-reviewer` before PR creation for browser implementation changes.
+   - Open the PR only after acceptance criteria are satisfied or any remaining scope is explicitly documented with linked follow-up issues.
    - Push the branch and open a PR linked to the issue.
    - PR body should include issue link, summary, validation, and remaining risks.
 

--- a/.claude/agents/browser-cli-reviewer.md
+++ b/.claude/agents/browser-cli-reviewer.md
@@ -60,6 +60,19 @@ Check for:
 
 If visual defects are found → return **NONPASS** and describe exactly what is wrong and where.
 
+### 5.5. Naver parity check
+
+For Naver parity issues (`#257`, `#252`, or follow-up Naver visual drift work), run the dedicated commands in `docs/naver-playwright-parity.md`.
+
+The reviewer must confirm:
+- Playwright baseline screenshot was generated.
+- Browser-daemon screenshot was generated at the same viewport width.
+- Naver shell content appears beyond raw placeholders.
+- `browser-cli logs` shows no critical startup blocker.
+- Remaining visual drift is documented in the PR or linked follow-up issue.
+
+For #257 fixture work, documented remaining drift does not fail the review by itself. For follow-up Naver visual drift issues, block on any regression or unresolved drift that the issue claims to fix.
+
 ### 6. Return verdict
 
 **PASS** — daemon started, both URLs rendered, no crashes, no visual defects.

--- a/.plan/issues/2026-07-04-issue-257-naver-playwright-parity-fixture.md
+++ b/.plan/issues/2026-07-04-issue-257-naver-playwright-parity-fixture.md
@@ -1,0 +1,69 @@
+# 2026-07-04 — Naver Playwright parity fixture
+
+- Date: 2026-07-04
+- GitHub Issue: #257
+- Status: Implemented, awaiting review
+
+## Goal
+
+Make `https://www.naver.com` verifiable against a Playwright/Chromium baseline at the project viewport, and ensure the browser-daemon output reaches the populated Naver shell without critical startup JS blockers.
+
+## Non-goals
+
+- Pixel-perfect Chromium parity in one PR.
+- Broad layout/CSS rewrites that are not required to satisfy #257 acceptance.
+- Fixing yunseong.dev parity (#258).
+
+## Context / Constraints
+
+- #278 is closed and removed the `onsubmit` startup blocker.
+- #257 acceptance requires reproducible baseline/browser screenshots, populated Naver shell, no critical JS startup blocker, reviewer coverage or documented dedicated command, and `cargo check --all-targets` plus relevant tests.
+- Render width is fixed to `800px` unless changed in code.
+- Long daemon/browser checks must use `timeout`.
+- Keep unrelated dirty files out of this PR.
+
+## Approach (Checklist)
+
+- [x] **Step 0: Recon**
+  - Inspected existing CLI/reviewer/docs patterns.
+  - Captured current Playwright/Chromium baseline for Naver at 800px.
+  - Captured current browser-daemon Naver screenshot at the same width.
+  - Compared images and identified remaining layout/CSS drift as follow-up scope.
+- [x] **Step 1: Implementation**
+  - Added a reproducible documented command for Naver Playwright baseline capture.
+  - Added documented browser-daemon navigation, log, and screenshot capture for the same URL/viewport.
+  - Updated `browser-cli-reviewer` with a dedicated Naver parity verification path.
+  - No runtime/layout code change was needed for #257 startup/shell acceptance because the current browser output already populates the main Naver shell and logs show no critical startup blocker.
+- [x] **Step 2: Tests**
+  - No targeted Rust tests were required because this change only updates verification docs/reviewer instructions.
+  - Ran `cargo check --all-targets`.
+  - Ran Naver baseline/browser capture commands and inspected screenshots.
+- [x] **Step 3: Follow-up Tracking**
+  - Created #288 for remaining layout/CSS visual drift.
+  - Remaining risks should be recorded in the PR body.
+
+## Validation
+
+- **Ran:**
+  - `cargo check --all-targets` — passed with existing warnings.
+  - Playwright baseline capture command for `https://www.naver.com` at 800px — generated `/tmp/browser-naver-parity/naver-playwright.png` (800 x 1200).
+  - Browser-daemon navigation/log/screenshot commands for `https://www.naver.com` — generated `/tmp/browser-naver-parity/naver-browser.png` (800 x 2251).
+  - `browser-cli logs` after navigation — no critical startup blocker such as `Cannot read properties of undefined (reading 'onsubmit')`.
+- **Observed output:**
+  - Browser text output includes populated Naver shell content, including search/autocomplete, pay/notification/cart, newsstand, feed tabs, article/content items, login, and footer sections.
+  - Browser screenshot is populated beyond raw placeholders.
+  - Browser screenshot is not visually identical to Chromium; substantial layout/CSS drift remains.
+  - Follow-up issue #288 tracks remaining Naver visual drift.
+
+## Risks & Rollback
+
+- **Risks:**
+  - Live Naver content changes frequently, making image comparison noisy.
+  - External resources may intermittently fail.
+  - Full visual parity may require several layout/CSS issues beyond #257 scope.
+- **Rollback steps:** Revert script/docs/code changes for the fixture path.
+
+## Open Questions
+
+- Generated screenshots are not committed; reproducible commands and local output paths are documented.
+- Naver stays as a dedicated heavier verification path in `browser-cli-reviewer`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@ Pipeline: `Network -> DOM -> Style -> Layout -> Render -> GUI`
 ### Project Rules
 - Use `./.agents/PRIORITY.md` to choose the next issue.
 - Follow the development workflow in `./.agents/docs/development-workflow.md`.
+- Treat GitHub issue acceptance criteria as the completion contract. Do not open a PR after only fixing a sub-blocker unless the issue explicitly allows partial delivery, or a narrower follow-up issue is created and linked.
+- Before PR creation, verify that the implemented behavior satisfies the issue goal, not only that tests pass. For visual/rendering issues, compare screenshots against the target/baseline and document remaining visual drift in the PR or a linked follow-up issue.
+- Run project-local `pair-review` before PR creation for non-trivial implementation work. Address must-fix findings before opening the PR.
 - Render width is fixed to `800px` unless changed in code.
 - Build/check/lint on host. For daemon/CLI execution, use `drun rust:latest` (resource-limited).
 - Never run long render/integration loops without timeout.

--- a/docs/naver-playwright-parity.md
+++ b/docs/naver-playwright-parity.md
@@ -1,0 +1,38 @@
+# Naver Playwright Parity Check
+
+Use this check for #257 and follow-up Naver visual parity work. It captures a Chromium baseline and the browser-daemon output at the project viewport width.
+
+## Capture Playwright Baseline
+
+```bash
+mkdir -p /tmp/browser-naver-parity
+timeout 90s npx --yes playwright screenshot \
+  --browser chromium \
+  --viewport-size "800,1200" \
+  --wait-for-timeout 5000 \
+  https://www.naver.com \
+  /tmp/browser-naver-parity/naver-playwright.png
+```
+
+## Capture Browser Output
+
+Start the daemon in one terminal:
+
+```bash
+timeout 180s ./target/debug/browser-daemon --no-gui --port 7071
+```
+
+Then run:
+
+```bash
+timeout 75s ./target/debug/browser-cli --port 7071 navigate https://www.naver.com
+timeout 30s ./target/debug/browser-cli --port 7071 logs
+timeout 45s ./target/debug/browser-cli --port 7071 screenshot /tmp/browser-naver-parity/naver-browser.png
+```
+
+## Expected Result
+
+- `naver-playwright.png` and `naver-browser.png` both exist.
+- Browser output shows populated Naver shell content beyond raw placeholders such as `#shortcutArea`, `#root`, and `#footer`.
+- `browser-cli logs` has no critical startup blocker such as `Cannot read properties of undefined (reading 'onsubmit')`.
+- Any visible layout/CSS drift is recorded in the PR or a linked follow-up issue. As of #257, remaining Naver layout/CSS drift is tracked in #288.


### PR DESCRIPTION
## Summary
- Add documented Playwright and browser-daemon capture commands for Naver parity verification.
- Record #257 validation evidence in the issue plan, including actual screenshot output paths and populated shell observations.
- Extend browser-cli-reviewer with the dedicated Naver parity path and record acceptance/pair-review workflow guardrails requested by the user.

## Validation
- `cargo check --all-targets` passed with existing warnings.
- Captured Playwright baseline: `/tmp/browser-naver-parity/naver-playwright.png` (800 x 1200).
- Captured browser output: `/tmp/browser-naver-parity/naver-browser.png` (800 x 2251).
- Visually inspected both images. Browser output is populated, but not Chromium-identical.
- `browser-cli logs` had no critical startup blocker such as `Cannot read properties of undefined (reading 'onsubmit')`.\n- Pair review critic returned `VERDICT: PASS`.\n\n## Follow-up\n- Remaining Naver layout/CSS visual drift is tracked in #288.\n\nCloses #257\nRelated #252, #288